### PR TITLE
Allow multiple config instances

### DIFF
--- a/spec/adapter/adapter_registry_spec.cr
+++ b/spec/adapter/adapter_registry_spec.cr
@@ -1,0 +1,42 @@
+require "../spec_helper"
+
+def create_configuration(adapter_name = nil)
+  Jennifer::Config.configure(:custom) do |custom|
+    if adapter_name
+      custom.adapter = adapter_name
+    else
+      {% if env("DB") == "mysql" %}
+        custom.adapter = "mysql"
+      {% else %}
+        custom.user = ENV["DB_USER"]? || "developer"
+        custom.password = ENV["DB_PASSWORD"]? || "1qazxsw2"
+      {% end %}
+    end
+    custom.db = "jennifer_test"
+  end
+end
+
+describe Jennifer::Adapter::AdapterRegistry do
+  it "should have packaged adapters registered" do
+    Jennifer::Adapter::AdapterRegistry.adapter_class("postgres").should eq(Jennifer::Adapter::Postgres)
+  end
+
+  it "should fail if an unknown adapter is requested" do
+    expect_raises(Jennifer::UnknownAdapter, /Unknown adapter someadapter, available adapters are/) do
+      create_configuration("someadapter")
+      Jennifer::Adapter::AdapterRegistry.adapter(:custom)
+    end
+  end
+
+  it "should create an instance of a configured adapter" do
+    create_configuration
+    Jennifer::Adapter::AdapterRegistry.adapter(:custom).should be_a(Jennifer::Adapter::Base)
+  end
+
+  it "should always return the same adapter instance once created" do
+    create_configuration
+    initial = Jennifer::Adapter::AdapterRegistry.adapter(:custom)
+    later = Jennifer::Adapter::AdapterRegistry.adapter(:custom)
+    later.should eq(initial)
+  end
+end

--- a/spec/adapter/adapter_registry_spec.cr
+++ b/spec/adapter/adapter_registry_spec.cr
@@ -6,6 +6,7 @@ def create_configuration(adapter_name = nil)
       custom.adapter = adapter_name
     else
       {% if env("DB") == "mysql" %}
+        custom.user = ENV["DB_USER"]? || "root"
         custom.adapter = "mysql"
       {% else %}
         custom.user = ENV["DB_USER"]? || "developer"
@@ -18,7 +19,12 @@ end
 
 describe Jennifer::Adapter::AdapterRegistry do
   it "should have packaged adapters registered" do
-    Jennifer::Adapter::AdapterRegistry.adapter_class("postgres").should eq(Jennifer::Adapter::Postgres)
+    # again, TBR when adapters can coexist
+    {% if env("DB") == "mysql" %}
+      Jennifer::Adapter::AdapterRegistry.adapter_class("mysql").should eq(Jennifer::Adapter::Mysql)
+    {% else %}
+      Jennifer::Adapter::AdapterRegistry.adapter_class("postgres").should eq(Jennifer::Adapter::Postgres)
+    {% end %}
   end
 
   it "should fail if an unknown adapter is requested" do

--- a/spec/adapter/adapter_selection_spec.cr
+++ b/spec/adapter/adapter_selection_spec.cr
@@ -1,0 +1,29 @@
+require "../spec_helper"
+
+class ModelExposingConfig < Jennifer::Model::Base
+  mapping(
+    id: {type: Int32, primary: true}
+  )
+  def self.validate_adapter_using_config(expected)
+    actual = self.adapter.config.key
+    raise "Expected model adapter to use database #{expected} but was #{actual}" unless actual == expected
+  end
+end
+
+class ModelUsingDefault < ModelExposingConfig
+end
+
+class ModelUsingOther < ModelExposingConfig
+  using_config :other_config
+end
+
+describe Jennifer::Adapter::AdapterSelection do
+  it "should use the default config when none specified" do
+    ModelUsingDefault.validate_adapter_using_config("default")
+  end
+
+  it "should use the specified config when explicitly set via using_config" do
+    # note other_config is setup in spec config
+    default = ModelUsingOther.validate_adapter_using_config("other_config")
+  end
+end

--- a/spec/adapter/base_spec.cr
+++ b/spec/adapter/base_spec.cr
@@ -1,7 +1,7 @@
 require "../spec_helper"
 
 describe Jennifer::Adapter::Base do
-  adapter = Jennifer::Adapter.adapter
+  adapter = Jennifer::Adapter::AdapterRegistry.adapter
 
   describe Jennifer::BadQuery do
     describe "query" do

--- a/spec/config.cr
+++ b/spec/config.cr
@@ -25,24 +25,34 @@ require "../src/jennifer"
 def set_default_configuration
   Jennifer::Config.reset_config
   Jennifer::Config.configure do |conf|
-    # conf.logger.level = Logger::DEBUG
-    conf.logger.level = Logger::ERROR
-    conf.host = "localhost"
-    conf.adapter = Spec.adapter
-    conf.migration_files_path = "./examples/migrations"
-    conf.db = "jennifer_test"
+    apply_config(conf)
+  end
+  Jennifer::Config.configure(:other_config) do |conf|
+    apply_config(conf)
+  end
+end
 
-    case Spec.adapter
-    when "mysql"
-      conf.user = ENV["DB_USER"]? || "root"
-      conf.password = ""
-    when "postgres"
-      conf.user = ENV["DB_USER"]? || "developer"
-      conf.password = ENV["DB_PASSWORD"]? || "1qazxsw2"
-    when "sqlite3"
-      conf.host = "./spec/fixtures"
-      conf.db = "jennifer_test.db"
-    end
+def apply_config(conf)
+  # conf.logger.level = Logger::DEBUG
+  conf.logger.level = Logger::ERROR
+  conf.host = "localhost"
+  conf.adapter = Spec.adapter
+  conf.migration_files_path = "./examples/migrations"
+  conf.db = "jennifer_test"
+
+  case Spec.adapter
+  when "mysql"
+    conf.user = ENV["DB_USER"]? || "root"
+    conf.password = ""
+    conf.adapter = "mysql"
+  when "postgres"
+    conf.user = ENV["DB_USER"]? || "developer"
+    conf.password = ENV["DB_PASSWORD"]? || "1qazxsw2"
+    conf.adapter = "postgres"
+  when "sqlite3"
+    conf.host = "./spec/fixtures"
+    conf.db = "jennifer_test.db"
+    conf.adapter = "sqlite"
   end
 end
 

