### PR TITLE
Extend query building; small refactoring

### DIFF
--- a/spec/factories.cr
+++ b/spec/factories.cr
@@ -1,6 +1,7 @@
 alias Criteria = Jennifer::QueryBuilder::Criteria
 alias Condition = Jennifer::QueryBuilder::Condition
 alias Join = Jennifer::QueryBuilder::Join
+alias Query = Jennifer::QueryBuilder::Query
 
 class CriteriaFactory < Factory::Base
   describe_class Criteria
@@ -19,14 +20,15 @@ end
 class JoinFactory < Factory::Base
   describe_class Join
   skip_all_constructors
-  argument_type String | Symbol | Criteria | Condition
+  argument_type String | Symbol | Criteria | Condition | Query?
 
   attr :table, "tests"
   attr :on, ->{ Factory.build_criteria == 1 }
   attr :type, :inner
+  attr :aliass, nil
 
   initialize_with do |hash, traits|
-    obj = described_class.new(hash["table"].as(String), hash["on"].as(Condition | Criteria), hash["type"].as(Symbol))
+    obj = described_class.new(hash["table"].as(String | Query), hash["on"].as(Condition | Criteria), hash["type"].as(Symbol))
     make_assigns(obj, traits)
     obj
   end

--- a/spec/model/relation_definition_spec.cr
+++ b/spec/model/relation_definition_spec.cr
@@ -342,7 +342,7 @@ describe Jennifer::Model::RelationDefinition do
         c = Factory.create_contact
         q = c.countries_query
         select_query(q)
-          .should match(/JOIN contacts_countries ON \(contacts_countries\.country_id = countries\.id AND contacts_countries\.contact_id = %s\)/)
+          .should match(/JOIN contacts_countries ON contacts_countries\.country_id = countries\.id AND contacts_countries\.contact_id = %s/)
         q.select_args.should eq(db_array(c.id))
       end
 
@@ -351,7 +351,7 @@ describe Jennifer::Model::RelationDefinition do
           c = Factory.create_contact
           q = c.facebook_many_profiles_query
           select_query(q)
-            .should match(/JOIN contacts_profiles ON \(contacts_profiles\.profile_id = profiles\.id AND contacts_profiles\.contact_id = %s\)/)
+            .should match(/JOIN contacts_profiles ON contacts_profiles\.profile_id = profiles\.id AND contacts_profiles\.contact_id = %s/)
           select_query(q)
             .should match(/profiles\.type = %s/)
           q.select_args.includes?("FacebookProfile").should be_true
@@ -361,7 +361,7 @@ describe Jennifer::Model::RelationDefinition do
           c = Factory.create_facebook_profile
           q = c.facebook_contacts_query
           select_query(q)
-            .should match(/JOIN contacts_profiles ON \(contacts_profiles\.contact_id = contacts\.id AND contacts_profiles\.profile_id = %s\)/)
+            .should match(/JOIN contacts_profiles ON contacts_profiles\.contact_id = contacts\.id AND contacts_profiles\.profile_id = %s/)
           q.select_args.should eq(db_array(c.id))
         end
       end

--- a/spec/query_builder/all_spec.cr
+++ b/spec/query_builder/all_spec.cr
@@ -1,0 +1,25 @@
+require "../spec_helper"
+
+describe Jennifer::QueryBuilder::All do
+  described_class = Jennifer::QueryBuilder::All
+  query = Contact.all.where { _id == 2 }
+
+  describe "#as_sql" do
+    it "wrap sql with ALL operator" do
+      all = Factory.build_expression.all(query)
+      all.as_sql.should match(/ALL \(SELECT .*\)/m)
+    end
+
+    it "nested request includes template argument placeholders" do
+      all = Factory.build_expression.all(query)
+      all.as_sql.should match(/id = %s/)
+    end
+  end
+
+  describe "#sql_args" do
+    it "returns arguments from nested query" do
+      all = Factory.build_expression.all(query)
+      all.sql_args.should eq([2])
+    end
+  end
+end

--- a/spec/query_builder/any_spec.cr
+++ b/spec/query_builder/any_spec.cr
@@ -1,0 +1,25 @@
+require "../spec_helper"
+
+describe Jennifer::QueryBuilder::Any do
+  described_class = Jennifer::QueryBuilder::Any
+  query = Contact.all.where { _id == 2 }
+
+  describe "#as_sql" do
+    it "wrap sql with ANY operator" do
+      any = Factory.build_expression.any(query)
+      any.as_sql.should match(/ANY \(SELECT .*\)/m)
+    end
+
+    it "nested request includes template argument placeholders" do
+      any = Factory.build_expression.any(query)
+      any.as_sql.should match(/id = %s/)
+    end
+  end
+
+  describe "#sql_args" do
+    it "returns arguments from nested query" do
+      any = Factory.build_expression.any(query)
+      any.sql_args.should eq([2])
+    end
+  end
+end

--- a/spec/query_builder/expression_builder_spec.cr
+++ b/spec/query_builder/expression_builder_spec.cr
@@ -96,4 +96,31 @@ describe ::Jennifer::QueryBuilder::ExpressionBuilder do
       c.table.should eq("qwe")
     end
   end
