### PR TITLE
Add allow blank to some validations

### DIFF
--- a/docs/model_mapping.md
+++ b/docs/model_mapping.md
@@ -110,9 +110,9 @@ end
 | `:getter` | if getter should be created (default - `true`) |
 | `:setter` | if setter should be created (default - `true`) |
 
-If you don't want to define all the table fields - pass seond argument to mapping as `false`.
+If you don't want to define all the table fields - pass `false` as second argument.
 
-It defines next methods:
+`%mapping` defines next methods:
 
 | method | args | description |
 | --- | --- | --- |
@@ -146,7 +146,10 @@ It defines next methods:
 | `#set_attribute` | `String \| Symbol`, `DB::Any` | sets attribute by given name |
 | `#attribute` | `String \| Symbol` | returns attribute value by it's name |
 
-Automatically model is associated with table with underscored pluralized class name, but special name can be defined using `::table_name` method in own body before using any relation (`::singular_table_name` - for singular variant).
+All allowed types are listed on the [Migration](/migration.md) page.
+
+
+Automatically model is associated with table with underscored pluralized name of it's class, but special name can be defined using `::table_name` method in own body before using any relation (`::singular_table_name` - for singular variant).
 
 **Important restriction** - model with no primary field is not allowed for now.
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -1,6 +1,32 @@
 # Validation
 