--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -96,6 +96,34 @@ describe Jennifer::Config do
       Jennifer::Config.retry_delay.should eq(666)
     end
   end
+
+  describe "::connection_string" do
+    it "should build a connection string from config" do
+      loaded_uri = "mysql://root:somepass@somehost/some_database?max_pool_size=111&initial_pool_size=222&max_idle_pool_size=333&retry_attempts=444&checkout_timeout=555.0&retry_delay=666.0"
+      Jennifer::Config.from_uri(loaded_uri)
+      Jennifer::Config.connection_string(:db).should eq(loaded_uri)
+    end
+
+    it "should ignore password if unset" do
+      clear_password
+      loaded_uri = "mysql://root@somehost/some_database?max_pool_size=111&initial_pool_size=222&max_idle_pool_size=333&retry_attempts=444&checkout_timeout=555.0&retry_delay=666.0"
+      Jennifer::Config.from_uri(loaded_uri)
+      Jennifer::Config.connection_string(:db).should eq(loaded_uri)
+    end
+
+    it "should build host part with host:port " do
+      clear_password
+      loaded_uri = "mysql://root@somehost:5432/some_database?max_pool_size=111&initial_pool_size=222&max_idle_pool_size=333&retry_attempts=444&checkout_timeout=555.0&retry_delay=666.0"
+      Jennifer::Config.from_uri(loaded_uri)
+      Jennifer::Config.connection_string(:db).should eq(loaded_uri)
+    end
+  end
+end
+
+def clear_password
+  Jennifer::Config.configure do |config|
+    config.password = ""
+  end
 end
 
 def ignoring_config_error(&block)

--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -3,12 +3,53 @@ require "./spec_helper"
 describe Jennifer::Config do
   describe "::read" do
     it "reads data from yaml file" do
-      begin
-        Jennifer::Config.read("./spec/fixtures/database.yml")
-        Jennifer::Config.config.db.should eq("jennifer_develop")
-      ensure
-        Jennifer::Config.config.db = "jennifer_test"
+      Jennifer::Config.read("./spec/fixtures/database.yml")
+      Jennifer::Config.configure{ |config| config.db.should eq("jennifer_develop") }
+    end
+  end
+
+  describe "::configure" do
+    it "should always use default config if no key supplied" do
+      ignoring_config_error do
+        Jennifer::Config.configure do |without_key|
+          Jennifer::Config.configure(:default) do |with_key|
+            without_key.should eq(with_key)
+          end
+        end
       end
+    end
+
+    it "different keys supply different configs" do
+      ignoring_config_error do
+        Jennifer::Config.configure(:some_config) do |some_config|
+          Jennifer::Config.configure(:another_config) do |another_config|
+            some_config.should_not eq(another_config)
+          end
+        end
+      end
+    end
+
+    it "same key supplies same config" do
+      ignoring_config_error do
+        Jennifer::Config.configure(:some_config) do |first|
+          Jennifer::Config.configure(:some_config) do |second|
+            raise "not the same config" unless first === second
+          end
+        end
+      end
+    end
+
+    it "config accessible by string or symbol" do
+      ignoring_config_error do
+        Jennifer::Config.configure(:some_config) do |first|
+          raise "not the same config" unless first === Jennifer::Config.get_instance("some_config")
+        end
+      end
+    end
+
+    it "config key is accessible from instance" do
+      Jennifer::Config.get_instance.key.should eq("default")
+      Jennifer::Config.get_instance(:some_config).key.should eq("some_config")
     end
   end
 
@@ -16,13 +57,14 @@ describe Jennifer::Config do
     it "should parse uri string" do
       db_uri = "mysql://root:password@somehost:3306/some_database"
       Jennifer::Config.from_uri(db_uri)
-      config = Jennifer::Config
-      config.adapter.should eq("mysql")
-      config.user.should eq("root")
-      config.password.should eq("password")
-      config.host.should eq("somehost")
-      config.port.should eq(3306)
-      config.db.should eq("some_database")
+      Jennifer::Config.configure do |config|
+        config.adapter.should eq("mysql")
+        config.user.should eq("root")
+        config.password.should eq("password")
+        config.host.should eq("somehost")
+        config.port.should eq(3306)
+        config.db.should eq("some_database")
+      end
     end
 
     it "expects adapter and database at very least" do
@@ -39,8 +81,7 @@ describe Jennifer::Config do
     end
 
     it "should ignore port if not supplied" do
-      db_uri = "mysql://root@somehost/some_database"
-      Jennifer::Config.from_uri(db_uri)
+      Jennifer::Config.from_uri("mysql://root@somehost/some_database")
       Jennifer::Config.port.should eq(-1)
     end
 
@@ -55,4 +96,9 @@ describe Jennifer::Config do
       Jennifer::Config.retry_delay.should eq(666)
     end
   end
+end
+
+def ignoring_config_error(&block)
+  yield
+rescue e : Jennifer::InvalidConfig
 end

--- a/src/jennifer.cr
+++ b/src/jennifer.cr
@@ -5,6 +5,7 @@ require "ifrit/converter"
 
 require "./jennifer/exceptions"
 require "./jennifer/adapter"
+require "./jennifer/adapter/adapter_registry"
 require "./jennifer/adapter/record"
 require "./jennifer/adapter/sql_generator"
 require "./jennifer/config"

--- a/src/jennifer/adapter.cr
+++ b/src/jennifer/adapter.cr
@@ -19,12 +19,6 @@ module Jennifer
       adapter.query(_query, args) { |rs| yield rs }
     end
 