+
+  describe "#any" do
+    it "creates any object with given query" do
+      query = Contact.all.where { _id == 1 }
+      any = Factory.build_expression.any(query)
+      any.is_a?(Jennifer::QueryBuilder::Any).should be_true
+      any.query.should eq(query)
+    end
+  end
+
+  describe "#all" do
+    it "creates all object with given query" do
+      query = Contact.all.where { _id == 1 }
+      all = Factory.build_expression.all(query)
+      all.is_a?(Jennifer::QueryBuilder::All).should be_true
+      all.query.should eq(query)
+    end
+  end
+
+  describe "#g" do
+    it "creates grouping with given condition" do
+      c1 = Factory.build_criteria
+      c2 = Factory.build_criteria
+      g = Factory.build_expression.g(c1 & c2)
+      g.is_a?(Jennifer::QueryBuilder::Grouping).should be_true
+    end
+  end
 end

--- a/spec/query_builder/grouping_spec.cr
+++ b/spec/query_builder/grouping_spec.cr
@@ -1,0 +1,21 @@
+require "../spec_helper"
+
+describe Jennifer::QueryBuilder::Grouping do
+  described_class = Jennifer::QueryBuilder::Grouping
+  c1 = Factory.build_criteria
+  c2 = Factory.build_criteria == 2
+
+  describe "#as_sql" do
+    it "wrap sql with paranthesis" do
+      g = described_class.new(c1 & c2)
+      g.as_sql.should match(/\(tests\.f1 AND tests\.f1 = %s\)/)
+    end
+  end
+
+  describe "#sql_args" do
+    it "returns arguments from nested query" do
+      g = described_class.new(c1 & c2)
+      g.sql_args.should eq([2])
+    end
+  end
+end

--- a/spec/query_builder/join_spec.cr
+++ b/spec/query_builder/join_spec.cr
@@ -1,14 +1,14 @@
 require "../spec_helper"
 
 describe Jennifer::QueryBuilder::Join do
-  describe "#to_sql" do
+  describe "#as_sql" do
     it "includes table name" do
       Factory.build_join.as_sql.should match(/ tests ON /)
     end
 
     it "calls to_sql on @on" do
       c = Factory.build_criteria
