### PR TITLE
 allow configuration via a db url

### DIFF
--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -2,13 +2,57 @@ require "./spec_helper"
 
 describe Jennifer::Config do
   describe "::read" do
-    it "reades data from yaml file" do
+    it "reads data from yaml file" do
       begin
         Jennifer::Config.read("./spec/fixtures/database.yml")
         Jennifer::Config.config.db.should eq("jennifer_develop")
       ensure
         Jennifer::Config.config.db = "jennifer_test"
       end
+    end
+  end
+
+  describe "::from_uri" do
+    it "should parse uri string" do
+      db_uri = "mysql://root:password@somehost:3306/some_database"
+      Jennifer::Config.from_uri(db_uri)
+      config = Jennifer::Config
+      config.adapter.should eq("mysql")
+      config.user.should eq("root")
+      config.password.should eq("password")
+      config.host.should eq("somehost")
+      config.port.should eq(3306)
+      config.db.should eq("some_database")
+    end
+
+    it "expects adapter and database at very least" do
+      expect_raises(Jennifer::InvalidConfig, /No database configured/) do
+        Jennifer::Config.configure {|c| c.db = ""}
+      end
+
+      expect_raises(Jennifer::InvalidConfig, /No adapter configured/) do
+        Jennifer::Config.configure do |c|
+          c.db = "somedb"
+          c.adapter = ""
+        end
+      end
+    end
+
+    it "should ignore port if not supplied" do
+      db_uri = "mysql://root@somehost/some_database"
+      Jennifer::Config.from_uri(db_uri)
+      Jennifer::Config.port.should eq(-1)
+    end
+
+    it "should parse connection params from the uri" do
+      db_uri = "mysql://root@somehost/some_database?max_pool_size=111&initial_pool_size=222&max_idle_pool_size=333&retry_attempts=444&checkout_timeout=555&retry_delay=666"
+      Jennifer::Config.from_uri(db_uri)
+      Jennifer::Config.max_pool_size.should eq(111)
+      Jennifer::Config.initial_pool_size.should eq(222)
+      Jennifer::Config.max_idle_pool_size.should eq(333)
+      Jennifer::Config.retry_attempts.should eq(444)
+      Jennifer::Config.checkout_timeout.should eq(555)
+      Jennifer::Config.retry_delay.should eq(666)
     end
   end
 end

--- a/spec/model/base_spec.cr
+++ b/spec/model/base_spec.cr
@@ -113,9 +113,9 @@ describe Jennifer::Model::Base do
     context "brakes unique index" do
       it "raises exception" do
         void_transaction do
-          Factory.create_address(street: "st. 1")
+          Factory.create_address(street: "st. 2")
           expect_raises(Jennifer::BaseException) do
-            Factory.create_address(street: "st. 1")
+            Factory.create_address(street: "st. 2")
           end
         end
       end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -61,6 +61,7 @@ end
 
 Spec.before_each do
   Jennifer::Adapter.adapter.begin_transaction
+  reset_config
 end
 
 Spec.after_each do
@@ -69,6 +70,11 @@ Spec.after_each do
 end
 
 # Helper methods ================
+
+def reset_config
+  Jennifer::Config.reset_config
+  Jennifer::Config.config.db = "jennifer_test"
+end
 
 def clean_db
   Jennifer::Adapter.adapter.class.remove_queries

--- a/src/jennifer/adapter/base.cr
+++ b/src/jennifer/adapter/base.cr
@@ -114,12 +114,16 @@ module Jennifer
       def self.connection_string(*options)
         auth_part = Config.user
         auth_part += ":#{Config.password}" if Config.password && !Config.password.empty?
+
+        host_part = Config.host
+        host_part += Config.port.to_s if Config.port && Config.port > 0
+
         String.build do |s|
-          s << Config.adapter << "://" << auth_part << "@" << Config.host
+          s << Config.adapter << "://" << auth_part << "@" << host_part
           s << "/" << Config.db if options.includes?(:db)
           s << "?"
           [
-            {% for arg in [:max_pool_size, :initial_pool_size, :max_idle_pool_size, :retry_attempts, :checkout_timeout, :retry_delay] %}
+            {% for arg in Config::CONNECTION_URI_PARAMS %}
               "{{arg.id}}=#{Config.{{arg.id}}}"
             {% end %},
           ].join(",", s)

--- a/src/jennifer/exceptions.cr
+++ b/src/jennifer/exceptions.cr
@@ -36,6 +36,12 @@ module Jennifer
     end
   end
 
+  class InvalidConfig < BaseException
+    def initialize(message)
+      @message = message
+    end
+  end
+
   class RecordNotFound < BaseException
     def initialize(query)
       @message = "There is no record by given query:\n#{query}"


### PR DESCRIPTION
I've been using Jennifer with some amber projects. The current generated database config in an amber project is in a url format (which is easily passed to crystal-db). I found myself parsing this into config for Jennifer in each and figured it would be nice to have Jennifer do this automatically. 