-    # :nodoc:
-    # Allows to assign newly created adapter and call setupe methods with existing adapter
-    private def self.adapter=(_adapter)
-      @@adapter = _adapter
-    end
-
     def self.adapter
       Jennifer::Adapter::AdapterRegistry.adapter
     end

--- a/src/jennifer/adapter.cr
+++ b/src/jennifer/adapter.cr
@@ -26,12 +26,7 @@ module Jennifer
     end
 
     def self.adapter
-      @@adapter ||= begin
-        a = adapter_class.not_nil!.build
-        self.adapter = a
-        a.prepare
-        a
-      end
+      Jennifer::Adapter::AdapterRegistry.adapter
     end
 
     def self.adapter_class

--- a/src/jennifer/adapter/adapter_registry.cr
+++ b/src/jennifer/adapter/adapter_registry.cr
@@ -4,7 +4,7 @@ module Jennifer
 
       @@adapter_classes = {} of String => Base.class
 
-      @@adapter_instances = {} of Symbol => Jennifer::Adapter::Base
+      @@adapter_instances = {} of String => Jennifer::Adapter::Base
 
       # Register an adapter class with a given name.
       #
@@ -33,7 +33,8 @@ module Jennifer
       # if no config key is supplied then :default is assumed. the first time this
       # is invoked, the adapter is created and this instance
       #
-      def self.adapter(config_key : Symbol = :default)
+      def self.adapter(config_key : String | Symbol = :default)
+        config_key = config_key.to_s
         unless @@adapter_instances.has_key?(config_key)
           config = Config.get_instance(config_key)
           config.logger.debug("Creating instance of '#{config.adapter}' adapter using '#{config_key}' config")

--- a/src/jennifer/adapter/adapter_registry.cr
+++ b/src/jennifer/adapter/adapter_registry.cr
@@ -1,0 +1,45 @@
+module Jennifer
+  module Adapter
+    class AdapterRegistry
+
+      @@adapter_classes = {} of String => Base.class
+
+      @@adapter_instances = {} of Symbol => Jennifer::Adapter::Base
+
+      # Register an adapter class with a given name.
+      #
+      def self.register_adapter(name : String, adapter_class : Jennifer::Adapter::Base.class)
+        @@adapter_classes[name] = adapter_class
+      end
+
+
+      register_adapter("postgres", Jennifer::Adapter::Postgres)
+      # register_adapter("mysql", Jennifer::Adapter::Mysql)
+      # register_adapter(:sqlite3, Jennifer::Adapter::Sqlite.class)
+
+      # Retrieve the adapter class registered with a given name
+      # Raises UnknownAdapter error if no adapter has been regiestered with that name
+      #
+      def self.adapter_class(name : String)
+        raise UnknownAdapter.new(name, @@adapter_classes.keys) unless @@adapter_classes.has_key?(name)
+        return @@adapter_classes[name]
+      end
+
+      # Create/Retrieve an Adapter instance for a given config key
+      # if no config key is supplied then :default is assumed. the first time this
+      # is invoked, the adapter is created and this instance
+      #
+      def self.adapter(config_key : Symbol = :default)
+        unless @@adapter_instances.has_key?(config_key)
+          config = Config.get_instance(config_key)
+          config.logger.debug("Creating instance of '#{config.adapter}' adapter using '#{config_key}' config")
+          adapter_class = adapter_class(config.adapter)
+          adapter = adapter_class.not_nil!.build(config_key)
+          @@adapter_instances[config_key] = adapter
+          adapter.prepare
+        end
+        @@adapter_instances[config_key].not_nil!
+      end
+    end
+  end
+end

--- a/src/jennifer/adapter/adapter_registry.cr
+++ b/src/jennifer/adapter/adapter_registry.cr
@@ -12,10 +12,14 @@ module Jennifer
         @@adapter_classes[name] = adapter_class
       end
 
-
-      register_adapter("postgres", Jennifer::Adapter::Postgres)
-      # register_adapter("mysql", Jennifer::Adapter::Mysql)
-      # register_adapter(:sqlite3, Jennifer::Adapter::Sqlite.class)
+      # temporary and will be refactored away when adapters can co-exist
+      {% if env("DB") == "mysql" %}
+        register_adapter("mysql", Jennifer::Adapter::Mysql)
+      {% elsif env("DB") == "sqlite3" %}
+        register_adapter("sqlite3", Jennifer::Adapter::Sqlite.class)
+      {% else %}
+        register_adapter("postgres", Jennifer::Adapter::Postgres)
+      {% end %}
 
       # Retrieve the adapter class registered with a given name
       # Raises UnknownAdapter error if no adapter has been regiestered with that name

--- a/src/jennifer/adapter/adapter_selection.cr
+++ b/src/jennifer/adapter/adapter_selection.cr
@@ -1,0 +1,15 @@
+module Jennifer
+  module Adapter
+    module AdapterSelection
+
+      # macro to redefine the adapter method to have it use a specific named
+      # configuration.
+      macro using_config(config_name)
+        def self.adapter
+          Jennifer::Adapter::AdapterRegistry.adapter({{config_name}})
+        end
+      end
+
+    end
+  end
+end

--- a/src/jennifer/adapter/base.cr
+++ b/src/jennifer/adapter/base.cr
@@ -16,7 +16,7 @@ module Jennifer
 
       getter db
 
-      def initialize(@config_key : Symbol = :default)
+      def initialize(@config_key : String | Symbol = :default)
         @db = DB.open(config.connection_string(:db))
       end
 
@@ -128,7 +128,7 @@ module Jennifer
         nil
       end
 
-      def self.db_connection
+      def db_connection
         DB.open(config.connection_string(:db)) do |db|
           yield(db)
         end
@@ -159,23 +159,23 @@ module Jennifer
         SqlGenerator.escape_string(size)
       end
 
-      def self.drop_database
+      def drop_database
         db_connection do |db|
           db.exec "DROP DATABASE #{config.db}"
         end
       end
 
-      def self.create_database
+      def create_database
         db_connection do |db|
           puts db.exec "CREATE DATABASE #{config.db}"
         end
       end
 
