### PR TITLE
Add sugar to mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Jennifer [![Build Status](https://travis-ci.org/imdrasil/jennifer.cr.svg)](https://travis-ci.org/imdrasil/jennifer.cr) [![Latest Release](https://img.shields.io/github/release/imdrasil/jennifer.cr.svg)](https://github.com/imdrasil/jennifer.cr/releases) [![Docs](https://img.shields.io/badge/docs-available-brightgreen.svg)](https://imdrasil.github.io/site/jennifer.cr/docs/)
+# Jennifer [![Build Status](https://travis-ci.org/imdrasil/jennifer.cr.svg)](https://travis-ci.org/imdrasil/jennifer.cr) [![Latest Release](https://img.shields.io/github/release/imdrasil/jennifer.cr.svg)](https://github.com/imdrasil/jennifer.cr/releases) [![Docs](https://img.shields.io/badge/docs-available-brightgreen.svg)](https://imdrasil.github.io/jennifer.cr/docs/)
 
 Another ActiveRecord pattern implementation for Crystal with a great query DSL and migration mechanism.
 
@@ -16,7 +16,7 @@ dependencies:
 
 ## Usage
 
-Jennifer allows you to maintain everything for your models - from db migrations and field mapping to callbacks and building queries. For detailed information see the [guide](https://imdrasil.github.io/site/jennifer.cr/docs/) or [api documentation](https://imdrasil.github.io/site/jennifer.cr/versions).
+Jennifer allows you to maintain everything for your models - from db migrations and field mapping to callbacks and building queries. For detailed information see the [guide](https://imdrasil.github.io/jennifer.cr/docs/) or [api documentation](https://imdrasil.github.io/jennifer.cr/versions).
 
 #### Migration
 
@@ -64,13 +64,13 @@ Several model examples
 class Contact < Jennifer::Model::Base
   with_timestamps
   mapping(
-    id: {type: Int32, primary: true},
+    id: Primary32,
     name: String,
-    gender: {type: String, default: "male", null: true},
+    gender: {type: String?, default: "male"},
     age: {type: Int32, default: 10},
-    description: {type: String, null: true},
-    created_at: {type: Time, null: true},
-    updated_at: {type: Time, null: true}
+    description: String?,
+    created_at: Time?,
+    updated_at: Time?
   )
 
   has_many :facebook_profiles, FacebookProfile
@@ -96,7 +96,7 @@ end
 class Passport < Jennifer::Model::Base
   mapping(
     enn: {type: String, primary: true},
-    contact_id: {type: Int32, null: true}
+    contact_id: Int32?
   )
 
   validates_with [EnnValidator]
@@ -105,7 +105,7 @@ end
 
 class Profile < Jennifer::Model::Base
   mapping(
-    id: {type: Int32, primary: true},
+    id: Primary32,
     login: String,
     contact_id: Int32?,
     type: String
@@ -124,7 +124,7 @@ end
 
 class Country < Jennifer::Model::Base
   mapping(
-    id: {type: Int32, primary: true},
+    id: Primary32,
     name: String
   )
 
@@ -151,18 +151,6 @@ Much more about the query DSL can be found on the wiki [[page|Query-DSL]]
 ### Important restrictions
 
 - sqlite3 has many limitations so its support won't be added any time soon
-
-### Similar shards
-
-- [active_record.cr](https://github.com/waterlink/active_record.cr) - small simple AR realization
-
-- [crecto](https://github.com/vladfaust/core.cr) - based on Phoenix's ecto lib and follows the repository pattern; 
-
-- [granite-orm](https://github.com/amberframework/granite-orm) - light weight orm focusing on mapping fields from request to your objects
-
-- [topaz](https://github.com/topaz-crystal/topaz) - inspired by AR ORM with migration mechanism
-
-- [micrate](https://github.com/juanedi/micrate) - standalone migration tool for crystal
 
 ### Versioning
 
@@ -219,6 +207,18 @@ NB. It also depends on then choosen adapter (postgres by default).
 
 
 The wiki pages also have a lot of usefull information. But from version 0.3.4 no new information will be added there untill it is moved to separate `.md` pages to allow contributing.
+
+## Similar shards
+
+- [active_record.cr](https://github.com/waterlink/active_record.cr) - small simple AR realization
+
+- [crecto](https://github.com/vladfaust/core.cr) - based on Phoenix's ecto lib and follows the repository pattern; 
+
+- [granite-orm](https://github.com/amberframework/granite-orm) - light weight orm focusing on mapping fields from request to your objects
+
+- [topaz](https://github.com/topaz-crystal/topaz) - inspired by AR ORM with migration mechanism
+
+- [micrate](https://github.com/juanedi/micrate) - standalone migration tool for crystal
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -195,6 +195,8 @@ PostgreSQL is used by default, but MySql is also supported while running tests b
 $ DB=mysql crystal spec
 ```
 
+Also you can override used user name and password using `DB_USER` and `DB_PASSWORD` env variables.
+
 ## Documentation
 
 Self documentation is not fully support yet but docs can be compiled using this shell script:

--- a/docs/model_mapping.md
+++ b/docs/model_mapping.md
@@ -5,13 +5,13 @@ Several model examples
 class Contact < Jennifer::Model::Base
   with_timestamps
   mapping(
-    id: {type: Int32, primary: true},
+    id: Primary32, # same as {type: Int32, primary: true}
     name: String,
-    gender: {type: String, default: "male", null: true},
+    gender: {type: String?, default: "male"},
     age: {type: Int32, default: 10},
-    description: {type: String, null: true},
-    created_at: {type: Time, null: true},
-    updated_at: {type: Time, null: true}
+    description: String?,
+    created_at: Time?,
+    updated_at: Time | Nil
   )
 
   has_many :addresses, Address
@@ -41,8 +41,8 @@ class Address < Jennifer::Model::Base
     id: {type: Int32, primary: true},
     main: Bool,
     street: String,
-    contact_id: {type: Int32, null: true},
-    details: {type: JSON::Any, null: true}
+    contact_id: Int32?,
+    details: JSON::Any?
   )
   validates_format :street, /st\.|street/
 
@@ -63,7 +63,7 @@ end
 
 class Profile < Jennifer::Model::Base
   mapping(
-    id: {type: Int32, primary: true},
+    id: Primary32,
     login: String,
     contact_id: Int32?,
     type: String
@@ -88,7 +88,7 @@ end
 
 class Country < Jennifer::Model::Base
   mapping(
-    id: {type: Int32, primary: true},
+    id: Primary32,
     name: String
   )
 
@@ -110,13 +110,21 @@ end
 | `:getter` | if getter should be created (default - `true`) |
 | `:setter` | if setter should be created (default - `true`) |
 
+To make some field nillable tou can use any of next options:
+
+- pass `null: true` option to the named tuple
+- use `?` in type declaration (e.g. `some_field: String?` and `some_filed: {type: String?}`)
+- use union with `Nil` in the type declaration (e.g. `some_field: String | Nil` and `some_filed: {type: String | Nil}`)
+
+Also for there is a shortcut for defining `Int32` and `Int64` primary keys
+
 If you don't want to define all the table fields - pass `false` as second argument.
 
 `%mapping` defines next methods:
 
 | method | args | description |
 | --- | --- | --- |
-| `#initialize` | Hash(String \| Symbol, DB::Any), NamedTuple, MySql::ResultSet | constructors |
+| `#initialize` | `Hash(String \| Symbol, DB::Any), NamedTuple, MySql::ResultSet` | constructors |
 | `::field_count`| | number of fields |
 | `::field_names`| | all fields names |
 | `#{{field_name}}` | | getter |
@@ -146,7 +154,7 @@ If you don't want to define all the table fields - pass `false` as second argume
 | `#set_attribute` | `String \| Symbol`, `DB::Any` | sets attribute by given name |
 | `#attribute` | `String \| Symbol` | returns attribute value by it's name |
 
-All allowed types are listed on the [Migration](/migration.md) page.
+All allowed types are listed on the [Migration](https://imdrasil.github.io/jennifer.cr/docs/migration) page.
 
 
 Automatically model is associated with table with underscored pluralized name of it's class, but special name can be defined using `::table_name` method in own body before using any relation (`::singular_table_name` - for singular variant).

--- a/docs/view.md
+++ b/docs/view.md
@@ -1,10 +1,92 @@
 # Views
 
-#### Materialized
+> For now any type of view should have defined primary key as well as model
 
-> Materialized view is supported only for postgre adapter
+## Non Materialized
 
-For defining materialized view `Jennfer::Model::Base` superclass should be used. And common restriction for obligatory primary field is also applied here as well.
+Both adapters support non materialized view. Here is an example of migration:
+
+```crystal
+class AddView20170916095004544 < Jennifer::Migration::Base
+  def up
+    create_view(:male_contacts, Jennifer::Query["contacts"].where { sql("gender = 'male'") })
+  end
+
+  def down
+    drop_view(:male_contacts)
+  end
+end
+```
+
+Second argument of `#create_view` describes query which will  be used to retrieve data. 
+
+**Importent restriction**: any prepared argument is not allowed for now - any argument should be escaped by your own.
+
+```crystal
+# bad
+create_view(:male_contacts, Jennifer::Query["contacts"].where { _gender == "male" })
+
+# good
+create_view(:male_contacts, Jennifer::Query["contacts"].where { sql("gender = 'male'") })
+create_view(:male_contacts, Jennifer::Query["contacts"].where { _gender == sql("male") })
+```
+
+There is an example of defining view:
+```crystal
+class MaleContact < Jennifer::View::Base
+  mapping({
+    id:     Primary32,
+    name:   String,
+    gender: String,
+    age:    Int32,
+  }, false)
+
+  scope :main { where { _age < 50 } }
+  scope :older { |age| where { _age >= age } }
+  scope :johny, JohnyQuery
+end
+```
+
+All regular model mapping functionality are also available for views (except any functionality for deleting, updating or creating new view objects). Any scoping functionality is allowed as well. Only `after_initialize` callback is allowed. STI is not supported.
+
+## Materialized
+
+> Materialized view is partially supported only by postgre adapter. MySQL doesn't provide support of materiazed view at all - only via simulating using regualr table.
+
+Regular migration for adding materialized view looks like this:
+
+```crystal
+class AddMaterializedView20170829000433679 < Jennifer::Migration::Base
+  VIEW_NAME = "female_contacts"
+
+  def up
+    create_materialized_view(
+      VIEW_NAME,
+      "SELECT * FROM contacts WHERE gender = 'female'"
+    )
+  end
+
+  def down
+    drop_materialized_view(VIEW_NAME)
+  end
+end
+```
+For now view request should be string based. Any column you want to extract should be listed in the `SELECT` clause of the request.
+
+For defining materialized view `Jennfer::Model::Base` superclass should be used. So example of defining created before materialized view looks like:
+
+```crystal
+class FemaleContact < Jennifer::Model::Base
+  mapping({
+    id:   Primary32,
+    name: String?,
+  }, false)
+end
+```
+
+Because of using `Model::Base` you are able to use some functionality of model (except deleting, creating and updating entities).
+
+All features of `%mapping` is supported as well.
 
 To refresh content of materialized view use:
 

--- a/docs/view.md
+++ b/docs/view.md
@@ -62,7 +62,7 @@ class AddMaterializedView20170829000433679 < Jennifer::Migration::Base
   def up
     create_materialized_view(
       VIEW_NAME,
-      "SELECT * FROM contacts WHERE gender = 'female'"
+      Contact.all.where { _gender == sql("'female'") }
     )
   end
 
@@ -71,7 +71,9 @@ class AddMaterializedView20170829000433679 < Jennifer::Migration::Base
   end
 end
 ```
-For now view request should be string based. Any column you want to extract should be listed in the `SELECT` clause of the request.
+As for non materialized view here all arguments should be escaped explicitly as well.
+
+> Until 0.5.0 source could be represented as stringgified raw sql, but this will be removed.
 
 For defining materialized view `Jennfer::Model::Base` superclass should be used. So example of defining created before materialized view looks like:
 

--- a/examples/migrations/20170829000433679_add_materialized_view.cr
+++ b/examples/migrations/20170829000433679_add_materialized_view.cr
@@ -1,18 +1,20 @@
 class AddMaterializedView20170829000433679 < Jennifer::Migration::Base
   VIEW_NAME = "female_contacts"
 
-  def up
-    {% if env("DB") == "postgres" || env("DB") == nil %}
+  {% if env("DB") == "postgres" || env("DB") == nil %}
+    def up
       create_materialized_view(
         VIEW_NAME,
-        "SELECT * FROM contacts WHERE gender = 'female'"
+        Contact.all.where { _gender == sql("'female'") }
       )
-    {% end %}
-  end
+    end
 
-  def down
-    {% if env("DB") == "postgres" || env("DB") == nil %}
+    def down
       drop_materialized_view(VIEW_NAME)
-    {% end %}
-  end
+    end
+  {% else %}
+    def up; end
+
+    def down; end
+  {% end %}
 end

--- a/spec/model/base_spec.cr
+++ b/spec/model/base_spec.cr
@@ -33,11 +33,11 @@ describe Jennifer::Model::Base do
 
   describe "::primary_field_type" do
     it "returns type of custom primary field" do
-      Passport.primary_field_type.should eq(String)
+      Passport.primary_field_type.should eq(String?)
     end
 
     it "returns type of default primary field name" do
-      Contact.primary_field_type.should eq(Int32)
+      Contact.primary_field_type.should eq(Int32?)
     end
   end
 

--- a/spec/model/mapping_spec.cr
+++ b/spec/model/mapping_spec.cr
@@ -164,10 +164,15 @@ describe Jennifer::Model::Mapping do
 
     describe "::field_count" do
       it "returns correct number of model fields" do
-        proper_count =
-          postgres_only { 9 }
-        mysql_only { 8 }
-        Contact.field_count.should eq(proper_count)
+        postgres_only do
+          proper_count = 9
+          Contact.field_count.should eq(proper_count)
+        end
+
+        mysql_only do
+          proper_count = 8
+          Contact.field_count.should eq(proper_count)
+        end
       end
     end
 

--- a/spec/model/sti_mapping_spec.cr
+++ b/spec/model/sti_mapping_spec.cr
@@ -1,6 +1,32 @@
 require "../spec_helper"
 
 describe Jennifer::Model::STIMapping do
+  describe "%mapping" do
+    context "types" do
+      context "nillable" do
+        context "using ? without named tuple" do
+          it "parses type as nillable" do
+            typeof(Factory.build_facebook_profile.uid).should eq(String?)
+          end
+        end
+
+        context "using :null option" do
+          it "parses type as nilable" do
+            typeof(Factory.build_twitter_profile.email).should eq(String?)
+          end
+        end
+      end
+    end
+
+    pending "defines default constructor if all fields are nilable or have default values and superclass has default constructor" do
+      TwitterProfile::WITH_DEFAULT_CONSTRUCTOR.should be_true
+    end
+
+    it "doesn't define default constructor if all fields are nilable or have default values" do
+      TwitterProfile::WITH_DEFAULT_CONSTRUCTOR.should be_false
+    end
+  end
+
   describe "#initialize" do
     context "ResultSet" do
       it "properly loads from db" do

--- a/spec/models.cr
+++ b/spec/models.cr
@@ -291,7 +291,7 @@ end
 
 class MaleContact < Jennifer::View::Base
   mapping({
-    id:     {type: Int32, primary: true},
+    id:     Primary32,
     name:   String,
     gender: String,
     age:    Int32,
@@ -306,14 +306,14 @@ class FakeContactView < Jennifer::View::Base
   view_name "male_contacs"
 
   mapping({
-    id: {type: Int32, primary: true},
+    id: Primary32,
   }, false)
 end
 
 class StrinctBrokenMaleContact < Jennifer::View::Base
   view_name "male_contacts"
   mapping({
-    id:   {type: Int32, primary: true},
+    id:   Primary32,
     name: String,
   })
 end
@@ -321,7 +321,7 @@ end
 class StrictMaleContactWithExtraField < Jennifer::View::Base
   view_name "male_contacts"
   mapping({
-    id:            {type: Int32, primary: true},
+    id:            Primary32,
     missing_field: String,
   })
 end
@@ -329,7 +329,7 @@ end
 class MaleContactWithDescription < Jennifer::View::Base
   view_name "male_contacts"
   mapping({
-    id:          {type: Int32, primary: true},
+    id:          Primary32,
     description: String,
   }, false)
 end

--- a/spec/models.cr
+++ b/spec/models.cr
@@ -25,26 +25,26 @@ class Contact < ApplicationRecord
   with_timestamps
   {% if env("DB") == "postgres" || env("DB") == nil %}
     mapping(
-      id:          {type: Int32, primary: true},
+      id:          Primary32,
       name:        String,
-      ballance:    {type: PG::Numeric, null: true},
+      ballance:    PG::Numeric?,
       age:         {type: Int32, default: 10},
-      gender:      {type: String, default: "male", null: true},
-      description: {type: String, null: true},
-      created_at:  {type: Time, null: true},
-      updated_at:  {type: Time, null: true},
-      tags: {type: Array(Int32)? },
+      gender:      {type: String?, default: "male"},
+      description: String?,
+      created_at:  Time | Nil,
+      updated_at:  Time?,
+      tags: Array(Int32)?,
     )
   {% else %}
     mapping(
-      id:          {type: Int32, primary: true},
+      id:          Primary32,
       name:        String,
-      ballance:    {type: Float64, null: true},
+      ballance:    Float64?,
       age:         {type: Int32, default: 10},
-      gender:      {type: String, default: "male", null: true},
-      description: {type: String, null: true},
-      created_at:  {type: Time, null: true},
-      updated_at:  {type: Time, null: true},
+      gender:      {type: String?, default: "male"},
+      description: String?,
+      created_at:  Time | Nil,
+      updated_at:  Time?,
     )
   {% end %}
 
@@ -78,8 +78,8 @@ class Address < Jennifer::Model::Base
     id: {type: Int32, primary: true},
     main: Bool,
     street: String,
-    contact_id: {type: Int32, null: true},
-    details: {type: JSON::Any, null: true}
+    contact_id: Int32?,
+    details: JSON::Any?
   )
   validates_format :street, /st\.|street/
 
@@ -103,7 +103,7 @@ end
 class Passport < Jennifer::Model::Base
   mapping(
     enn: {type: String, primary: true},
-    contact_id: {type: Int32, null: true}
+    contact_id: Int32?
   )
 
   validates_with [EnnValidator]
@@ -124,7 +124,7 @@ end
 
 class Profile < ApplicationRecord
   mapping(
-    id: {type: Int32, primary: true},
+    id: Primary32,
     login: String,
     contact_id: Int32?,
     type: String
@@ -135,7 +135,7 @@ end
 
 class FacebookProfile < Profile
   sti_mapping(
-    uid: String
+    uid: String? # for testing purposes
   )
 
   validates_length :uid, is: 4
@@ -145,14 +145,14 @@ end
 
 class TwitterProfile < Profile
   sti_mapping(
-    email: String
+    email: {type: String, null: true} # for testing purposes
   )
 end
 
 class Country < Jennifer::Model::Base
   mapping(
-    id: {type: Int32, primary: true},
-    name: {type: String, null: true}
+    id: Primary32,
+    name: String?
   )
 
   validates_exclusion :name, ["asd", "qwe"]
@@ -201,7 +201,7 @@ end
 
 class OneFieldModel < Jennifer::Model::Base
   mapping(
-    id: {type: Int32, primary: true}
+    id: Primary32
   )
 end
 
@@ -209,7 +209,7 @@ class OneFieldModelWithExtraArgument < Jennifer::Model::Base
   table_name "one_field_models"
 
   mapping(
-    id: {type: Int32, primary: true},
+    id: Primary32,
     missing_field: String
   )
 end
@@ -218,8 +218,8 @@ class ContactWithNotAllFields < Jennifer::Model::Base
   table_name "contacts"
 
   mapping(
-    id: {type: Int32, primary: true},
-    name: {type: String, null: true},
+    id: Primary32,
+    name: String?,
   )
 end
 
@@ -227,8 +227,8 @@ class ContactWithNotStrictMapping < Jennifer::Model::Base
   table_name "contacts"
 
   mapping({
-    id:   {type: Int32, primary: true},
-    name: {type: String, null: true},
+    id:   Primary32,
+    name: String?,
   }, false)
 end
 
@@ -236,11 +236,11 @@ class ContactWithDependencies < Jennifer::Model::Base
   table_name "contacts"
 
   mapping({
-    id:          {type: Int32, primary: true},
-    name:        {type: String, null: true},
-    description: {type: String, null: true},
+    id:          Primary32,
+    name:        String?,
+    description: String?,
     age:         {type: Int32, default: 10},
-    gender:      {type: String, default: "male", null: true},
+    gender:      {type: String?, default: "male"},
   }, false)
 
   has_many :addresses, Address, dependent: :delete, foreign: :contact_id
@@ -255,7 +255,7 @@ end
 class ContactWithCustomField < Jennifer::Model::Base
   table_name "contacts"
   mapping({
-    id:   {type: Int32, primary: true},
+    id:   Primary32,
     name: String,
   }, false)
 end
@@ -263,7 +263,7 @@ end
 class ContactWithInValidation < Jennifer::Model::Base
   table_name "contacts"
   mapping({
-    id:   {type: Int32, primary: true},
+    id:   Primary32,
     name: String?,
   }, false)
 
@@ -273,15 +273,15 @@ end
 class ContactWithNillableName < Jennifer::Model::Base
   table_name "contacts"
   mapping({
-    id:   {type: Int32, primary: true},
-    name: {type: String, null: true},
+    id:   Primary32,
+    name: String?,
   }, false)
 end
 
 class FemaleContact < Jennifer::Model::Base
   mapping({
-    id:   {type: Int32, primary: true},
-    name: {type: String, null: true},
+    id:   Primary32,
+    name: String?,
   }, false)
 end
 

--- a/spec/view/base_spec.cr
+++ b/spec/view/base_spec.cr
@@ -17,14 +17,18 @@ describe Jennifer::View::Base do
 
   describe "::primary_field_type" do
     it "returns type of primary field" do
-      MaleContact.primary_field_type.should eq(Int32)
+      MaleContact.primary_field_type.should eq(Int32?)
     end
   end
 
   describe "::table_name" do
+    pending "add" do
+    end
   end
 
   describe "::c" do
+    pending "add" do
+    end
   end
 
   describe "%scope" do

--- a/spec/view/experimental_mapping_spec.cr
+++ b/spec/view/experimental_mapping_spec.cr
@@ -70,7 +70,14 @@ describe Jennifer::View::ExperimentalMapping do
   describe "%mapping" do
     describe "#initialize" do
       context "from result set" do
-        pending "properly creates object" do
+        it "properly creates object" do
+          Factory.create_contact(gender: "male")
+          count = 0
+          MaleContact.all.each_result_set do |rs|
+            MaleContact.build(rs)
+            count += 1
+          end
+          count.should eq(1)
         end
       end
 
@@ -136,6 +143,12 @@ describe Jennifer::View::ExperimentalMapping do
           c.name.should eq("b")
         end
       end
+
+      describe "::_{{attribute}}" do
+        c = MaleContact._name
+        it { c.table.should eq(MaleContact.view_name) }
+        it { c.field.should eq("name") }
+      end
     end
 
     describe "criteria attribute class shortcut" do
@@ -165,13 +178,43 @@ describe Jennifer::View::ExperimentalMapping do
     end
 
     describe "#to_h" do
-      pending "creates hash with symbol keys" do
+      it "creates hash with symbol keys" do
+        Factory.create_contact(age: 19, gender: "male")
+        MaleContact.all.first!.to_h[:age].should eq(19)
       end
     end
 
-    describe "#attribute_hash" do
-      pending "creates hash with attributes" do
+    describe "#to_str_h" do
+      it "creates hash with string keys" do
+        Factory.create_contact(age: 19, gender: "male")
+        MaleContact.all.first!.to_str_h["age"].should eq(19)
       end
+    end
+
+    describe "#attribute" do
+      it "returns attribute value by given name" do
+        c = MaleContact.build(Factory.build_contact(name: "Jessy").to_h)
+
+        c.attribute("name").should eq("Jessy")
+        c.attribute(:name).should eq("Jessy")
+      end
+    end
+
+    describe "#attributes_hash" do
+      pending "makes to_h and removes all nil values" do
+      end
+    end
+  end
+
+  describe "::strict_mapping?" do
+    it "returns false if mapping doesn't describe all db view fields" do
+      MaleContact.strict_mapping?.should eq(false)
+    end
+  end
+
+  describe "::field_names" do
+    it "returns array of defined fields" do
+      MaleContact.field_names.should eq(%w(id name gender age))
     end
   end
 end

--- a/src/jennifer/adapter/postgres/migration/base.cr
+++ b/src/jennifer/adapter/postgres/migration/base.cr
@@ -1,27 +1,27 @@
 module Jennifer
   module Migration
     abstract class Base
-      def create_enum(name, values)
+      def create_enum(name : String | Symbol, values)
         TableBuilder::CreateEnum.new(name, values).process
       end
 
-      def drop_enum(name)
+      def drop_enum(name : String | Symbol)
         TableBuilder::DropEnum.new(name).process
       end
 
-      def change_enum(name, options)
+      def change_enum(name : String | Symbol, options)
         TableBuilder::ChangeEnum.new(name, options).process
       end
 
-      def data_type_exists?(name)
+      def data_type_exists?(name : String | Symbol)
         Adapter.adapter.as(Postgres).data_type_exists?(name)
       end
 
-      def create_materialized_view(name, _as)
-        TableBuilder::CreateMaterializedView.new(name, _as).process
+      def create_materialized_view(name : String | Symbol, source)
+        TableBuilder::CreateMaterializedView.new(name, source).process
       end
 
-      def drop_materialized_view(name)
+      def drop_materialized_view(name : String | Symbol)
         TableBuilder::DropMaterializedView.new(name).process
       end
     end

--- a/src/jennifer/adapter/postgres/migration/table_builder/create_materialized_view.cr
+++ b/src/jennifer/adapter/postgres/migration/table_builder/create_materialized_view.cr
@@ -3,16 +3,30 @@ module Jennifer
   module Migration
     module TableBuilder
       class CreateMaterializedView < Base
-        def initialize(name, @as : String)
+        @query : QueryBuilder::Query | String
+
+        def initialize(name, @query)
           super(name)
         end
 
         def process
-          query = <<-SQL
-            CREATE MATERIALIZED VIEW #{name}
-            AS #{@as}
-          SQL
-          adapter.exec(query)
+          buff = generate_query
+          adapter.exec buff
+        end
+
+        private def generate_query
+          if @query.is_a?(String)
+            puts "String was used for describing source request of materialized  view. Use QueryBuilder::Query instead"
+            @query.as(String)
+          else
+            String.build do |s|
+              s <<
+                "CREATE MATERIALIZED VIEW " <<
+                @name <<
+                " AS " <<
+                Adapter::SqlGenerator.select(@query.as(QueryBuilder::Query))
+            end
+          end
         end
       end
     end

--- a/src/jennifer/migration/base.cr
+++ b/src/jennifer/migration/base.cr
@@ -1,8 +1,6 @@
 module Jennifer
   module Migration
     abstract class Base
-      TABLE_NAME = "migration_versions"
-
       delegate create_data_type, to: Adapter.adapter
       delegate table_exists?, index_exists?, column_exists?, view_exists?, to: Adapter.adapter
 
@@ -13,7 +11,7 @@ module Jennifer
         to_s[-17..-1]
       end
 
-      def create_table(name, id = true)
+      def create_table(name, id : Bool = true)
         tb = TableBuilder::CreateTable.new(name)
         tb.integer(:id, {:primary => true, :auto_increment => true}) if id
         yield tb
@@ -46,17 +44,17 @@ module Jennifer
         TableBuilder::DropTable.new(name).process
       end
 
-      def change_table(name)
+      def change_table(name : String | Symbol)
         tb = TableBuilder::ChangeTable.new(name)
         yield tb
         tb.process
       end
 
-      def create_view(name, source)
+      def create_view(name : String | Symbol, source)
         TableBuilder::CreateView.new(name.to_s, source).process
       end
 
-      def drop_view(name)
+      def drop_view(name : String | Symbol)
         TableBuilder::DropView.new(name.to_s).process
       end
 

--- a/src/jennifer/migration/runner.cr
+++ b/src/jennifer/migration/runner.cr
@@ -50,13 +50,13 @@ module Jennifer
 
       def self.create
         r = Adapter.adapter_class.create_database
-        puts "DB created!"
+        puts "DB is created!"
         r
       end
 
       def self.drop
-        puts Adapter.adapter_class.drop_database
-        puts "DB droped"
+        Adapter.adapter_class.drop_database
+        puts "DB is dropped!"
       end
 
       def self.rollback(options : Hash(Symbol, DBAny))

--- a/src/jennifer/migration/table_builder/change_table.cr
+++ b/src/jennifer/migration/table_builder/change_table.cr
@@ -68,7 +68,7 @@ module Jennifer
           @drop_columns.each { |c| Adapter.adapter.drop_column(@name, c) }
           @fields.each { |n, opts| Adapter.adapter.add_column(@name, n, opts) }
           @changed_columns.each do |n, opts|
-            Adapter.adapter.change_column(@name, n, opts[:new_name], opts)
+            Adapter.adapter.change_column(@name, n, opts[:new_name].as(String | Symbol), opts)
           end
           @indexes.each(&.process)
           @drop_index.each(&.process)

--- a/src/jennifer/model/sti_mapping.cr
+++ b/src/jennifer/model/sti_mapping.cr
@@ -36,20 +36,31 @@ module Jennifer
           super + FIELD_NAMES
         end
 
-        # generating hash with options
+        # NOTE: next section is a copy-paste from mapping.cr (with removing any parsing of primary option)
+        {%
+          add_default_constructor = @type.superclass.constant("WITH_DEFAULT_CONSTRUCTOR")
+          nillable_regexp = /(::Nil)|( Nil)/
+          json_regexp = /JSON::Any/
+        %}
+
+        # generates hash with options
         {% for key, value in properties %}
           {% unless value.is_a?(HashLiteral) || value.is_a?(NamedTupleLiteral) %}
             {% properties[key] = {type: value} %}
+          {% end %}
+          {%
+            _type = properties[key][:type]
+            _s_type = properties[key][:stringified_type] = _type.stringify
+          %}
+          {% if _s_type =~ nillable_regexp %}
+            {%
+              properties[key][:null] = true
+              properties[key][:parsed_type] = _s_type
+            %}
           {% else %}
-            {% properties[key][:type] = properties[key][:type] %}
+            {% properties[key][:parsed_type] = properties[key][:null] ? _type.stringify + "?" : _type.stringify %}
           {% end %}
-          {% if properties[key][:primary] %}
-            {% primary = key %}
-            {% primary_type = properties[key][:type] %}
-            {% primary_auto_incrementable = ["Int32", "Int64"].includes?(properties[key][:type].stringify) %}
-          {% end %}
-          {% t_string = properties[key][:type].stringify %}
-          {% properties[key][:parsed_type] = properties[key][:null] || properties[key][:primary] ? t_string + "?" : t_string %}
+          {% add_default_constructor = add_default_constructor && (properties[key][:null] || properties[key].keys.includes?(:default)) %}
         {% end %}
 
         __field_declaration({{properties}}, false)
@@ -125,9 +136,14 @@ module Jennifer
           initialize(values)
         end
 
-        def initialize
-          initialize({} of String => ::Jennifer::DBAny)
-        end
+        {% if add_default_constructor %}
+          WITH_DEFAULT_CONSTRUCTOR = true
+          def initialize
+            initialize({} of String => ::Jennifer::DBAny)
+          end
+        {% else %}
+          WITH_DEFAULT_CONSTRUCTOR = false
+        {% end %}
 
         def changed?
           super ||
@@ -177,7 +193,7 @@ module Jennifer
                 local = value.as({{value[:parsed_type].id}})
                 @{{key.id}} = local
               else
-                raise ::Jennifer::BaseException.new("rong type for #{name} : #{value.class}")
+                raise ::Jennifer::BaseException.new("Wrong type for #{name} : #{value.class}")
               end
             {% end %}
             end
@@ -194,7 +210,7 @@ module Jennifer
                 if value.is_a?({{value[:parsed_type].id}})
                   self.{{key.id}} = value.as({{value[:parsed_type].id}})
                 else
-                  raise ::Jennifer::BaseException.new("rong type for #{name} : #{value.class}")
+                  raise ::Jennifer::BaseException.new("Wrong type for #{name} : #{value.class}")
                 end
             {% end %}
           {% end %}
@@ -220,8 +236,8 @@ module Jennifer
         def attributes_hash
           hash = super
           {% for key, value in properties %}
-            {% if !value[:null] || value[:primary] %}
-              hash.delete(:{{key}}) if hash[:{{key}}]?.nil?
+            {% if !value[:null] %}
+              hash.delete(:{{key.id}}) unless hash.has_key?(:{{key.id}})
             {% end %}
           {% end %}
           hash
@@ -232,16 +248,14 @@ module Jennifer
           args = res[:args]
           fields = res[:fields]
           {% for key, value in properties %}
-            {% unless value[:primary] %}
-              if @{{key.id}}_changed
-                args << {% if value[:type].stringify == "JSON::Any" %}
-                          @{{key.id}}.to_json
-                        {% else %}
-                          @{{key.id}}
-                        {% end %}
-                fields << "{{key.id}}"
-              end
-            {% end %}
+            if @{{key.id}}_changed
+              args << {% if value[:stringified_type] =~ json_regexp %}
+                        @{{key.id}}.to_json
+                      {% else %}
+                        @{{key.id}}
+                      {% end %}
+              fields << "{{key.id}}"
+            end
           {% end %}
           {args: args, fields: fields}
         end
@@ -251,14 +265,12 @@ module Jennifer
           args = res[:args]
           fields = res[:fields]
           {% for key, value in properties %}
-            {% unless value[:primary] && primary_auto_incrementable %}
-              args << {% if value[:type].stringify == "JSON::Any" %}
-                        (@{{key.id}} ? @{{key.id}}.to_json : nil)
-                      {% else %}
-                        @{{key.id}}
-                      {% end %}
-              fields << {{key.stringify}}
-            {% end %}
+            args << {% if value[:stringified_type] =~ json_regexp %}
+                      (@{{key.id}} ? @{{key.id}}.to_json : nil)
+                    {% else %}
+                      @{{key.id}}
+                    {% end %}
+            fields << {{key.stringify}}
           {% end %}
 
           { args: args, fields: fields }

--- a/src/jennifer/sam.cr
+++ b/src/jennifer/sam.cr
@@ -26,12 +26,12 @@ Sam.namespace "db" do
 
   desc "Drops database"
   task "drop" do |t, args|
-    puts Jennifer::Migration::Runner.drop
+    Jennifer::Migration::Runner.drop
   end
 
   desc "Creates database"
   task "create" do |t, args|
-    puts Jennifer::Migration::Runner.create
+    Jennifer::Migration::Runner.create
   end
 
   desc "Runs db:create and db:migrate"


### PR DESCRIPTION
**breaking changes**
- now `Migration::Base#create_materialized_view` accepts `QueryBuilder::Query` for the 2nd argument instead of `String`

other changes:

- add automatic adding `null: true` if given field type in mapping is nillable (both for model and view)
- add `Primary32` and `Primary64` shortcuts for `Int32` and `Int64` primary fields (both for model and view)
- small refactoring of mapping macrosses
- small refactoring of `Adapter::Base` public interface