-For validation purposes is used [accord](https://github.com/neovintage/accord) shard. Also there are several general macroses for declaring validations:
+For validation purposes is used [accord](https://github.com/neovintage/accord) shard. So this allows to specify custom class validator:
+
+```crystal
+class Passport < Jennifer::Model::Base
+  mapping(
+    enn: {type: String, primary: true},
+    contact_id: {type: Int32, null: true}
+  )
+
+  validates_with [EnnValidator]
+  belongs_to :contact, Contact
+end
+
+class EnnValidator < Accord::Validator
+  def initialize(context : Passport)
+    @context = context
+  end
+
+  def call(errors : Accord::ErrorList)
+    if @context.enn!.size < 4 && @context.enn![0].downcase == 'a'
+      errors.add(:enn, "Invalid enn")
+    end
+  end
+end
+```
+
+Also there are several general macroses for declaring validations:
 
 - `validates_with_method(*names)` - accepts method name/names
 - `validates_inclusion(field, value)` - checks if `value` includes `@{{field}}`
@@ -10,6 +36,8 @@ For validation purposes is used [accord](https://github.com/neovintage/accord) s
 - `validates_uniqueness(field)` - check if `@{{field.id}}` is unique
 - `validates_presence_of(field)` - check if `@{{field.id}}` is not `nil`
 
+Next macrosses accept `allow_blank` key (which is be default is `false`) which describe `null` allowness during validation: `validates_inclucion`, `validates_exclusion`, `validates_format` and `validates_length`. This means that if `allow_blank: true` is passed, validation will pass if field is `nil` or validation condition is satified. In another words - validation will be sciped if field is `nil`. 
+
 Methods `#save!` and `#create!` will raise an exception if at validation fails. `#save` will return true\false representing object saving.
 
-To manually check validity call `#validate!` before `#valid?`.
+> To manually check validity call `#validate!` before `#valid?`.

--- a/shard.yml
+++ b/shard.yml
@@ -20,7 +20,7 @@ development_dependencies:
 dependencies:
   sam:
     github: imdrasil/sam.cr
-    version: "0.2.1"
+    version: "~> 0.2.4"
   inflector:
     github: phoffer/inflector.cr
     version: "~> 0.1.8"
@@ -29,3 +29,4 @@ dependencies:
     version: "~> 1.1.0"
   ifrit:
     github: imdrasil/ifrit
+    version: "~> 0.1.1"

--- a/spec/factories.cr
+++ b/spec/factories.cr
@@ -91,7 +91,7 @@ end
 
 class FacebookProfileFactory < ProfileFactory
   describe_class FacebookProfile
-  attr :uid, "123"
+  attr :uid, "1234"
   attr :type, FacebookProfile.to_s
 end
 

--- a/spec/model/mapping_spec.cr
+++ b/spec/model/mapping_spec.cr
@@ -14,30 +14,30 @@ describe Jennifer::Model::Mapping do
     end
 
     it "raises exception with errors if invalid on save!" do
-        contact = Factory.create_contact
-        contact.age = 12
-        contact.name = "much too long for name"
-        contact.description = "much too long for description"
-        begin
-          contact.save!
-          fail("should raise validation exception")
-        rescue ex : Jennifer::RecordInvalid
-          ex.errors.size.should eq(3)
-          raw_errors = ex.errors.@errors
-          validate_error(raw_errors[0], :age, "should be in 13..75 but is 12")
-          validate_error(raw_errors[1], :name, "should be lte 15 but is much too long for name")
-          validate_error(raw_errors[2], :description, "Too large description")
-        end
+      contact = Factory.create_contact
+      contact.age = 12
+      contact.name = "much too long for name"
+      contact.description = "much too long for description"
+      begin
+        contact.save!
+        fail("should raise validation exception")
+      rescue ex : Jennifer::RecordInvalid
+        ex.errors.size.should eq(3)
+        raw_errors = ex.errors.@errors
+        validate_error(raw_errors[0], :age, "must be in 13..75 but is 12")
+        validate_error(raw_errors[1], :name, "must be less than or equal 15 but is 22")
+        validate_error(raw_errors[2], :description, "Too large description")
+      end
     end
 
     it "should not raise validation exception when skipped" do
-        contact = Factory.create_contact
-        contact.age = 12
-        begin
-          contact.save!(true)
-        rescue ex : Jennifer::RecordInvalid
-          fail("should not raise validation exception")
-        end
+      contact = Factory.create_contact
+      contact.age = 12
+      begin
+        contact.save!(true)
+      rescue ex : Jennifer::RecordInvalid
+        fail("should not raise validation exception")
+      end
     end
   end
 

--- a/spec/model/sti_mapping_spec.cr
+++ b/spec/model/sti_mapping_spec.cr
@@ -4,9 +4,9 @@ describe Jennifer::Model::STIMapping do
   describe "#initialize" do
     context "ResultSet" do
       it "properly loads from db" do
-        f = c = Factory.create_facebook_profile(uid: "111", login: "my_login")
+        f = c = Factory.create_facebook_profile(uid: "1111", login: "my_login")
         res = FacebookProfile.find!(f.id)
-        res.uid.should eq("111")
+        res.uid.should eq("1111")
         res.login.should eq("my_login")
       end
     end

--- a/spec/model/validation_spec.cr
+++ b/spec/model/validation_spec.cr
@@ -86,23 +86,65 @@ describe Jennifer::Model::Validation do
     end
 
     context "maximum" do
-      it "pass valid names" do
-        a = Factory.build_contact(name: "123456789012345")
-        a.validate!
-        a.valid?.should be_true
+      context "doesn't allow blank" do
+        it "adds error message" do
+          c = ContactWithDependencies.new({:name => nil, :description => "asdasd"})
+          c.validate!
+          c.valid?.should be_false
+          c.errors[:name].empty?.should_not be_true
+        end
       end
 
-      it "doesn't pass invalid names" do
-        a = Factory.build_contact(name: "1234567890123456")
-        a.validate!
-        a.valid?.should be_false
+      context "allows blank" do
+        it "doesn't add error message" do
+          c = ContactWithDependencies.new({:name => "asd", :description => nil})
+          c.validate!
+          c.valid?.should be_true
+        end
+
+        it "validates if presence" do
+          c = ContactWithDependencies.new({:name => "asd", :description => "a"})
+          c.validate!
+          c.valid?.should be_false
+          c.description = "sd"
+          c.validate!
+          c.valid?.should be_true
+        end
       end
     end
 
-    pending "in" do
+    context "in" do
+      context "doesn't allow blank" do
+        it "adds error message" do
+          c = ContactWithInValidation.new({:name => nil})
+          c.validate!
+          c.valid?.should be_false
+          c.errors[:name].empty?.should_not be_true
+        end
+
+        it "validates if presence" do
+          c = ContactWithInValidation.new({:name => "a"})
+          c.validate!
+          c.valid?.should be_false
+          c.name = "sd"
+          c.validate!
+          c.valid?.should be_true
+        end
+      end
     end
 
-    pending "is" do
+    context "is" do
+      it "adds error if invalid" do
+        p = Factory.create_facebook_profile(login: "asd", uid: "12")
+        p.validate!
+        p.valid?.should be_false
+      end
+
+      it "does nothing if valid" do
+        p = Factory.create_facebook_profile(login: "asd", uid: "1234")
+        p.validate!
+        p.valid?.should be_true
+      end
     end
   end
 

--- a/spec/models.cr
+++ b/spec/models.cr
@@ -138,6 +138,8 @@ class FacebookProfile < Profile
     uid: String
   )
 
+  validates_length :uid, is: 4
+
   has_and_belongs_to_many :facebook_contacts, Contact, foreign: :profile_id
 end
 
@@ -234,14 +236,20 @@ class ContactWithDependencies < Jennifer::Model::Base
   table_name "contacts"
 
   mapping({
-    id:   {type: Int32, primary: true},
-    name: String,
+    id:          {type: Int32, primary: true},
+    name:        {type: String, null: true},
+    description: {type: String, null: true},
+    age:         {type: Int32, default: 10},
+    gender:      {type: String, default: "male", null: true},
   }, false)
 
   has_many :addresses, Address, dependent: :delete, foreign: :contact_id
   has_many :facebook_profiles, FacebookProfile, dependent: :nullify, foreign: :contact_id
   has_many :passports, Passport, dependent: :destroy, foreign: :contact_id
   has_many :twitter_profiles, TwitterProfile, dependent: :restrict_with_exception, foreign: :contact_id
+
+  validates_length :name, minimum: 2
+  validates_length :description, minimum: 2, allow_blank: true
 end
 
 class ContactWithCustomField < Jennifer::Model::Base
@@ -250,6 +258,16 @@ class ContactWithCustomField < Jennifer::Model::Base
     id:   {type: Int32, primary: true},
     name: String,
   }, false)