-      def self.generate_schema
+      def generate_schema
         raise "Not implemented"
       end
 
-      def self.load_schema
+      def load_schema
         raise "Not implemented"
       end
 

--- a/src/jennifer/adapter/base.cr
+++ b/src/jennifer/adapter/base.cr
@@ -16,13 +16,16 @@ module Jennifer
 
       getter db
 
-      def initialize
-        @db = DB.open(Config.connection_string(:db))
+      def initialize(@config_key : Symbol = :default)
+        @db = DB.open(config.connection_string(:db))
       end
 
-      def self.build
-        a = new
-        a
+      def config
+        Jennifer::Config.get_instance(@config_key)
+      end
+
+      def self.build(config_key = :default)
+        new config_key
       end
 
       def prepare

--- a/src/jennifer/adapter/base.cr
+++ b/src/jennifer/adapter/base.cr
@@ -17,7 +17,7 @@ module Jennifer
       getter db
 
       def initialize
-        @db = DB.open(Base.connection_string(:db))
+        @db = DB.open(Config.connection_string(:db))
       end
 
       def self.build
@@ -126,7 +126,7 @@ module Jennifer
       end
 
       def self.db_connection
-        DB.open(connection_string) do |db|
+        DB.open(Config.connection_string(:db)) do |db|
           yield(db)
         end
       rescue e
@@ -136,25 +136,6 @@ module Jennifer
 
       def self.join_table_name(table1, table2)
         [table1.to_s, table2.to_s].sort.join("_")
-      end
-
-      def self.connection_string(*options)
-        auth_part = Config.user
-        auth_part += ":#{Config.password}" if Config.password && !Config.password.empty?
-
-        host_part = Config.host
-        host_part += Config.port.to_s if Config.port && Config.port > 0
-
-        String.build do |s|
-          s << Config.adapter << "://" << auth_part << "@" << host_part
-          s << "/" << Config.db if options.includes?(:db)
-          s << "?"
-          [
-            {% for arg in Config::CONNECTION_URI_PARAMS %}
-              "{{arg.id}}=#{Config.{{arg.id}}}"
-            {% end %},
-          ].join(",", s)
-        end
       end
 
       def self.extract_arguments(hash)

--- a/src/jennifer/adapter/base.cr
+++ b/src/jennifer/adapter/base.cr
@@ -36,7 +36,7 @@ module Jennifer
         time = Time.now.ticks
         res = with_connection { |conn| conn.exec(_query, args) }
         time = Time.now.ticks - time
-        Config.logger.debug { regular_query_message(time / TICKS_PER_MICROSECOND, _query, args) }
+        config.logger.debug { regular_query_message(time / TICKS_PER_MICROSECOND, _query, args) }
         res
       rescue e : BaseException
         BadQuery.prepend_information(e, _query, args)
@@ -48,7 +48,7 @@ module Jennifer
       def query(_query, args = [] of DB::Any)
         time = Time.now.ticks
         res = with_connection { |conn| conn.query(_query, args) { |rs| time = Time.now.ticks - time; yield rs } }
-        Config.logger.debug { regular_query_message(time / TICKS_PER_MICROSECOND, _query, args) }
+        config.logger.debug { regular_query_message(time / TICKS_PER_MICROSECOND, _query, args) }
         res
       rescue e : BaseException
         BadQuery.prepend_information(e, _query, args)
@@ -61,7 +61,7 @@ module Jennifer
         time = Time.now.ticks
         res = with_connection { |conn| conn.scalar(_query, args) }
         time = Time.now.ticks - time
-        Config.logger.debug { regular_query_message(time / TICKS_PER_MICROSECOND, _query, args) }
+        config.logger.debug { regular_query_message(time / TICKS_PER_MICROSECOND, _query, args) }
         res
       rescue e : BaseException
         BadQuery.prepend_information(e, _query, args)
@@ -129,7 +129,7 @@ module Jennifer
       end
 
       def self.db_connection
-        DB.open(Config.connection_string(:db)) do |db|
+        DB.open(config.connection_string(:db)) do |db|
           yield(db)
         end
       rescue e
@@ -161,13 +161,13 @@ module Jennifer
 
       def self.drop_database
         db_connection do |db|
-          db.exec "DROP DATABASE #{Config.db}"
+          db.exec "DROP DATABASE #{config.db}"
         end
       end
 
       def self.create_database
         db_connection do |db|
-          puts db.exec "CREATE DATABASE #{Config.db}"
+          puts db.exec "CREATE DATABASE #{config.db}"
         end
       end
 

--- a/src/jennifer/adapter/postgres.cr
+++ b/src/jennifer/adapter/postgres.cr
@@ -305,7 +305,7 @@ module Jennifer
         io << " ARRAY" if options[:array]?
       end
 
-      def self.create_database
+      def create_database
         opts = [config.db, "-O", config.user, "-h", config.host, "-U", config.user]
         Process.run("PGPASSWORD=#{config.password} createdb \"${@}\"", opts, shell: true).inspect
       end
@@ -321,7 +321,7 @@ module Jennifer
         end
       end
 
-      def self.drop_database
+      def drop_database
         io = IO::Memory.new
         opts = [config.db, "-h", config.host, "-U", config.user]
         s = Process.run("PGPASSWORD=#{config.password} dropdb \"${@}\"", opts, shell: true, output: io, error: io)
@@ -330,14 +330,14 @@ module Jennifer
         end
       end
 
-      def self.generate_schema
+      def generate_schema
         io = IO::Memory.new
         opts = ["-U", config.user, "-d", config.db, "-h", config.host, "-s"]
         s = Process.run("PGPASSWORD=#{config.password} pg_dump \"${@}\"", opts, shell: true, output: io)
         File.write(config.structure_path, io.to_s)
       end
 
-      def self.load_schema
+      def load_schema
         io = IO::Memory.new
         opts = ["-U", config.user, "-d", config.db, "-h", config.host, "-a", "-f", config.structure_path]
         s = Process.run("PGPASSWORD=#{config.password} psql \"${@}\"", opts, shell: true, output: io)

