### PR TITLE
allow nil to be passed for the type of an index in a migration

### DIFF
--- a/spec/adapter/postgres_spec.cr
+++ b/spec/adapter/postgres_spec.cr
@@ -11,7 +11,16 @@ postgres_only do
 
     describe "#add_index" do
       # tested via adding index in migration
-      pending "add" do
+      it "should add a covering index if no type is specified" do
+        index_name = "contacts_age_index"
+        options = {
+          :type => nil,
+          :fields => [:age],
+          :order => {} of Symbol => Symbol,
+          :lengths => {} of Symbol => Symbol
+        }
+        adapter.add_index("contacts", index_name, options)
+        adapter.index_exists?("", index_name).should be_true
       end
     end
 

--- a/spec/adapter/postgres_spec.cr
+++ b/spec/adapter/postgres_spec.cr
@@ -9,18 +9,44 @@ postgres_only do
       end
     end
 
-    describe "#add_index" do
-      # tested via adding index in migration
-      it "should add a covering index if no type is specified" do
-        index_name = "contacts_age_index"
-        options = {
-          :type => nil,
-          :fields => [:age],
-          :order => {} of Symbol => Symbol,
-          :lengths => {} of Symbol => Symbol
-        }
-        adapter.add_index("contacts", index_name, options)
-        adapter.index_exists?("", index_name).should be_true
+    describe "index manipulation" do
+      age_index_options = {
+        :type => nil,
+        :fields => [:age],
+        :order => {} of Symbol => Symbol,
+        :lengths => {} of Symbol => Symbol
+      }
+      index_name = "contacts_age_index"
+
+      context "#index_exists?" do
+        it "returns true if exists index with given name" do
+          adapter.index_exists?("", "contacts_description_index").should be_true
+        end
+
+        it "returns false if index is not exist" do
+          adapter.index_exists?("", "contacts_description_index_test").should be_false
+        end
+      end
+
+      context "#add_index" do
+        it "should add a covering index if no type is specified" do
+          delete_index_if_exists(adapter, index_name)
+
+          adapter.add_index("contacts", index_name, age_index_options)
+          adapter.index_exists?("", index_name).should be_true
+        end
+      end
+
+      context "#drop_index" do
+        it "should drop an index if it exists" do
+          delete_index_if_exists(adapter, index_name)
+
+          adapter.add_index("contacts", index_name, age_index_options)
+          adapter.index_exists?("", index_name).should be_true
+
+          adapter.drop_index("", index_name)
+          adapter.index_exists?("", index_name).should be_false
+        end
       end
     end
 
@@ -34,15 +60,7 @@ postgres_only do
     describe "#insert" do
     end
 
-    describe "#index_exists?" do
-      it "returns true if exists index with given name" do
-        adapter.index_exists?("", "contacts_description_index").should be_true
-      end
 
-      it "returns false if index is not exist" do
-        adapter.index_exists?("", "contacts_description_index_test").should be_false
-      end
-    end
 
     describe "#material_view_exists?" do
       it "returns true if exists" do
@@ -82,4 +100,8 @@ postgres_only do
       end
     end
   end
+end
+
+def delete_index_if_exists(adapter, index)
+  adapter.drop_index("", index) if adapter.index_exists?("", index)
 end

--- a/src/jennifer/adapter/postgres.cr
+++ b/src/jennifer/adapter/postgres.cr
@@ -155,6 +155,10 @@ module Jennifer
         exec "DROP TYPE #{name}"
       end
 
+      def drop_index(table, name)
+        exec "DROP INDEX #{name}"
+      end
+
       def query_string_array(_query, field_count = 1)
         result = [] of Array(String)
         query(_query) do |rs|

--- a/src/jennifer/adapter/postgres.cr
+++ b/src/jennifer/adapter/postgres.cr
@@ -289,6 +289,8 @@ module Jennifer
         case name
         when :unique, :uniq
           "UNIQUE "
+        when nil
+          " "
         else
           raise ArgumentError.new("Unknown index type: #{name}")
         end

--- a/src/jennifer/migration/table_builder/change_table.cr
+++ b/src/jennifer/migration/table_builder/change_table.cr
@@ -44,12 +44,12 @@ module Jennifer
 
         # add_index("index_name", [:field1, :field2], { :length => { :field1 => 2, :field2 => 3 }, :order => { :field1 => :asc }})
         # add_index("index_name", [:field1], { :length => { :field1 => 2, :field2 => 3 }, :order => { :field1 => :asc }})
-        def add_index(name : String, fields : Array(Symbol), type : Symbol, lengths : Hash(Symbol, Int32) = {} of Symbol => Int32, orders : Hash(Symbol, Symbol) = {} of Symbol => Symbol)
+        def add_index(name : String, fields : Array(Symbol), type : Symbol? = nil, lengths : Hash(Symbol, Int32) = {} of Symbol => Int32, orders : Hash(Symbol, Symbol) = {} of Symbol => Symbol)
           @indexes << CreateIndex.new(@name, name, fields, type, lengths, orders)
           self
         end
 
-        def add_index(name : String, field : Symbol, type : Symbol, length : Int32? = nil, order : Symbol? = nil)
+        def add_index(name : String, field : Symbol, type : Symbol? = nil, length : Int32? = nil, order : Symbol? = nil)
           add_index(
             name,
             [field],

--- a/src/jennifer/migration/table_builder/create_index.cr
+++ b/src/jennifer/migration/table_builder/create_index.cr
@@ -2,7 +2,7 @@ module Jennifer
   module Migration
     module TableBuilder
       class CreateIndex < Base
-        getter index_name : String, _fields : Array(Symbol), type : Symbol, lengths : Hash(Symbol, Int32), orders : Hash(Symbol, Symbol)
+        getter index_name : String, _fields : Array(Symbol), type : Symbol?, lengths : Hash(Symbol, Int32), orders : Hash(Symbol, Symbol)
 
         def initialize(table_name, @index_name, @_fields, @type, @lengths, @orders)
           super(table_name)

--- a/src/jennifer/migration/table_builder/create_table.cr
+++ b/src/jennifer/migration/table_builder/create_table.cr
@@ -35,12 +35,12 @@ module Jennifer
           timestamp(:updated_at, {:null => true})
         end
 
-        def add_index(name : String, fields : Array(Symbol), type : Symbol, lengths : Hash(Symbol, Int32) = {} of Symbol => Int32, orders : Hash(Symbol, Symbol) = {} of Symbol => Symbol)
+        def add_index(name : String, fields : Array(Symbol), type : Symbol? = nil, lengths : Hash(Symbol, Int32) = {} of Symbol => Int32, orders : Hash(Symbol, Symbol) = {} of Symbol => Symbol)
           @indexes << CreateIndex.new(@name, name, fields, type, lengths, orders)
           self
         end
 
-        def add_index(name : String, field : Symbol, type : Symbol, length : Int32? = nil, order : Symbol? = nil)
+        def add_index(name : String, field : Symbol, type : Symbol? = nil, length : Int32? = nil, order : Symbol? = nil)
           add_index(
             name,
             [field],


### PR DESCRIPTION
passing nil for the type will create a default no frills index for the supplied field/fields. This allows for
```ruby
t.add_index("index_by_name", :name)
t.add_index("unique_name", :name, :uniq)
```

Might not hurt to extract the index functions to a module to avoid the duplication, what are your thoughts?