### PR TITLE
Fix relation reloading after eager loading it

### DIFF
--- a/spec/config.cr
+++ b/spec/config.cr
@@ -1,33 +1,49 @@
-adapter = ""
+module Spec
+  @@adapter = ""
+
+  def self.adapter
+    @@adapter
+  end
+
+  def self.adapter=(v)
+    @@adapter = v
+  end
+end
+
 {% if env("DB") == "mysql" %}
   require "../src/jennifer/adapter/mysql"
-  adapter = "mysql"
+  Spec.adapter = "mysql"
 {% elsif env("DB") == "sqlite3" %}
   require "../src/jennifer/adapter/sqlite3"
-  adapter = "sqlite3"
+  Spec.adapter = "sqlite3"
 {% else %}
   require "../src/jennifer/adapter/postgres"
-  adapter = "postgres"
+  Spec.adapter = "postgres"
 {% end %}
 require "../src/jennifer"
 
-Jennifer::Config.configure do |conf|
-  # conf.logger.level = Logger::DEBUG
-  conf.logger.level = Logger::ERROR
-  conf.host = "localhost"
-  conf.adapter = adapter
-  conf.migration_files_path = "./examples/migrations"
-  conf.db = "jennifer_test"
+def set_default_configuration
+  Jennifer::Config.reset_config
+  Jennifer::Config.configure do |conf|
+    # conf.logger.level = Logger::DEBUG
+    conf.logger.level = Logger::ERROR
+    conf.host = "localhost"
+    conf.adapter = Spec.adapter
+    conf.migration_files_path = "./examples/migrations"
+    conf.db = "jennifer_test"
 
-  case adapter
-  when "mysql"
-    conf.user = ENV["DB_USER"]? || "root"
-    conf.password = ""
-  when "postgres"
-    conf.user = ENV["DB_USER"]? || "developer"
-    conf.password = ENV["DB_PASSWORD"]? || "1qazxsw2"
-  when "sqlite3"
-    conf.host = "./spec/fixtures"
-    conf.db = "jennifer_test.db"
+    case Spec.adapter
+    when "mysql"
+      conf.user = ENV["DB_USER"]? || "root"
+      conf.password = ""
+    when "postgres"
+      conf.user = ENV["DB_USER"]? || "developer"
+      conf.password = ENV["DB_PASSWORD"]? || "1qazxsw2"
+    when "sqlite3"
+      conf.host = "./spec/fixtures"
+      conf.db = "jennifer_test.db"
+    end
   end
 end
+
+set_default_configuration

--- a/spec/model/base_spec.cr
+++ b/spec/model/base_spec.cr
@@ -277,18 +277,6 @@ describe Jennifer::Model::Base do
     end
   end
 
-  describe "::search_by_sql" do
-    it "returns array" do
-      Factory.create_contact(name: "Ivan", age: 15)
-      Factory.create_contact(name: "Max", age: 19)
-      Factory.create_contact(name: "Ivan", age: 50)
-
-      res = Contact.search_by_sql("SELECT contacts.* from contacts where age > 16")
-
-      res.size.should eq(2)
-    end
-  end
-
   describe "::models" do
     it "returns all model classes" do
       models = Jennifer::Model::Base.models

--- a/spec/query_builder/model_query_spec.cr
+++ b/spec/query_builder/model_query_spec.cr
@@ -56,6 +56,23 @@ describe Jennifer::QueryBuilder::ModelQuery do
 
     pending "with aliases" do
     end
+
+    it "stops reloading relation from db if there is no records" do
+      Factory.create_contact
+      c = Contact.all.eager_load(:addresses).to_a
+      count = query_count
+      c[0].addresses
+      (query_count - count).should eq(0)
+    end
+
+    it "stop reloading relation from the db if it is already loaded" do
+      c = Factory.create_contact
+      Factory.create_address(contact_id: c.id)
+      c = Contact.all.eager_load(:addresses).to_a
+      count = query_count
+      c[0].addresses.size.should eq(1)
+      (query_count - count).should eq(0)
+    end
   end
 
   describe "#relation" do
@@ -276,6 +293,23 @@ describe Jennifer::QueryBuilder::ModelQuery do
   describe "#includes" do
     it "doesn't add JOIN condition" do
       Contact.all.includes(:address)._joins.nil?.should be_true