--- a/src/jennifer/adapter/postgres.cr
+++ b/src/jennifer/adapter/postgres.cr
@@ -113,7 +113,7 @@ module Jennifer
             .join("pg_namespace") { _oid == _pg_class__relnamespace }
             .where do
             (_attnum > 0) &
-              (_pg_namespace__nspname == Config.schema) &
+              (_pg_namespace__nspname == config.schema) &
               (_pg_class__relname == table) &
               _attisdropped.not
           end.count
@@ -125,7 +125,7 @@ module Jennifer
       def material_view_exists?(name)
         Query["pg_class"].join("pg_namespace") { _oid == _pg_class__relnamespace }.where do
           (_relkind == "m") &
-            (_pg_namespace__nspname == Config.schema) &
+            (_pg_namespace__nspname == config.schema) &
             (_relname == name)
         end.exists?
       end
@@ -145,7 +145,7 @@ module Jennifer
       def index_exists?(table, name)
         Query["pg_class"]
           .join("pg_namespace") { _oid == _pg_class__relnamespace }
-          .where { (_pg_class__relname == name) & (_pg_namespace__nspname == Config.schema) }
+          .where { (_pg_class__relname == name) & (_pg_namespace__nspname == config.schema) }
           .exists?
       end
 
@@ -306,8 +306,8 @@ module Jennifer
       end
 
       def self.create_database
-        opts = [Config.db, "-O", Config.user, "-h", Config.host, "-U", Config.user]
-        Process.run("PGPASSWORD=#{Config.password} createdb \"${@}\"", opts, shell: true).inspect
+        opts = [config.db, "-O", config.user, "-h", config.host, "-U", config.user]
+        Process.run("PGPASSWORD=#{config.password} createdb \"${@}\"", opts, shell: true).inspect
       end
 
       private def index_type_translate(name)
@@ -323,8 +323,8 @@ module Jennifer
 
       def self.drop_database
         io = IO::Memory.new
-        opts = [Config.db, "-h", Config.host, "-U", Config.user]
-        s = Process.run("PGPASSWORD=#{Config.password} dropdb \"${@}\"", opts, shell: true, output: io, error: io)
+        opts = [config.db, "-h", config.host, "-U", config.user]
+        s = Process.run("PGPASSWORD=#{config.password} dropdb \"${@}\"", opts, shell: true, output: io, error: io)
         if s.exit_code != 0
           raise io.to_s
         end
@@ -332,15 +332,15 @@ module Jennifer
 
       def self.generate_schema
         io = IO::Memory.new
-        opts = ["-U", Config.user, "-d", Config.db, "-h", Config.host, "-s"]
-        s = Process.run("PGPASSWORD=#{Config.password} pg_dump \"${@}\"", opts, shell: true, output: io)
-        File.write(Config.structure_path, io.to_s)
+        opts = ["-U", config.user, "-d", config.db, "-h", config.host, "-s"]
+        s = Process.run("PGPASSWORD=#{config.password} pg_dump \"${@}\"", opts, shell: true, output: io)
+        File.write(config.structure_path, io.to_s)
       end
 
       def self.load_schema
         io = IO::Memory.new
-        opts = ["-U", Config.user, "-d", Config.db, "-h", Config.host, "-a", "-f", Config.structure_path]
-        s = Process.run("PGPASSWORD=#{Config.password} psql \"${@}\"", opts, shell: true, output: io)
+        opts = ["-U", config.user, "-d", config.db, "-h", config.host, "-a", "-f", config.structure_path]
+        s = Process.run("PGPASSWORD=#{config.password} psql \"${@}\"", opts, shell: true, output: io)
         raise "Cant load schema: exit code #{s.exit_code}" if s.exit_code != 0
       end
     end

--- a/src/jennifer/adapter/sqlite3.cr
+++ b/src/jennifer/adapter/sqlite3.cr
@@ -94,7 +94,7 @@ module Jennifer
       #
 
       private def self.db_path
-        File.join(Config.host, Config.db)
+        File.join(config.host, config.db)
       end
 
       private def column_definition(name, options, io)

--- a/src/jennifer/adapter/transactions.cr
+++ b/src/jennifer/adapter/transactions.cr
@@ -56,11 +56,11 @@ module Jennifer
           conn.transaction do |tx|
             lock_connection(tx)
             begin
-              Config.logger.debug("TRANSACTION START")
+              config.logger.debug("TRANSACTION START")
               res = yield(tx)
-              Config.logger.debug("TRANSACTION COMMIT")
+              config.logger.debug("TRANSACTION COMMIT")
             rescue e
-              Config.logger.debug("TRANSACTION ROLLBACK")
+              config.logger.debug("TRANSACTION ROLLBACK")
               raise e
             ensure
               lock_connection(previous_transaction)
@@ -73,7 +73,7 @@ module Jennifer
       # NOTICE: designed for test usage
       def begin_transaction
         raise ::Jennifer::BaseException.new("Couldn't manually begin non top level transaction") if current_transaction
-        Config.logger.debug("TRANSACTION START")
+        config.logger.debug("TRANSACTION START")
         lock_connection(@db.checkout.begin_transaction)
       end
 
@@ -83,7 +83,7 @@ module Jennifer
         raise ::Jennifer::BaseException.new("No transaction to rollback") unless t
         t = t.not_nil!
         t.rollback
-        Config.logger.debug("TRANSACTION ROLLBACK")
+        config.logger.debug("TRANSACTION ROLLBACK")
         t.connection.release
         lock_connection(nil)
       end

--- a/src/jennifer/config.cr
+++ b/src/jennifer/config.cr
@@ -28,6 +28,8 @@ module Jennifer
       define_fields(INT_FIELDS, default: 0)
       define_fields(FLOAT_FIELDS, default: 0.0)
 
+      property :key
+
       def initialize
         @adapter = "postgres"
         @host = "localhost"