+end
+
+class ContactWithInValidation < Jennifer::Model::Base
+  table_name "contacts"
+  mapping({
+    id:   {type: Int32, primary: true},
+    name: String?,
+  }, false)
+
+  validates_length :name, in: 2..10
 end
 
 class ContactWithNillableName < Jennifer::Model::Base

--- a/src/jennifer/model/validation_messages.cr
+++ b/src/jennifer/model/validation_messages.cr
@@ -1,0 +1,41 @@
+module Jennifer
+  module Model
+    module ValidationMessages
+      def must_be_message(expected, actual)
+        "must be in #{expected} but is #{actual}"
+      end
+
+      def must_not_be_message(expected, actual)
+        "must not be in #{expected} but is #{actual}"
+      end
+
+      def not_blank_message
+        "must not be blank"
+      end
+
+      def length_in_message(expected, actual)
+        "must be of size #{expected} but has #{actual}"
+      end
+
+      def length_is_message(expected, actual)
+        "must be of size#{expected} but has #{actual}"
+      end
+
+      def length_min_message(expected, actual)
+        "must be greater than or equal #{expected} but is #{actual}"
+      end
+
+      def length_max_message(expected, actual)
+        "must be less than or equal #{expected} but is #{actual}"
+      end
+
+      def must_be_like_message(expected, actual)
+        "must be like #{expected} but is #{actual}"
+      end
+
+      def must_be_unique_message(value)
+        "must be unique"
+      end
+    end
+  end
+end


### PR DESCRIPTION
- adds `allow_blank` (which is false by default) to the next validation macroses: `validates_inclucion`, `validates_exclusion`, `validates_format` and `validates_length`
- updated `ifrit` and `sam` versions