+    end
+
+    it "stops reloading relation from db if there is no records" do
+      Factory.create_contact
+      c = Contact.all.includes(:addresses).to_a
+      count = query_count
+      c[0].addresses
+      (query_count - count).should eq(0)
+    end
+
+    it "stop reloading relation from the db if it is already loaded" do
+      c = Factory.create_contact
+      Factory.create_address(contact_id: c.id)
+      c = Contact.all.includes(:addresses).to_a
+      count = query_count
+      c[0].addresses.size.should eq(1)
+      (query_count - count).should eq(0)
     end
   end
 

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -61,7 +61,7 @@ end
 
 Spec.before_each do
   Jennifer::Adapter.adapter.begin_transaction
-  reset_config
+  set_default_configuration
 end
 
 Spec.after_each do
@@ -70,11 +70,6 @@ Spec.after_each do
 end
 
 # Helper methods ================
-
-def reset_config
-  Jennifer::Config.reset_config
-  Jennifer::Config.config.db = "jennifer_test"
-end
 
 def clean_db
   Jennifer::Adapter.adapter.class.remove_queries

--- a/spec/view/base_spec.cr
+++ b/spec/view/base_spec.cr
@@ -113,18 +113,6 @@ describe Jennifer::View::Base do
     end
   end
 
-  describe "::search_by_sql" do
-    it "returns array" do
-      Factory.create_contact(name: "Ivan", age: 15)
-      Factory.create_contact(name: "Max", age: 22)
-      Factory.create_contact(name: "Ivan", age: 50)
-
-      res = MaleContact.search_by_sql("SELECT male_contacts.* from male_contacts where age > 20")
-
-      res.size.should eq(2)
-    end
-  end
-
   describe "::views" do
     it "returns all model classes" do
       views = Jennifer::View::Base.views

--- a/src/jennifer/model/base.cr
+++ b/src/jennifer/model/base.cr
@@ -136,6 +136,10 @@ module Jennifer
         raise Jennifer::UnknownRelation.new(self.class, name)
       end
 
+      def relation_retrieved(name)
+        raise Jennifer::UnknownRelation.new(self.class, name)
+      end
+
       abstract def primary
       abstract def attribute(name)
       abstract def set_attribute(name, value)
@@ -261,16 +265,6 @@ module Jennifer
         end.delete
       end
 
-      def self.search_by_sql(query : String, args = [] of Supportable)
-        result = [] of self
-        ::Jennifer::Adapter.adapter.query(query, args) do |rs|
-          rs.each do
-            result << build(rs)
-          end
-        end
-        result
-      end
-
       macro inherited
         ::Jennifer::Model::Validation.inherited_hook
         ::Jennifer::Model::Callback.inherited_hook
@@ -296,7 +290,6 @@ module Jennifer
         macro finished
           ::Jennifer::Model::Validation.finished_hook
           ::Jennifer::Model::Callback.finished_hook
-          ::Jennifer::Model::RelationDefinition.finished_hook
 
           def self.relation(name : String)
             @@relations[name]

--- a/src/jennifer/model/relation_definition.cr
+++ b/src/jennifer/model/relation_definition.cr
@@ -67,7 +67,7 @@ module Jennifer
           \{% RELATION_NAMES << "#{name.id}" %}
 
           @\{{name.id}} = [] of \{{klass}}
-          @__\{{name.id}}_retrived = false
+          @__\{{name.id}}_retrieved = false
 
           # returns relation metaobject
           def self.\{{name.id}}_relation
@@ -83,22 +83,26 @@ module Jennifer
 
           # returns array of related objects
           def \{{name.id}}
-            if !@__\{{name.id}}_retrived && @\{{name.id}}.empty?
-              @__\{{name.id}}_retrived = true
+            if !@__\{{name.id}}_retrieved && @\{{name.id}}.empty?
+              @__\{{name.id}}_retrieved = true
               @\{{name.id}} = \{{name.id}}_query.to_a.as(Array(\{{klass}}))
             end
             @\{{name.id}}
           end
 
-          # builds related object from hash
+          # builds related object from hash and adds to relation
           def append_\{{name.id}}(rel : Hash)
-            @__\{{name.id}}_retrived = true
+            @__\{{name.id}}_retrieved = true
             @\{{name.id}} << \{{klass}}.build(rel, false)
           end
 
           def append_\{{name.id}}(rel : \{{klass}})
-            @__\{{name.id}}_retrived = true
+            @__\{{name.id}}_retrieved = true
             @\{{name.id}} << rel
+          end
+
+          def __\{{name.id}}_retrieved
+            @__\{{name.id}}_retrieved = true
           end
 
           # removes given object from relation array
@@ -111,6 +115,7 @@ module Jennifer
             rel
           end
 
+          # Insert given object to db and relation
           def add_\{{name.id}}(rel : Hash)
             @\{{name.id}} << \{{@type}}.\{{name.id}}_relation.insert(self, rel).as(\{{klass}})
           end