--- a/src/jennifer/config.cr
+++ b/src/jennifer/config.cr
@@ -77,11 +77,31 @@ module Jennifer
         raise Jennifer::InvalidConfig.new("No database configured") if db.empty?
       end
 
+      def connection_string(*options)
+        auth_part = @user
+        auth_part += ":#{@password}" if @password && !@password.empty?
+
+        host_part = @host
+        host_part += ":#{@port}" if @port && @port > 0
+
+        String.build do |s|
+          s << @adapter << "://"
+          s << auth_part << "@" if auth_part.size > 0
+          s << host_part
+          s << "/" << @db if options.includes?(:db)
+          s << "?"
+          {% for arg, index in CONNECTION_URI_PARAMS %}
+            s << "{{arg.id}}=#{@{{arg.id}}}"
+            s << "&" if {{index}} < {{CONNECTION_URI_PARAMS.size - 1}}
+          {% end %}
+        end
+      end
+
       def from_uri(db_uri : String)
         begin
           from_uri(URI.parse(db_uri))
-        rescue e
-          self.logger.error("Error parsing database uri #{db_uri}")
+        rescue e : URI::Error
+          self.logger.error("Error parsing database uri #{db_uri} - #{e.message}")
         end
       end
 

--- a/src/jennifer/config.cr
+++ b/src/jennifer/config.cr
@@ -4,139 +4,157 @@ require "logger"
 module Jennifer
   class Config
     CONNECTION_URI_PARAMS = [:max_pool_size, :initial_pool_size, :max_idle_pool_size, :retry_attempts, :checkout_timeout, :retry_delay]
-    STRING_FIELDS = {:user, :password, :db, :host, :adapter, :migration_files_path, :schema, :structure_folder}
-    INT_FIELDS    = {:port, :max_pool_size, :initial_pool_size, :max_idle_pool_size, :retry_attempts}
-    FLOAT_FIELDS  = [:checkout_timeout, :retry_delay]
 
-    macro define_fields(const, default)
-      {% for field in @type.constant(const.stringify) %}
-      @@{{field.id}} = {{default}}
+    class ConfigInstance
+      STRING_FIELDS = {:adapter, :user, :password, :db, :host, :adapter, :migration_files_path, :schema, :structure_folder, :key}
+      INT_FIELDS    = {:port, :max_pool_size, :initial_pool_size, :max_idle_pool_size, :retry_attempts}
+      FLOAT_FIELDS  = [:checkout_timeout, :retry_delay]
 
-      def self.{{field.id}}=(value)
-        @@{{field.id}} = value
+      macro define_fields(const, default)
+        {% for field in @type.constant(const.stringify) %}
+        @{{field.id}} = {{default}}
+
+        def {{field.id}}=(value)
+          @{{field.id}} = value
+        end
+
+        def {{field.id}}
+          @{{field.id}}
+        end
+      {% end %}
       end
 
-      def self.{{field.id}}
-        @@{{field.id}}
+      define_fields(STRING_FIELDS, default: "")
+      define_fields(INT_FIELDS, default: 0)
+      define_fields(FLOAT_FIELDS, default: 0.0)
+
+      def initialize
+        @adapter = "postgres"
+        @host = "localhost"
+        @port = -1
+        @migration_files_path = "./db/migrations"
+        @schema = "public"
+        @db = ""
+        @key = "default"
+
+        @initial_pool_size = 1
+        @max_pool_size = 5
+        @max_idle_pool_size = 1
+        @retry_attempts = 1
+
+        @checkout_timeout = 5.0
+        @retry_delay = 1.0
+
+        @logger = Logger.new(STDOUT)
+        @logger.not_nil!.level = Logger::DEBUG
+        @logger.not_nil!.formatter = Logger::Formatter.new do |severity, datetime, progname, message, io|
+          io << datetime << ": " << message
+        end
       end
-    {% end %}
+
+      def structure_folder
+        if @structure_folder.empty?
+          File.dirname(@migration_files_path)
+        else
+          @structure_folder
+        end
+      end
+
+      def structure_path
+        File.join(self.structure_folder, "structure.sql")
+      end
+
+      def logger
+        @logger.not_nil!
+      end
+
+      def logger=(value)
+        @logger = value
+      end
+
+      def validate_config
+        raise Jennifer::InvalidConfig.new("No adapter configured") if adapter.empty?
+        raise Jennifer::InvalidConfig.new("No database configured") if db.empty?
+      end
+
+      def from_uri(db_uri : String)
+        begin
+          from_uri(URI.parse(db_uri))
+        rescue e
+          self.logger.error("Error parsing database uri #{db_uri}")
+        end
+      end
+
+      def from_uri(uri : URI)
+        @adapter = uri.scheme.to_s if uri.scheme
+        @host = uri.host.to_s if uri.host
+        @port = uri.port.not_nil!  if uri.port
+        @db = uri.path.to_s.lchop if uri.path
+        @user = uri.user.to_s if uri.user
+        @password = uri.password.to_s if uri.password
+
+        if uri.query
+          params = HTTP::Params.parse(uri.query.to_s)
+          {% for field in CONNECTION_URI_PARAMS %}
+            {% if STRING_FIELDS.includes?(field) %}
+                @{{field.id}} = params["{{field.id}}"] if params["{{field.id}}"]?
+            {% end %}
+            {% if INT_FIELDS.includes?(field) %}
+                @{{field.id}} = params["{{field.id}}"].to_i if params["{{field.id}}"]?
+            {% end %}
+            {% if FLOAT_FIELDS.includes?(field) %}
+                @{{field.id}} = params["{{field.id}}"].to_f if params["{{field.id}}"]?
+            {% end %}
+          {% end %}
+        end
+        validate_config
+        self
+      end
+
+      def read(path : String, env : String | Symbol = :development)
+        _env = env.to_s
+        source = YAML.parse(File.read(path))[_env]
+        {% for field in STRING_FIELDS %}
+          @{{field.id}} = source["{{field.id}}"].as_s if source["{{field.id}}"]?
+        {% end %}
+        {% for field in INT_FIELDS %}
+          @{{field.id}} = source["{{field.id}}"].as_s.to_i if source["{{field.id}}"]?
+        {% end %}
+        {% for field in FLOAT_FIELDS %}
+          @{{field.id}} = source["{{field.id}}"].as_s.to_f if source["{{field.id}}"]?
+        {% end %}
+        self.validate_config
+        self
+      end
     end
 
