### PR TITLE
Prepare for Crystal 0.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,14 +186,23 @@ to your `spec_helper.cr`. NB. you could simply use regular deleting or truncatio
 
 > Before developing any feature please create an issue where you describe your idea.
 
-Before development create the db user (see `/spec/config.cr` file) by running
+Before development create the db user (see `/spec/config.cr` file) by running:
 ```shell
-$ crystal example/migrate.cr -- db:setup
+# Postgres
+$ crystal examples/run.cr -- db:setup
+
+# Mysql
+$ DB=mysql crystal examples/run.cr -- db:setup
 ```
 
 PostgreSQL is used by default, but MySql is also supported while running tests by using:
 ```shell
 $ DB=mysql crystal spec
+```
+
+In case you need to set the database user or password, use:
+```shell
+$ DB_USER=user DB_PASSWORD=pass crystal spec
 ```
 
 Also you can override used user name and password using `DB_USER` and `DB_PASSWORD` env variables.
@@ -212,14 +221,13 @@ NB. It also depends on then choosen adapter (postgres by default).
 
 - [active_record.cr](https://github.com/waterlink/active_record.cr) - small simple AR realization
 
-- [crecto](https://github.com/vladfaust/core.cr) - based on Phoenix's ecto lib and follows the repository pattern; 
+- [crecto](https://github.com/vladfaust/core.cr) - based on Phoenix's ecto lib and follows the repository pattern;
 
 - [granite-orm](https://github.com/amberframework/granite-orm) - light weight orm focusing on mapping fields from request to your objects
 
 - [topaz](https://github.com/topaz-crystal/topaz) - inspired by AR ORM with migration mechanism
 
 - [micrate](https://github.com/juanedi/micrate) - standalone migration tool for crystal
-
 
 ## Contributing
 

--- a/shard.yml
+++ b/shard.yml
@@ -4,19 +4,22 @@ version: 0.4.2
 authors:
   - Roman Kalnytskyi <moranibaca@gmail.com>
 
-crystal: 0.23.1
+crystal: 0.24.1
 
 license: MIT
 
 development_dependencies:
   mysql:
     github: crystal-lang/crystal-mysql
+    version: "~> 0.4"
   pg:
     github: will/crystal-pg
+    version: "~> 0.14.1"
   sqlite3:
     github: crystal-lang/crystal-sqlite3
   factory:
     github: imdrasil/factory
+    branch: master
 dependencies:
   sam:
     github: imdrasil/sam.cr

--- a/src/jennifer/migration/base.cr
+++ b/src/jennifer/migration/base.cr
@@ -94,7 +94,7 @@ module Jennifer
         migrations.map { |e| e.underscore.split("_").last }
       end
 
-      macro def self.migrations
+      def self.migrations
         {% begin %}
           {% if @type.all_subclasses.size > 0 %}
             [

--- a/src/jennifer/model/base.cr
+++ b/src/jennifer/model/base.cr
@@ -156,7 +156,7 @@ module Jennifer
         raise AbstractMethod.new(:relation, {{@type}})
       end
 
-      macro def self.models
+      def self.models
         {% begin %}
           [
             {% for model in @type.all_subclasses %}

--- a/src/jennifer/model/mapping.cr
+++ b/src/jennifer/model/mapping.cr
@@ -90,7 +90,7 @@ module Jennifer
       end
 
       macro mapping(properties, strict = true)
-        macro def self.children_classes
+        def self.children_classes
           {% begin %}
             {% if @type.all_subclasses.size > 0 %}
               [{{ @type.all_subclasses.join(", ").id }}]

--- a/src/jennifer/model/relation_definition.cr
+++ b/src/jennifer/model/relation_definition.cr
@@ -378,7 +378,7 @@ module Jennifer
       macro inherited_hook
         RELATION_NAMES = [] of String
 
-        macro def set_inverse_of(name : String, object)
+        def set_inverse_of(name : String, object)
           \{% begin %}
             \{% relations = RELATION_NAMES %}
             \{% if relations.size > 0 %}
@@ -395,7 +395,7 @@ module Jennifer
           \{% end %}
         end
 
-        macro def append_relation(name : String, hash)
+        def append_relation(name : String, hash)
           \{% begin %}
             \{% relations = RELATION_NAMES %}
             \{% if relations.size > 0 %}
@@ -411,7 +411,7 @@ module Jennifer
           \{% end %}
         end
 
-        macro def relation_retrieved(name : String)
+        def relation_retrieved(name : String)
           \{% begin %}
             \{% relations = RELATION_NAMES %}
             \{% if relations.size > 0 %}
@@ -428,7 +428,7 @@ module Jennifer
         end
 
 
-        macro def __refresh_relation_retrieves
+        def __refresh_relation_retrieves
           \{% begin %}
             \{% relations = RELATION_NAMES %}
             \{% for rel in relations %}

--- a/src/jennifer/view/base.cr
+++ b/src/jennifer/view/base.cr
@@ -85,7 +85,7 @@ module Jennifer
 
       abstract def attribute(name)
 
-      macro def self.views
+      def self.views
         {% begin %}
           {% if @type.all_subclasses.size > 1 %}
             [{{@type.all_subclasses.join(", ").id}}] - [Jennifer::View::Materialized]


### PR DESCRIPTION
Crystal 0.24 introduces [a couple of breaking changes](https://github.com/crystal-lang/crystal/releases/tag/0.24.0). The ones that affect `jennifer` are:

- Removing the `Time#ticks` method. `Time.measure` or `Time.monotonic` can be used instead (they provide nanosecond precision). See https://github.com/crystal-lang/crystal/pull/5093

- Removing the `macro def` construct (in favour of just calling def with macro syntax inside the method body). See https://github.com/crystal-lang/crystal/pull/5040

The `pg` shard has been updated [here](https://github.com/will/crystal-pg/issues/116), but it still uses a branch, because the changes are breaking. You can leave this PR unmerged until the `pg` shard changes get their own version and I can update the `shard.yml` accordingly (but I have no problem with using it as it is).

The changes I introduce here are breaking as well, they won't work with Crystal 0.23.

Let me know if these changes are ok or if I should update anything.

Oh, and thanks for this lovely ORM :)