### PR TITLE
Add query object for scope

### DIFF
--- a/spec/model/base_spec.cr
+++ b/spec/model/base_spec.cr
@@ -116,38 +116,66 @@ describe Jennifer::Model::Base do
   describe "::c" do
   end
 
-  describe "scope macro" do
-    it "executes in query context" do
-      ::Jennifer::Adapter::SqlGenerator.select(Contact.all.ordered).should match(/ORDER BY name ASC/)
-    end
+  describe "%scope" do
+    context "with block" do
+      it "executes in query context" do
+        ::Jennifer::Adapter::SqlGenerator.select(Contact.all.ordered).should match(/ORDER BY name ASC/)
+      end
 
-    context "without arguemnt" do
-      it "is accessible from query object" do
-        Contact.all.main.as_sql.should match(/contacts\.age >/)
+      context "without arguemnt" do
+        it "is accessible from query object" do
+          Contact.all.main.as_sql.should match(/contacts\.age >/)
+        end
+      end
+
+      context "with argument" do
+        it "is accessible from query object" do
+          Contact.all.older(12).as_sql.should match(/contacts\.age >=/)
+        end
+      end
+
+      context "same names" do
+        it "is accessible from query object" do
+          Address.all.main.as_sql.should match(/addresses\.main/)
+          Contact.all.main.as_sql.should match(/contacts\.age >/)
+        end
+      end
+
+      it "is chainable" do
+        c1 = Factory.create_contact(age: 15)
+        c2 = Factory.create_contact(age: 15)
+        c3 = Factory.create_contact(age: 13)
+        Factory.create_address(contact_id: c1.id, main: true)
+        Factory.create_address(contact_id: c2.id, main: false)
+        Factory.create_address(contact_id: c3.id, main: true)
+        Contact.all.with_main_address.older(14).count.should eq(1)
       end
     end
 
-    context "with argument" do
-      it "is accessible from query object" do
-        Contact.all.older(12).as_sql.should match(/contacts\.age >=/)
+    context "with query object class" do
+      it "executes in class context" do
+        ::Jennifer::Adapter::SqlGenerator.select(Contact.johny).should match(/name =/)
       end
-    end
 
-    context "same names" do
-      it "is accessible from query object" do
-        Address.all.main.as_sql.should match(/addresses\.main/)
-        Contact.all.main.as_sql.should match(/contacts\.age >/)
+      context "without arguemnt" do
+        it "is accessible from query object" do
+          Contact.all.johny.as_sql.should match(/contacts\.name =/)
+        end
       end
-    end
 
-    it "is chainable" do
-      c1 = Factory.create_contact(age: 15)
-      c2 = Factory.create_contact(age: 15)
-      c3 = Factory.create_contact(age: 13)
-      Factory.create_address(contact_id: c1.id, main: true)
-      Factory.create_address(contact_id: c2.id, main: false)
-      Factory.create_address(contact_id: c3.id, main: true)
-      Contact.all.with_main_address.older(14).count.should eq(1)
+      context "with argument" do
+        it "is accessible from query object" do
+          Contact.all.by_age(12).as_sql.should match(/contacts\.age =/)
+        end
+      end
+
+      it "is chainable" do
+        c1 = Factory.create_contact(name: "Johny")
+        c3 = Factory.create_contact
+        Factory.create_address(contact_id: c1.id, main: true)
+        Factory.create_address(contact_id: c3.id, main: true)
+        Contact.all.with_main_address.johny.count.should eq(1)
+      end
     end
   end
 

--- a/spec/models.cr
+++ b/spec/models.cr
@@ -1,3 +1,16 @@
+struct JohnyQuery < Jennifer::QueryBuilder::QueryObject
+  def call
+    relation.where { _name == "Johny" }
+  end
+end
+
+struct WithArgumentQuery < Jennifer::QueryBuilder::QueryObject
+  def call
+    this = self
+    relation.where { _age == this.params[0] }
+  end
+end
+
 class Contact < Jennifer::Model::Base
   with_timestamps
   {% if env("DB") == "postgres" || env("DB") == nil %}
@@ -40,6 +53,8 @@ class Contact < Jennifer::Model::Base
   scope :older { |age| where { _age >= age } }
   scope :ordered { order(name: :asc) }
   scope :with_main_address { relation(:addresses).where { _addresses__main } }
+  scope :johny, JohnyQuery
+  scope :by_age, WithArgumentQuery
 
   def name_check
     if @description && @description.not_nil!.size > 10

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -16,6 +16,7 @@ require "./config"
 require "./models.cr"
 require "./factories.cr"
 
