### PR TITLE
Fix type for DropIndex class

### DIFF
--- a/src/jennifer/migration/base.cr
+++ b/src/jennifer/migration/base.cr
@@ -76,7 +76,7 @@ module Jennifer
       end
 
       def drop_index(table_name, name)
-        TableBuilder::DropInde.new(table_name, name).process
+        TableBuilder::DropIndex.new(table_name, name).process
         self
       end
 


### PR DESCRIPTION
Fix #72 `DropIndex` class reference in the migration class