-      Factory.build_join(on: c).as_sql.should match(/#{c.as_sql}$/)
+      Factory.build_join(on: c).as_sql.should match(/ON #{c.as_sql}$/)
     end
 
     context "left" do
@@ -28,6 +28,17 @@ describe Jennifer::QueryBuilder::Join do
         Factory.build_join.as_sql.should match(/^JOIN/)
       end
     end
+
+    context "full" do
+      it "starts with full outer join" do
+        Factory.build_join(type: :full).as_sql.should match(/^FULL OUTER JOIN/)
+      end
+    end
+
+    context "invalid join type" do
+      pending "raises exception" do
+      end
+    end
   end
 
   describe "#sql_args" do
@@ -35,5 +46,62 @@ describe Jennifer::QueryBuilder::Join do
       c = Factory.build_criteria(field: "f2")
       Factory.build_join(on: c).sql_args.should eq(c.sql_args)
     end
+
+    context "source is a query" do
+      it "includes source query sql arguments" do
+        args = Factory.build_join(table: Query["tests2"].where { _id == "asd" }).sql_args
+        args.size.should eq(2)
+        args[0].should eq("asd")
+      end
+    end
   end
+end
+
+describe Jennifer::QueryBuilder::LateralJoin do
+  described_class = Jennifer::QueryBuilder::LateralJoin
+
+  describe "#as_sql" do
+    it "includes source request definition" do
+      lateral_join.as_sql.should match(/ \(SELECT tests\.\*\nFROM tests\nWHERE tests\.id = %s\n\) ON /m)
+    end
+
+    it "calls to_sql on @on" do
+      c = Factory.build_criteria
+      lateral_join(on: c).as_sql.should match(/ON #{c.as_sql}$/)
+    end
+
+    context "left" do
+      it "starts with left" do
+        lateral_join(type: :left).as_sql.should match(/^LEFT JOIN LATERAL/)
+      end
+    end
+
+    context "right" do
+      it "starts with right" do
+        lateral_join(type: :right).as_sql.should match(/^RIGHT JOIN LATERAL/)
+      end
+    end
+
+    context "inner" do
+      it "starts with pure join" do
+        lateral_join.as_sql.should match(/^JOIN LATERAL/)
+      end
+    end
+
+    context "full" do
+      it "starts with full outer join" do
+        lateral_join(type: :full).as_sql.should match(/^FULL OUTER JOIN LATERAL/)
+      end
+    end
+
+    context "invalid join type" do
+      pending "raises exception" do
+      end
+    end
+  end
+end
+
+def lateral_join(type = :inner, on = Factory.build_criteria(table: "t1") == 2)
+  q = Jennifer::QueryBuilder::Query["tests"]
+  Jennifer::QueryBuilder::LateralJoin.new(q.where { _id == 2 }, on, type)
 end

--- a/spec/query_builder/logic_operator_spec.cr
+++ b/spec/query_builder/logic_operator_spec.cr
@@ -1,0 +1,15 @@
+require "../spec_helper"
+
+describe Jennifer::QueryBuilder::LogicOperator do
+  described_class = Jennifer::QueryBuilder::LogicOperator
+  expression = Factory.build_expression
+
+  context "complex expression with grouping" do
+    it "puts paranthesis around proper elemets" do
+      c1 = Factory.build_criteria(field: "f1")
+      c2 = Factory.build_criteria(field: "f2")
+      c3 = Factory.build_criteria(field: "f3")
+      (c1 & expression.g(c2 | c3)).as_sql.should eq("tests.f1 AND (tests.f2 OR tests.f3)")
+    end
+  end
+end

--- a/spec/query_builder/query_spec.cr
+++ b/spec/query_builder/query_spec.cr
@@ -143,10 +143,58 @@ describe Jennifer::QueryBuilder::Query do
   end
 
   describe "#join" do
-    it "addes inner join by default" do
+    it "adds inner join by default" do
       q1 = Factory.build_query
       q1.join(Address) { _test__id == _contact_id }
       q1._joins!.map(&.type).should eq([:inner])
+    end
+
+    context "with Query as a source" do
+      it "creates proper join" do
+        q = Factory.build_query
+        q.join(Factory.build_query, "t1") { sql("true") }
+        q._joins![0].as_sql.should match(/SELECT/m)
+      end
+    end
+
+    context "with ModelQuery as a source" do
+      it "creates proper join" do
+        q = Factory.build_query
+        q.join(Contact.where { _id == 2 }, "t1") { sql("true") }
+        q._joins![0].as_sql.should match(/SELECT contacts/m)
+      end
+    end
+  end
+
+  describe "#laterla_join" do
+    join_query = Contact.where { _id == 2 }
+
+    it "adds inner join by default" do
+      q1 = Factory.build_query
+      q1.lateral_join(join_query, "t") { _test__id == _contact_id }
+      q1._joins!.map(&.type).should eq([:inner])
+    end
+
+    it "builds laterla join" do
+      q1 = Factory.build_query
+      q1.lateral_join(join_query, "t") { _test__id == _contact_id }
+      q1._joins!.map(&.class).should eq([Jennifer::QueryBuilder::LateralJoin])
+    end
+
+    context "with Query as a source" do
+      it "creates proper join" do
+        q = Factory.build_query
+        q.lateral_join(Factory.build_query, "t1") { sql("true") }
+        q._joins![0].as_sql.should match(/SELECT/m)
+      end
+    end
+
+    context "with ModelQuery as a source" do
+      it "creates proper join" do
+        q = Factory.build_query
+        q.lateral_join(join_query, "t1") { sql("true") }
+        q._joins![0].as_sql.should match(/SELECT contacts/m)
+      end
     end
   end
 
@@ -175,6 +223,10 @@ describe Jennifer::QueryBuilder::Query do
       res = Contact.all.select("COUNT(id) as count, contacts.name").group("name").having { sql("COUNT(id)") > 1 }.pluck(:name)
       res.size.should eq(1)
       res[0].should eq("Ivan")
+    end
+
+    it "joins several having invocation with AND" do
+      Contact.all.having { _id > 1 }.having { _id < 2 }._having!.as_sql.should eq("contacts.id > %s AND contacts.id < %s")
     end
   end
 
@@ -263,9 +315,10 @@ describe Jennifer::QueryBuilder::Query do
 
     context "with hash with string keys" do
       it "treats all keys as raw sql without brackets" do
-        orders = Contact.all.order({"age" => :desc})._order.keys
-        orders[0].is_a?(Jennifer::QueryBuilder::RawSql)
-        orders[0].identifier.should eq("age")
+        orders = Contact.all.order({"age" => :desc})._order
+        orders.keys[0].is_a?(Jennifer::QueryBuilder::RawSql)
+        orders.keys[0].identifier.should eq("age")
+        orders.values[0].should eq("desc")
       end
     end
 
@@ -296,13 +349,70 @@ describe Jennifer::QueryBuilder::Query do
     end
   end
 
+  describe "#reorder" do
+    context "with named tuple" do
+      it "converts all keys to criterias" do
+        base_query = Contact.all.order(id: :desc)
+
+        orders = base_query.reorder(age: :desc, id: "asc")._order
+        orders.size.should eq(2)
+        orders = orders.keys
+        orders[0].table.should eq("contacts")
+        orders[0].field.should eq("age")
+      end
+    end
+
+    context "with hash with string keys" do
+      it "treats all keys as raw sql without brackets" do
+        base_query = Contact.all.order(id: :desc)
+        orders = base_query.reorder({"age" => :desc})._order
+        orders.keys[0].is_a?(Jennifer::QueryBuilder::RawSql)
+        orders.keys[0].identifier.should eq("age")
+        orders.values[0].should eq("desc")
+      end
+    end
+
+    context "with hash with symbol keys" do
+      it "treats all keys as criterias" do
+        base_query = Contact.all.order(id: :desc)
+
+        orders = base_query.reorder({:age => :desc})._order.keys
+        orders[0].identifier.should eq("contacts.age")
+      end
+    end
+
+    context "wiht hash with criterias as keys" do
+      it "adds them to pool" do
+        base_query = Contact.all.order(id: :desc)
+        orders = base_query.reorder({Contact._id => :desc})._order
+        orders.keys[0].identifier.should eq("contacts.id")
+      end
+
+      it "marks raw sql not to use brackets" do
+        base_query = Contact.all.order(id: :desc)
+        orders = base_query.reorder({Contact.context.sql("raw sql") => :desc, Contact._id => "asc"})._order.keys
+        orders[0].identifier.should eq("raw sql")
+      end
+    end
+
+    context "with block" do
+      it "marks raw sql not to use brackets" do
+        base_query = Contact.all.order(id: :desc)
+        orders = base_query.reorder { {sql("raw sql") => :desc, _id => "asc"} }._order.keys
+        orders[0].identifier.should eq("raw sql")
+      end
+    end
+  end
+
   describe "#limit" do
-    pending "sets @limit" do
+    it "sets limit" do
+      Contact.all.limit(2).to_sql.should match(/LIMIT 2/m)
     end
   end
 
   describe "#offset" do
-    pending "sets @offset" do
+    it "sets offset" do
+      Contact.all.offset(2).to_sql.should match(/OFFSET 2/m)
     end
   end
 
@@ -416,6 +526,104 @@ describe Jennifer::QueryBuilder::Query do
         i += 1
       end
       i.should eq(15)
+    end
+  end
+
+  describe "#distinct" do
+    it "adds DISTINC to SELECT clause" do
+      Query["contacts"].select(:age).distinct.to_sql.should match(/SELECT DISTINCT contacts\.age/)
+    end
+
+    it "returns uniq rows" do
+      Factory.create_contact(name: "a1")
+      Factory.create_contact(name: "a2")
+      Factory.create_contact(name: "a1")
+      r = Contact.all.order(name: :asc).select(:name).distinct.results
+      r.size.should eq(2)
+      r.map(&.name).should eq(["a1", "a2"])
+    end
+  end
+
+  describe "#find_records_by_sql" do
+    query = <<-SQL
+      SELECT contacts.*
+      FROM contacts
+    SQL
+
+    it "builds all requested objects" do
+      Factory.create_contact
+      res = Query["contacts"].find_records_by_sql(query)
+      res.size.should eq(1)
+      res[0].id.nil?.should be_false
+    end
+
+    it "respects none method" do
+      Factory.create_contact
+      res = Query["contacts"].none.find_records_by_sql(query)
+      res.size.should eq(0)
+    end
+  end
+
+  describe "#find_in_batches" do
+    query = Query["contacts"]
+
+    context "with primary field" do
+      context "as criteria" do
+        pk = Factory.build_criteria(table: "contacts", field: "id")
+
+        it "yields proper amount of records" do
+          Factory.create_contact(3)
+          executed = false
+          query.find_in_batches(batch_size: 2, primary_key: pk) do |records|
+            executed = true
+            records.size.should eq(2)
+            break
+          end
+          executed.should be_true
+        end
+
+        it "yields proper amount of times" do
+          Factory.create_contact(3)
+          yield_count = 0
+          query.find_in_batches(batch_size: 2, primary_key: pk) do |records|
+            yield_count += 1
+          end
+          yield_count.should eq(2)
+        end
+
+        it "use 'start' argument as start primary key value" do
+          yield_count = 0
+          ids = Factory.create_contact(3).map(&.id)
+          query.find_in_batches(ids[1], 2, pk) do |records|
+            yield_count += 1
+            records[0].id.should eq(ids[1])
+            records[1].id.should eq(ids[2])
+          end
+          yield_count.should eq(1)
+        end
+      end
+
+      context "as string" do
+        it "properly loads records" do
+          Factory.create_contact(3)
+          yield_count = 0
+          query.find_in_batches(primary_key: "id", batch_size: 2) do |records|
+            yield_count += 1
+          end
+          yield_count.should eq(2)
+        end
+      end
+    end
+
+    context "without primary key" do
+      it "uses 'start' as a page number" do
+        Factory.create_contact(3)
+        yield_count = 0
+        query.find_in_batches(1, 2) do |records|
+          yield_count += 1
+        end
+        yield_count.should eq(1)
+      end
     end
   end
 end

--- a/src/jennifer.cr
+++ b/src/jennifer.cr
@@ -10,7 +10,10 @@ require "./jennifer/adapter/sql_generator"
 require "./jennifer/config"
 require "./jennifer/version"
 
+require "./jennifer/query_builder/sql_node"
+require "./jennifer/query_builder/logic_operator"
 require "./jennifer/query_builder/*"
+
 require "./jennifer/adapter/base"
 require "./jennifer/relation/base"
 require "./jennifer/relation/*"

--- a/src/jennifer/adapter/postgres/sql_notation.cr
+++ b/src/jennifer/adapter/postgres/sql_notation.cr
@@ -25,7 +25,7 @@ module Jennifer
       def update(query, options : Hash)
         esc = Adapter.adapter_class.escape_string(1)
         String.build do |s|
-          s << "UPDATE " << query.table << " SET "
+          s << "UPDATE " << query._table << " SET "
           options.map { |k, v| "#{k.to_s}= #{esc}" }.join(", ", s)
           s << "\n"
 

--- a/src/jennifer/exceptions.cr
+++ b/src/jennifer/exceptions.cr
@@ -16,6 +16,12 @@ module Jennifer
 
     def initialize(@message)
     end
+
+    def self.assert_column_count(requested, actual)
+      if requested > actual
+        raise self.new("ResultSet includes only #{actual} columns when at least #{requested} are required")
+      end
+    end
   end
 
   class BadQuery < BaseException
@@ -60,6 +66,7 @@ module Jennifer
 
   class RecordInvalid < BaseException
     getter :errors
+
     def initialize(@errors : Accord::ErrorList)
       @message = "Object is invalid: #{errors.inspect}"
     end

--- a/src/jennifer/model/base.cr
+++ b/src/jennifer/model/base.cr
@@ -227,7 +227,7 @@ module Jennifer
         all.where { this.primary == _id }.first!
       end
 
-      def self.all
+      def self.all : QueryBuilder::ModelQuery(self)
         QueryBuilder::ModelQuery(self).build(table_name)
       end
 

--- a/src/jennifer/model/mapping.cr
+++ b/src/jennifer/model/mapping.cr
@@ -169,11 +169,13 @@ module Jennifer
         # NOTE: don't use it manually - there is some dependencies on caller such as reading tesult set to the end
         # if eception was raised
         def _extract_attributes(pull : DB::ResultSet)
+          requested_columns_count = self.class.actual_table_field_count
+          ::Jennifer::BaseException.assert_column_count(requested_columns_count, pull.column_count)
           {% for key, value in properties %}
             %var{key.id} = nil
             %found{key.id} = false
           {% end %}
-          self.class.actual_table_field_count.times do
+          requested_columns_count.times do
             column = pull.column_name(pull.column_index)
             case column
             {% for key, value in properties %}

--- a/src/jennifer/query_builder/all.cr
+++ b/src/jennifer/query_builder/all.cr
@@ -1,0 +1,17 @@
+module Jennifer
+  module QueryBuilder
+    class All < SQLNode
+      getter query : Query
+      delegate sql_args, sql_args_count, to: @query
+
+      def_clone
+
+      def initialize(@query)
+      end
+
+      def as_sql
+        "ALL (#{@query.to_sql})"
+      end
+    end
+  end
+end

--- a/src/jennifer/query_builder/any.cr
+++ b/src/jennifer/query_builder/any.cr
@@ -1,0 +1,17 @@
+module Jennifer
+  module QueryBuilder
+    class Any < SQLNode
+      getter query : Query
+      delegate sql_args, sql_args_count, to: @query
+
+      def_clone
+
+      def initialize(@query)
+      end
+
+      def as_sql
+        "ANY (#{@query.to_sql})"
+      end
+    end
+  end
+end

--- a/src/jennifer/query_builder/condition.cr
+++ b/src/jennifer/query_builder/condition.cr
@@ -3,11 +3,12 @@ require "./criteria"
 module Jennifer
   module QueryBuilder
     class Condition
+      include LogicOperator::Operators
+
       RAW_OPERATORS = [:is, :is_not]
 
-      getter rhs : Criteria::Rightable, lhs : Criteria, operator : Symbol = :bool
+      getter lhs : Criteria, rhs : Criteria::Rightable?, operator : Symbol = :bool
 
-      @rhs = nil
       @negative = false
 
       def_clone
@@ -16,8 +17,7 @@ module Jennifer
         @lhs = Criteria.new(field, table, relation)
       end
 
-      def initialize(criteria)
-        @lhs = criteria
+      def initialize(@lhs)
       end
 
       def initialize(@lhs, @operator, @rhs)
@@ -48,28 +48,6 @@ module Jennifer
       def not
         @negative = !@negative
         self
-      end
-
-      def &(other : Condition | LogicOperator)
-        op = And.new
-        op.add(self)
-        op.add(other)
-        op
-      end
-
-      def &(other : Criteria)
-        self & Condition.new(other)
-      end
-
-      def |(other : Condition | LogicOperator)
-        op = Or.new
-        op.add(self)
-        op.add(other)
-        op
-      end
-
-      def |(other : Criteria)
-        self | Condition.new(other)
       end
 
       def to_s

--- a/src/jennifer/query_builder/executables.cr
+++ b/src/jennifer/query_builder/executables.cr
@@ -1,0 +1,211 @@
+module Jennifer
+  module QueryBuilder
+    module Executables
+      def last
+        reverse_order
+        old_limit = @limit
+        @limit = 1
+        r = to_a[0]?
+        @limit = old_limit
+        reverse_order
+        r
+      end
+
+      def last!
+        old_limit = @limit
+        @limit = 1
+        reverse_order
+        result = to_a
+        reverse_order
+        @limit = old_limit
+        raise RecordNotFound.new(Adapter::SqlGenerator.select(self)) if result.empty?
+        result[0]
+      end
+
+      def first
+        old_limit = @limit
+        @limit = 1
+        r = to_a[0]?
+        @limit = old_limit
+        r
+      end
+
+      def first!
+        old_limit = @limit
+        result = to_a
+        @limit = old_limit
+        raise RecordNotFound.new(Adapter::SqlGenerator.select(self)) if result.empty?
+        result[0]
+      end
+
+      def pluck(fields : Array)
+        ::Jennifer::Adapter.adapter.pluck(self, fields.map(&.to_s))
+      end
+
+      def pluck(field : String | Symbol)
+        ::Jennifer::Adapter.adapter.pluck(self, field.to_s)
+      end
+
+      def pluck(*fields : String | Symbol)
+        ::Jennifer::Adapter.adapter.pluck(self, fields.to_a.map(&.to_s))
+      end
+
+      def delete
+        ::Jennifer::Adapter.adapter.delete(self)
+      end
+
+      def exists?
+        ::Jennifer::Adapter.adapter.exists?(self)
+      end
+
+      def count : Int32
+        ::Jennifer::Adapter.adapter.count(self)
+      end
+
+      # skips any callbacks and validations
+      def modify(options : Hash)
+        ::Jennifer::Adapter.adapter.modify(self, options)
+      end
+
+      def update(options : Hash)
+        ::Jennifer::Adapter.adapter.update(self, options)
+      end
+
+      def update(**options)
+        update(options.to_h)
+      end
+
+      # skips all callbacks and validations
+      def increment(fields : Hash)
+        hash = {} of Symbol | String => NamedTuple(value: DBAny, operator: Symbol)
+        fields.each do |k, v|
+          hash[k] = {value: v, operator: :+}
+        end
+        modify(hash)
+      end
+
+      # skips all callbacks and validations
+      def increment(**fields)
+        hash = {} of Symbol | String => NamedTuple(value: DBAny, operator: Symbol)
+        fields.each do |k, v|
+          hash[k] = {value: v, operator: :+}
+        end
+        modify(hash)
+      end
+
+      # skips any callbacks and validations
+      def decrement(fields : Hash)
+        hash = {} of Symbol | String => NamedTuple(value: DBAny, operator: Symbol)
+        fields.each do |k, v|
+          hash[k] = {value: v, operator: :-}
+        end
+        modify(hash)
+      end
+
+      # skips any callbacks and validations
+      def decrement(**fields)
+        hash = {} of Symbol | String => NamedTuple(value: DBAny, operator: Symbol)
+        fields.each do |k, v|
+          hash[k] = {value: v, operator: :-}
+        end
+        modify(hash)
+      end
+
+      def to_a
+        results
+      end
+
+      def db_results
+        result = [] of Hash(String, DBAny)
+        return result if @do_nothing
+        each_result_set do |rs|
+          result << Adapter.adapter.result_to_hash(rs)
+        end
+        result
+      end
+
+      def results
+        result = [] of Record
+        return result if @do_nothing
+        each_result_set { |rs| result << Record.new(rs) }
+        result
+      end
+
+      # works only if there is id field and it is covertable to Int32
+      def ids
+        pluck(:id).map(&.to_i)
+      end
+
+      def each
+        to_a.each do |e|
+          yield e
+        end
+      end
+
+      def each_result_set(&block)
+        ::Jennifer::Adapter.adapter.select(self) do |rs|
+          begin
+            rs.each do
+              yield rs
+            end
+          rescue e : Exception
+            rs.read_to_end
+            raise e
+          end
+        end
+      end
+
+      def find_in_batches(start = nil, batch_size : Int32 = 1000, primary_key : Criteria? = nil, &block)
+        if primary_key.nil?
+          start ||= 0
+          Config.logger.warn("#find_in_batches methods was called without passing primary_key" \
+                             " key field name which may results in not proper records extraction; 'start' argument" \
+                             " was realized as page number.")
+          request = clone.reorder({} of String => String).limit(batch_size)
+
+          records = request.offset(start * batch_size).to_a
+          while records.any?
+            records_size = records.size
+            yield records
+            break if records_size < batch_size
+            start += 1
+            records = request.offset(start * batch_size).to_a
+          end
+        else
+          primary_key = primary_key.not_nil!
+          request = clone.reorder({primary_key => "asc"}).limit(batch_size)
+
+          records = start ? request.clone.where { primary_key >= start }.to_a : request.to_a
+          while records.any?
+            records_size = records.size
+            primary_key_offset = records.last.attribute(primary_key.field)
+            yield records
+            break if records_size < batch_size
+            records = request.clone.where { primary_key > primary_key_offset }.to_a
+          end
+        end
+      end
+
+      def find_in_batches(start = nil, batch_size : Int32 = 1000, primary_key : String? = nil, &block)
+        raise ArgumentError.new("Primary key shoulb not be nil") if primary_key.nil?
+        find_in_batches(start, batch_size, @expression.c(primary_key.not_nil!)) { |records| yield records }
+      end
+
+      def find_records_by_sql(query : String, args : Array(DBAny) = [] of DBAny)
+        results = [] of Record
+        return results if @do_nothing
+        ::Jennifer::Adapter.adapter.query(query, args) do |rs|
+          begin
+            rs.each do
+              results << Record.new(rs)
+            end
+          rescue e : Exception
+            rs.read_to_end
+            raise e
+          end
+        end
+        results
+      end
+    end
+  end
+end

--- a/src/jennifer/query_builder/expression_builder.cr
+++ b/src/jennifer/query_builder/expression_builder.cr
@@ -9,7 +9,7 @@ module Jennifer
       end
 
       # Initialize object copy;
-      protected def initialize_copy(other : Criteria)
+      protected def initialize_copy(other : ExpressionBuilder)
         @table = other.@table.clone
         @relation = other.@relation.clone
         @query = other.@query
@@ -30,6 +30,22 @@ module Jennifer
       def c(name : String, table_name : String? = nil, relation : String? = nil)
         @query.not_nil!.with_relation! if @query
         Criteria.new(name, table_name || @table, relation || @relation)
+      end
+
+      def g(condition : LogicOperator)
+        Grouping.new(condition)
+      end
+
+      def group(condition : LogicOperator)
+        g(condition)
+      end
+
+      def any(query : Query)
+        Any.new(query)
+      end
+
+      def all(query : Query)
+        All.new(query)
       end
 
       def star(table : String = @table)

--- a/src/jennifer/query_builder/grouping.cr
+++ b/src/jennifer/query_builder/grouping.cr
@@ -1,0 +1,20 @@
+module Jennifer
+  module QueryBuilder
+    class Grouping < SQLNode
+      include LogicOperator::Operators
+
+      getter condition : LogicOperator
+
+      def_clone
+
+      delegate sql_args, sql_args_count, to: @condition
+
+      def initialize(@condition)
+      end
+
+      def as_sql
+        "(" + @condition.as_sql + ")"
+      end
+    end
+  end
+end

--- a/src/jennifer/query_builder/join.cr
+++ b/src/jennifer/query_builder/join.cr
@@ -1,8 +1,8 @@
 module Jennifer
   module QueryBuilder
     class Join
-      @type : Symbol
-      property table : String, type, on : Condition | LogicOperator, aliass : String?, relation : String?
+      setter table : String | Query
+      property type : Symbol, on : Condition | LogicOperator, aliass : String?, relation : String?
 
       def_clone
 
@@ -13,6 +13,14 @@ module Jennifer
       def initialize(@table, @on : Condition | LogicOperator, @type, @aliass = nil, @relation = nil)
       end
 
+      def table
+        @table.is_a?(String) ? @table.as(String) : ""
+      end
+
+      def has_alias?
+        !@aliass.nil?
+      end
+
       def as_sql
         sql_string =
           case @type
@@ -20,14 +28,27 @@ module Jennifer
             "LEFT JOIN "
           when :right
             "RIGHT JOIN "
-          else
+          when :inner
             "JOIN "
+          when :full, :full_outer
+            "FULL OUTER JOIN "
+          else
+            raise ArgumentError.new("Bad join type: #{@type}.")
           end
-        sql_string + "#{table_name} ON #{@on.as_sql}\n"
+
+        sql_string + "#{table_definition} ON #{@on.as_sql}\n"
       end
 
-      def table_name
-        @aliass ? "#{@table} #{@aliass}" : @table
+      def table_definition
+        @aliass ? "#{table_name} #{@aliass}" : table_name
+      end
+
+      def table_name : String
+        if @table.is_a?(String)
+          @table.as(String)
+        else
+          "(" + @table.as(Query).to_sql + ")"
+        end
       end
 
       def alias_tables(aliases)
@@ -36,11 +57,31 @@ module Jennifer
       end
 
       def sql_args
-        @on.sql_args
+        @table.is_a?(String) ? @on.sql_args : @table.as(Query).sql_args + @on.sql_args
       end
 
       def sql_args_count
-        @on.sql_args_count
+        @table.is_a?(String) ? @on.sql_args_count : @table.as(Query).sql_args_count + @on.sql_args_count
+      end
+    end
+
+    class LateralJoin < Join
+      def as_sql
+        sql_string =
+          case @type
+          when :left
+            "LEFT JOIN "
+          when :right
+            "RIGHT JOIN "
+          when :inner
+            "JOIN "
+          when :full, :full_outer
+            "FULL OUTER JOIN "
+          else
+            raise ArgumentError.new("Bad join type: #{@type}.")
+          end + "LATERAL "
+
+        sql_string + "#{table_definition} ON #{@on.as_sql}\n"
       end
     end
   end

--- a/src/jennifer/query_builder/joining.cr
+++ b/src/jennifer/query_builder/joining.cr
@@ -1,0 +1,57 @@
+module Jennifer
+  module QueryBuilder
+    module Joining
+      def join(source : Class, aliass : String? = nil, type = :inner, relation : String? = nil)
+        eb = ExpressionBuilder.new(source.table_name, relation, self)
+        with_relation! if relation
+        other = with eb yield eb
+        add_join(Join.new(source.table_name, other, type, relation: relation))
+        self
+      end
+
+      def join(source : String, aliass : String? = nil, type = :inner, relation : String? = nil)
+        eb = ExpressionBuilder.new(source, relation, self)
+        with_relation! if relation
+        other = with eb yield eb
+        add_join(Join.new(source, other, type, relation))
+        self
+      end
+
+      # NOTE: aliass with passing source as a query is mandatory and will be passed to expression builder as table name
+      def join(source : Query, aliass : String, type = :inner)
+        eb = ExpressionBuilder.new(aliass, nil, self)
+        other = with eb yield eb
+        add_join(Join.new(source, other, type, nil))
+        self
+      end
+
+      def lateral_join(source : Query, aliass : String? = nil, type = :inner, relation : String? = nil)
+        eb = ExpressionBuilder.new(aliass, nil, self)
+        other = with eb yield eb
+        add_join(LateralJoin.new(source, other, type, nil))
+        self
+      end
+
+      def left_join(source : Class, aliass : String? = nil)
+        join(source, aliass, :left) { |eb| with eb yield }
+      end
+
+      def left_join(source : String, aliass : String? = nil)
+        join(source, aliass, :left) { |eb| with eb yield }
+      end
+
+      def right_join(source : Class, aliass : String? = nil)
+        join(source, aliass, :right) { |eb| with eb yield }
+      end
+
+      def right_join(source : String)
+        join(source, aliass, :left) { |eb| with eb yield }
+      end
+
+      protected def add_join(value : Join)
+        @joins ||= [] of Join
+        @joins.not_nil! << value
+      end
+    end
+  end
+end

--- a/src/jennifer/query_builder/json_selector.cr
+++ b/src/jennifer/query_builder/json_selector.cr
@@ -1,6 +1,6 @@
 module Jennifer
   module QueryBuilder
-    class Criteria
+    class Criteria < SQLNode
     end
 
     class JSONSelector < Criteria

--- a/src/jennifer/query_builder/ordering.cr
+++ b/src/jennifer/query_builder/ordering.cr
@@ -1,0 +1,88 @@
+module Jennifer
+  module QueryBuilder
+    module Ordering
+      def order(**opts)
+        order(opts.to_h)
+      end
+
+      def order(opts : Hash(String, String | Symbol))
+        opts.each do |k, v|
+          @order[@expression.sql(k, false)] = v.to_s
+        end
+        self
+      end
+
+      def order(opts : Hash(Symbol, String | Symbol))
+        opts.each do |k, v|
+          key = @expression.c(k.to_s)
+          @order[key] = v.to_s
+        end
+        self
+      end
+
+      def order(opts : Hash(Criteria, String | Symbol))
+        opts.each do |k, v|
+          @order[k] = v.to_s
+          k.as(RawSql).without_brackets if k.is_a?(RawSql)
+        end
+        self
+      end
+
+      def order(opts : Hash(String | Symbol, String | Symbol))
+        opts.each do |k, v|
+          key = k.is_a?(String) ? @expression.sql(k, false) : @expression.c(k.to_s)
+          @order[key] = v.to_s
+        end
+        self
+      end
+
+      def order(&block)
+        order(with @expression yield)
+      end
+
+      def reorder(**opts)
+        reorder(opts.to_h)
+      end
+
+      def reorder(opts : Hash(String, String | Symbol))
+        @order.clear
+        order(opts)
+      end
+
+      def reorder(opts : Hash(Symbol, String | Symbol))
+        @order.clear
+        order(opts)
+      end
+
+      def reorder(opts : Hash(Criteria, String | Symbol))
+        @order.clear
+        order(opts)
+      end
+
+      def reorder(opts : Hash(String | Symbol, String | Symbol))
+        @order.clear
+        order(opts)
+      end
+
+      def reorder(&block)
+        reorder(with @expression yield)
+      end
+
+      private def reverse_order
+        if @order.empty?
+          @order[@expression.c("id")] = "DESC"
+        else
+          @order.each do |k, v|
+            @order[k] =
+              case v
+              when "asc", "ASC"
+                "DESC"
+              else
+                "ASC"
+              end
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/jennifer/query_builder/sql_node.cr
+++ b/src/jennifer/query_builder/sql_node.cr
@@ -1,0 +1,21 @@
+module Jennifer
+  module QueryBuilder
+    abstract class SQLNode
+      abstract def as_sql
+      abstract def sql_args : Array
+
+      def sql_args_count : Int32
+        sql_args.size
+      end
+
+      def set_relation(table, name)
+      end
+
+      def alias_tables(aliases)
+      end
+
+      def change_table(old_name, new_name)
+      end
+    end
+  end
+end

--- a/src/jennifer/relation/base.cr
+++ b/src/jennifer/relation/base.cr
@@ -21,7 +21,7 @@ module Jennifer
 
       @name : String
 
-      def initialize(@name, foreign : String | Symbol?, primary : String | Symbol?, query, @through = nil)
+      def initialize(@name, foreign : String | Symbol?, primary : String | Symbol?, query : QueryBuilder::Query, @through = nil)
         @foreign = foreign.to_s if foreign
         @primary = primary.to_s if primary
         @join_query = query.tree


### PR DESCRIPTION
- added `all` and `any` constructions
- extracted some methods to modules
- added `grouping` in building complex logical constructions - now no `AND` or `OR` groups are surrounded with parenthesis - to do this `#g` (or `#grouping`) method should be used
- added reordering of query
- now `#distinct` just adds `DISTINCT` to the sql instead of extracting only given field
- allows to stuck several `#having` executions
- adds loading records by sql (`#find_by_sql` and `#find_records_by_sql`)
- allows to request records in batches (`#find_in_batches`)