+# This was added to track exact count of hitting DB
 abstract class DB::Connection
   def scalar(query, *args)
     Jennifer::Adapter.adapter_class.log_query(query)
@@ -34,7 +35,6 @@ abstract class DB::Connection
   end
 end
 
-# This was added to track exact count of hitting DB
 abstract class Jennifer::Adapter::Base
   @@execution_counter = 0
   @@queries = [] of String
@@ -57,6 +57,8 @@ abstract class Jennifer::Adapter::Base
   end
 end
 
+# Callbaks =======================
+
 Spec.before_each do
   Jennifer::Adapter.adapter.begin_transaction
 end
@@ -65,6 +67,8 @@ Spec.after_each do
   Jennifer::Adapter.adapter.class.remove_queries
   Jennifer::Adapter.adapter.rollback_transaction
 end
+
+# Helper methods =================
 
 def match_array(expect, target)
   (expect - target).size.should eq(0)

--- a/src/jennifer/exceptions.cr
+++ b/src/jennifer/exceptions.cr
@@ -29,6 +29,10 @@ module Jennifer
   end
 
   class UnknownRelation < BaseException
+    def initialize(owner, exception : KeyError)
+      initialize(owner, /"(?<r>.*)"$/.match(exception.message.to_s).try &.["r"])
+    end
+
     def initialize(owner, relation)
       @message = "Unknown relation for #{owner}: #{relation}"
     end

--- a/src/jennifer/model/scoping.cr
+++ b/src/jennifer/model/scoping.cr
@@ -1,0 +1,42 @@
+module Jennifer
+  module Model
+    module Scoping
+      macro scope(name, &block)
+        {% underscored_arg_list = block.args.map(&.stringify).map { |e| "__" + e }.join(", ").id %}
+
+        class Jennifer::QueryBuilder::ModelQuery(T)
+          def {{name.id}}({{ block.args.splat }})
+            T.{{name.id}}(self, {{block.args.splat}})
+          end
+        end
+
+        def self.{{name.id}}({{ underscored_arg_list }})
+          {{name.id}}(all{% if !block.args.empty? %}, {{underscored_arg_list}} {% end %})
+        end
+
+        def self.{{name.id}}(_query : ::Jennifer::QueryBuilder::ModelQuery({{@type}}){% if !block.args.empty? %}, {{ underscored_arg_list }} {% end %})
+          {% if !block.args.empty? %}
+            {{ block.args.splat }} = {{underscored_arg_list}}
+          {% end %}
+          _query.exec { {{block.body}} }
+        end
+      end
+
+      macro scope(name, klass)
+        class Jennifer::QueryBuilder::ModelQuery(T)
+          def {{name.id}}(*args)
+            T.{{name.id}}(self, *args)
+          end
+        end
+
+        def self.{{name.id}}(_query : ::Jennifer::QueryBuilder::ModelQuery({{@type}}), *args)
+          {{klass}}.new(_query, *args).call
+        end
+
+        def self.{{name.id}}(*args)
+          {{name.id}}(all, *args)
+        end
+      end
+    end
+  end
+end

--- a/src/jennifer/query_builder/model_query.cr
+++ b/src/jennifer/query_builder/model_query.cr
@@ -2,7 +2,12 @@ require "./*"
 
 module Jennifer
   module QueryBuilder
-    class ModelQuery(T) < Query
+    abstract class IModelQuery < Query
+      abstract def model_class
+      abstract def with(arr)
+    end
+
+    class ModelQuery(T) < IModelQuery
       @preload_relations = [] of String
 
       def initialize(*opts)

--- a/src/jennifer/query_builder/query_object.cr
+++ b/src/jennifer/query_builder/query_object.cr
@@ -1,0 +1,17 @@
+module Jennifer
+  module QueryBuilder
+    abstract struct QueryObject
+      getter relation : ::Jennifer::QueryBuilder::IModelQuery, params : Array(Jennifer::DBAny)
+
+      def initialize(@relation)
+        @params = [] of Jennifer::DBAny
+      end
+
+      def initialize(@relation, *options)
+        @params = Ifrit.typed_array_cast(options, Jennifer::DBAny)
+      end
+
+      abstract def call
+    end
+  end
+end


### PR DESCRIPTION
[Original Issue](https://github.com/imdrasil/jennifer.cr/issues/30)

Now as `%scope` argument could be used struct which is inherited from `Jennifer::QueryBuilder::QueryObject` and has implemented `#call` method