@@ -143,7 +148,7 @@ module Jennifer
           end
 
           @\{{name.id}} = [] of \{{klass}}
-          @__\{{name.id}}_retrived = false
+          @__\{{name.id}}_retrieved = false
 
           def self.\{{name.id}}_relation
             @@\{{name.id}}_relation ||= ::Jennifer::Relation::ManyToMany(\{{klass}}, \{{@type}}).new("\{{name.id}}", \{{foreign}}, \{{primary}},
@@ -161,21 +166,25 @@ module Jennifer
           end
 
           def \{{name.id}}
-            if !@__\{{name.id}}_retrived && @\{{name.id}}.empty?
-              @__\{{name.id}}_retrived = true
+            if !@__\{{name.id}}_retrieved && @\{{name.id}}.empty?
+              @__\{{name.id}}_retrieved = true
               @\{{name.id}} = \{{name.id}}_query.to_a.as(Array(\{{klass}}))
             end
             @\{{name.id}}
           end
 
           def append_\{{name.id}}(rel : Hash)
-            @__\{{name.id}}_retrived = true
+            @__\{{name.id}}_retrieved = true
             @\{{name.id}} << \{{klass}}.build(rel, false)
           end
 
           def append_\{{name.id}}(rel : \{{klass}})
-            @__\{{name.id}}_retrived = true
+            @__\{{name.id}}_retrieved = true
             @\{{name.id}} << rel
+          end
+
+          def __\{{name.id}}_retrieved
+            @__\{{name.id}}_retrieved = true
           end
 
           def remove_\{{name.id}}(rel : \{{klass}})
@@ -210,7 +219,7 @@ module Jennifer
           \{% RELATION_NAMES << "#{name.id}" %}
 
           @\{{name.id}} : \{{klass}}?
-          @__\{{name.id}}_retrived = false
+          @__\{{name.id}}_retrieved = false
 
           def self.\{{name.id}}_relation
             @@\{{name.id}}_relation ||= ::Jennifer::Relation::BelongsTo(\{{klass}}, \{{@type}}).new("\{{name.id}}", \{{foreign}}, \{{primary}},
@@ -218,8 +227,8 @@ module Jennifer
           end
 
           def \{{name.id}}
-            if !@__\{{name.id}}_retrived && @\{{name.id}}.nil?
-              @__\{{name.id}}_retrived = true
+            if !@__\{{name.id}}_retrieved && @\{{name.id}}.nil?
+              @__\{{name.id}}_retrieved = true
               @\{{name.id}} = \{{name.id}}_reload
             end
             @\{{name.id}}
@@ -239,13 +248,17 @@ module Jennifer
           end
 
           def append_\{{name.id}}(rel : Hash)
-            @__\{{name.id}}_retrived = true
+            @__\{{name.id}}_retrieved = true
             @\{{name.id}} = \{{klass}}.build(rel, false)
           end
 
           def append_\{{name.id}}(rel : \{{klass}})
-            @__\{{name.id}}_retrived = true
+            @__\{{name.id}}_retrieved = true
             @\{{name.id}} = rel
+          end
+
+          def __\{{name.id}}_retrieved
+            @__\{{name.id}}_retrieved = true
           end
 
           def remove_\{{name.id}}
@@ -272,7 +285,7 @@ module Jennifer
           \{% RELATION_NAMES << "#{name.id}" %}
 
           @\{{name.id}} : \{{klass}}?
-          @__\{{name.id}}_retrived = false
+          @__\{{name.id}}_retrieved = false
 
           def self.\{{name.id}}_relation
             @@\{{name.id}}_relation ||= ::Jennifer::Relation::HasOne(\{{klass}}, \{{@type}}).new("\{{name.id}}", \{{foreign}}, \{{primary}},
@@ -280,8 +293,8 @@ module Jennifer
           end
 
           def \{{name.id}}
-            if !@__\{{name.id}}_retrived && @\{{name.id}}.nil?
-              @__\{{name.id}}_retrived = true
+            if !@__\{{name.id}}_retrieved && @\{{name.id}}.nil?
+              @__\{{name.id}}_retrieved = true
               @\{{name.id}} = \{{name.id}}_reload
             end
             @\{{name.id}}
@@ -301,13 +314,17 @@ module Jennifer
           end
 
           def append_\{{name.id}}(rel : Hash)
-            @__\{{name.id}}_retrived = true
+            @__\{{name.id}}_retrieved = true
             @\{{name.id}} = \{{klass}}.build(rel, false)
           end
 
           def append_\{{name.id}}(rel : \{{klass}})
-            @__\{{name.id}}_retrived = true
+            @__\{{name.id}}_retrieved = true
             @\{{name.id}} = rel
+          end
+
+          def __\{{name.id}}_retrieved
+            @__\{{name.id}}_retrieved = true
           end
 
           def remove_\{{name.id}}
@@ -323,35 +340,52 @@ module Jennifer
             @\{{name.id}} = \{{@type}}.\{{name.id}}_relation.insert(self, rel)
           end
         end
-
-        macro update_relation_methods
-          def append_relation(name, hash)
-            \\{% if RELATION_NAMES.size > 0 %}
-              case name
-              \\{% for rel in RELATION_NAMES %}
-                when \\{{rel}}
-                  append_\\{{rel.id}}(hash)
-              \\{% end %}
-              else
-                super(name, hash)
-              end
-            \\{% end %}
-          end
-        end
-      end
-
-      macro finished_hook
-        update_relation_methods
-
-        def __refresh_relation_retrieves
-          \{% for rel in RELATION_NAMES %}
-            @__\{{rel.id}}_retrived = false
-          \{% end %}
-        end
       end
 
       macro inherited_hook
         RELATION_NAMES = [] of String
+
+        macro def append_relation(name, hash)
+          \{% begin %}
+            \{% relations = @type.constant("RELATION_NAMES") %}
+            \{% if relations.size > 0 %}
+              case name
+              \{% for rel in relations %}
+                when \{{rel}}
+                  append_\{{rel.id}}(hash)
+              \{% end %}
+              else
+                super(name, hash)
+              end
+            \{% end %}
+          \{% end %}
+        end
+
+        macro def relation_retrieved(name)
+          \{% begin %}
+            \{% relations = @type.constant("RELATION_NAMES") %}
+            \{% if relations.size > 0 %}
+              case name
+              \{% for rel in relations %}
+                when \{{rel}}
+                  __\{{rel.id}}_retrieved
+              \{% end %}
+              else
+                super(name)
+              end
+            \{% end %}
+          \{% end %}
+        end
+
+
+        macro def __refresh_relation_retrieves
+          \{% begin %}
+            \{% relations = @type.constant("RELATION_NAMES") %}
+            \{% for rel in relations %}
+              @__\{{rel.id}}_retrieved = false
+            \{% end %}
+          \{% end %}
+        end
       end
     end
   end

--- a/src/jennifer/model/sti_mapping.cr
+++ b/src/jennifer/model/sti_mapping.cr
@@ -274,10 +274,6 @@ module Jennifer
           {% end %}
           super
         end
-
-        macro finished
-          ::Jennifer::Model::RelationDefinition.finished_hook
-        end
       end
 
       macro sti_mapping(**properties)

--- a/src/jennifer/query_builder/model_query.cr
+++ b/src/jennifer/query_builder/model_query.cr
@@ -190,7 +190,9 @@ module Jennifer
 
           new_collection = rel.query(primary_fields).db_results
 
-          unless new_collection.empty?
+          if new_collection.empty?
+            collection.each(&.relation_retrieved(name))
+          else
             collection.each_with_index do |mod, i|
               pv = primary_fields[i]
               # TODO: check if deleting elements from array will increase performance
@@ -237,7 +239,11 @@ module Jennifer
             end
           end
         end
-        add_preloaded(h_result.values)
+        collection = h_result.values
+        @relations.each do |rel|
+          collection.each(&.relation_retrieved(rel))
+        end
+        add_preloaded(collection)
       end
 
       private def add_aliases

--- a/src/jennifer/view/base.cr
+++ b/src/jennifer/view/base.cr
@@ -48,16 +48,6 @@ module Jennifer
         build(values)
       end
 
-      def self.search_by_sql(query : String, args = [] of DBAny)
-        result = [] of self
-        ::Jennifer::Adapter.adapter.query(query, args) do |rs|
-          rs.each do
-            result << build(rs)
-          end
-        end
-        result
-      end
-
       def self.all
         QueryBuilder::ModelQuery(self).new(table_name)
       end
@@ -78,6 +68,10 @@ module Jennifer
       end
 
       def append_relation(name, hash)
+        raise Jennifer::UnknownRelation.new(self.class, name)
+      end
+
+      def relation_retrieved(name)
         raise Jennifer::UnknownRelation.new(self.class, name)
       end
 


### PR DESCRIPTION
- fixes `#includes` and `#eager_load` methods: marks empty relations as retrieved ones
- small test refactoring
- removed `Model::Base#search_by_sql` and `View::Base#search_by_sql` methods because of `QueryBuilder::ModelQuery#find_by_sql` method presence
- `RelationDefinition` macros optimization