-    define_fields(STRING_FIELDS, default: "")
-    define_fields(INT_FIELDS, 0)
-    define_fields(FLOAT_FIELDS, 0.0)
+    @@configs = {} of String => ConfigInstance
 
-    def self.structure_folder
-      if @@structure_folder.empty?
-        File.dirname(@@migration_files_path)
-      else
-        @@structure_folder
+    def self.get_instance(config_key : String | Symbol = :default)
+      config_key = config_key.to_s
+      return @@configs[config_key] if @@configs.has_key?(config_key)
+      ConfigInstance.new.tap do |config|
+        @@configs[config_key] = config
+        config.key = config_key
       end
-    end
-
-    def self.structure_path
-      File.join(Config.structure_folder, "structure.sql")
     end
 
     def self.reset_config
-      @@adapter = "postgres"
-      @@host = "localhost"
-      @@port = -1
-      @@migration_files_path = "./db/migrations"
-      @@schema = "public"
-      @@db = ""
-
-      @@initial_pool_size = 1
-      @@max_pool_size = 5
-      @@max_idle_pool_size = 1
-      @@retry_attempts = 1
-
-      @@checkout_timeout = 5.0
-      @@retry_delay = 1.0
-
-      @@logger = Logger.new(STDOUT)
-      @@logger.not_nil!.level = Logger::DEBUG
-      @@logger.not_nil!.formatter = Logger::Formatter.new do |severity, datetime, progname, message, io|
-        io << datetime << ": " << message
-      end
+      @@configs = {} of String => ConfigInstance
     end
 
-    reset_config
-
-    def self.logger
-      @@logger.not_nil!
+    def self.configure(config_name : Symbol = :default, &block)
+      config = get_instance(config_name)
+      yield config
+      config.validate_config
     end
 
-    def self.logger=(value)
-      @@logger = value
-    end
-
-    def self.configure(&block)
-      yield self
-      self.validate_config
-    end
-
-    def self.validate_config
-      raise Jennifer::InvalidConfig.new("No adapter configured") if adapter.empty?
-      raise Jennifer::InvalidConfig.new("No database configured") if db.empty?
-    end
-
-    def self.configure
-      self
-    end
-
-    def self.config
-      self
-    end
-
-    def self.from_uri(db_uri : String)
-      begin
-        from_uri(URI.parse(db_uri))
-      rescue e
-        self.logger.error("Error parsing database uri #{db_uri}")
-      end
-    end
-
-    def self.from_uri(uri : URI)
-      config.adapter = uri.scheme.to_s if uri.scheme
-      config.host = uri.host.to_s if uri.host
-      config.port = uri.port.not_nil!  if uri.port
-      config.db = uri.path.to_s.lchop if uri.path
-      config.user = uri.user.to_s if uri.user
-      config.password = uri.password.to_s if uri.password
-
-      if uri.query
-        params = HTTP::Params.parse(uri.query.to_s)
-        {% for field in CONNECTION_URI_PARAMS %}
-          {% if STRING_FIELDS.includes?(field) %}
-              @@{{field.id}} = params["{{field.id}}"] if params["{{field.id}}"]?
-          {% end %}
-          {% if INT_FIELDS.includes?(field) %}
-              @@{{field.id}} = params["{{field.id}}"].to_i if params["{{field.id}}"]?
-          {% end %}
-          {% if FLOAT_FIELDS.includes?(field) %}
-              @@{{field.id}} = params["{{field.id}}"].to_f if params["{{field.id}}"]?
-          {% end %}
-        {% end %}
-      end
-      self.validate_config
-      self
-    end
-    
-    def self.read(path : String, env : String | Symbol = :development)
-      _env = env.to_s
-      source = YAML.parse(File.read(path))[_env]
-      {% for field in STRING_FIELDS %}
-        @@{{field.id}} = source["{{field.id}}"].as_s if source["{{field.id}}"]?
+    {%for method in ConfigInstance.methods %}
+      {% unless method.name.ends_with?('=') %}
+        def self.{{method.name}}({% if method.args.size > 0 %} {{*method.args}} {% end %})
+          get_instance(:default).{{method.name}}({{* method.args.map(&.name)}})
+        end
       {% end %}
-      {% for field in INT_FIELDS %}
-        @@{{field.id}} = source["{{field.id}}"].as_s.to_i if source["{{field.id}}"]?
-      {% end %}
-      {% for field in FLOAT_FIELDS %}
-        @@{{field.id}} = source["{{field.id}}"].as_s.to_f if source["{{field.id}}"]?
-      {% end %}
-      self.validate_config
-      self
-    end
+    {% end %}
   end
 end

--- a/src/jennifer/exceptions.cr
+++ b/src/jennifer/exceptions.cr
@@ -85,6 +85,12 @@ module Jennifer
     end
   end
 
+  class UnknownAdapter < BaseException
+    def initialize(name, available)
+      @message = "Unknown adapter #{name}, available adapters are #{available.join(", ")}"
+    end
+  end
+
   class RecordExists < BaseException
     def initialize(record, relation)
       @message = "#{record.class}##{record.primary} has associated records in #{relation} relation"

--- a/src/jennifer/model/mapping.cr
+++ b/src/jennifer/model/mapping.cr
@@ -106,7 +106,7 @@ module Jennifer
         @@strict_mapping : Bool?
 
         def self.strict_mapping?
-          @@strict_mapping ||= ::Jennifer::Adapter.adapter.table_column_count(table_name) == field_count
+          @@strict_mapping ||= adapter.table_column_count(table_name) == field_count
         end
 
         # Returns field count
@@ -333,7 +333,7 @@ module Jennifer
         end
 
         def save(skip_validation = false) : Bool
-          unless ::Jennifer::Adapter.adapter.under_transaction?
+          unless {{@type}}.adapter.under_transaction?
             {{@type}}.transaction do
               save_without_transaction(skip_validation)
             end || false
@@ -354,7 +354,7 @@ module Jennifer
           response =
             if new_record?
               return false unless __before_create_callback
-              res = ::Jennifer::Adapter.adapter.insert(self)
+              res = {{@type}}.adapter.insert(self)
               {% if primary && primary_auto_incrementable %}
                 if primary.nil? && res.last_insert_id > -1
                   init_primary_field(res.last_insert_id.to_i)
@@ -364,7 +364,7 @@ module Jennifer
               __after_create_callback
               res
             else
-              ::Jennifer::Adapter.adapter.update(self)
+              {{@type}}.adapter.update(self)
             end
           __after_save_callback
           response.rows_affected == 1
@@ -440,7 +440,7 @@ module Jennifer
 
           _primary = self.class.primary
           _primary_value = primary
-          ::Jennifer::Adapter.adapter.update(self.class.all.where { _primary == _primary_value }, values)
+          {{@type}}.adapter.update(self.class.all.where { _primary == _primary_value }, values)
         end
 
         # Sets *name* field with *value*

--- a/src/jennifer/sam.cr
+++ b/src/jennifer/sam.cr
@@ -1,37 +1,37 @@
 Sam.namespace "db" do
   desc "Will call all pending migrations"
   task "migrate" do |t, args|
-    Jennifer::Migration::Runner.migrate
+    Jennifer::Migration::Runner.migrate(config_key(args), 1)
   end
 
   desc "Invoke next migration. Usage: db:step [<count>]"
   task "step" do |t, args|
     if !args.raw.empty?
-      Jennifer::Migration::Runner.migrate(args.raw.last.as(String).to_i)
+      Jennifer::Migration::Runner.migrate(config_key(args), args.raw.last.as(String).to_i)
     else
-      Jennifer::Migration::Runner.migrate(1)
+      Jennifer::Migration::Runner.migrate(config_key(args), 1)
     end
   end
 
   desc "Rollback migration. Usage: db:rollback [v=<migration_exclusive_version> | <count_to_rollback>]"
   task "rollback" do |t, args|
+    options = {:count => 1}
     if !args.raw.empty?
-      Jennifer::Migration::Runner.rollback({:count => args.raw.last.as(String).to_i})
+      options = {:count => args.raw.last.as(String).to_i}
     elsif args["v"]?
-      Jennifer::Migration::Runner.rollback({:to => args["v"].as(String)})
-    else
-      Jennifer::Migration::Runner.rollback({:count => 1})
+      options = {:to => args["v"].as(String)}
     end
+    Jennifer::Migration::Runner.rollback(config_key(args), options)
   end
 
   desc "Drops database"
   task "drop" do |t, args|
-    puts Jennifer::Migration::Runner.drop
+    puts Jennifer::Migration::Runner.drop(config_key(args))
   end
 
   desc "Creates database"
   task "create" do |t, args|
-    puts Jennifer::Migration::Runner.create
+    puts Jennifer::Migration::Runner.create(config_key(args))
   end
 
   desc "Runs db:create and db:migrate"
@@ -40,12 +40,12 @@ Sam.namespace "db" do
 
   namespace "schema" do
     desc "Loads database structure from structure.sql"
-    task "load" do
-      Jennifer::Migration::Runner.load_schema
+    task "load" do |t, args|
+      Jennifer::Migration::Runner.load_schema(config_key(args))
     end
   end
 
-  desc "Prints version of last runned migration"
+  desc "Prints version of last migration run"
   task "version" do
     version = Jennifer::Migration::Version.all.last
     if version
@@ -54,6 +54,11 @@ Sam.namespace "db" do
       puts "DB has no ran migration yet."
     end
   end
+end
+
+private def config_key(args)
+  return args["config"].to_s if args["config"]?
+  "default"
 end
 
 Sam.namespace "generate" do


### PR DESCRIPTION
This is a pretty wide reaching change and I've tried to segment it into separate commits as much as possible. I'd definitely recommend approaching it a commit at a time.  There is still work to do here to cover everything, but the feature is getting pretty large and this is a good checkpoint. I'll outline the remaining work at the end

With this PR, configs are now namable e.g. you can name config instances when they're created
```ruby
Jennifer::Config.configure(:some_config) do |config|
 ...
end

# and  without a key it uses a default config instance 
Jennifer::Config.configure do |default_config|
 ...
end
```
Named configs can be used inside of models by applying a macro `using_config`
```ruby
class ModelUsingOther < Jennifer::Model::Base
  using_config :some_config
  ...
end
```

To enable this the PR introduces registries for Configs and Adapters. The config registry holds the individual config instances and the Adapter registry holds Adapter instances per config.

The adapter registry is functionally complete, but given how the adapter logic gets compiled in, only a single adapter can be registered at a time. This is ok for now and as soon as adapters can co-exist the guard macros around the registrations can be removed. Making them co-exist is a ball of wax though and could do with discussion. Definitely outside the scope of this change though.

Final commit is to clean up static calls to the Config module and use an instance instead.

Outstanding work
- [ ] still many calls to Adapter.adapter. This has been hardwired to just use the default config but the needs to be replaced with calls to an adapter instance tied to a config. This may be something to tackle as part of the adapter co-existence changes. There are a couple of places where static access is assumed where care will be needed e.g. [field](https://github.com/sgargan/jennifer.cr/blame/master/src/jennifer/adapter/postgres/field.cr#L15)
- [ ] migrations still only use the default config. This will be easy enough to do, the sam tasks will need to take a config_key and the Migration base will need to use the adapter selection. I've a chunk of this work done, but figured it was better to get this shipped and let the migration follow.

EDIT: Doesn't look like I'll get away without updating the migrations in this PR as CI needs to be able to migrate. I'll make those changes.