### PR TITLE
Fix sti loading

### DIFF
--- a/docs/model_sti.md
+++ b/docs/model_sti.md
@@ -28,6 +28,18 @@ class TwitterProfile < Profile
 end
 ```
 
-Subclass extends superclass definition with new fields and use string fild `type` to indentify itself.
+Requirements:
 
-> Now `Profile.all` will return objects of `Profile` class not taking into account `type` field.
+- created table for STI should include **all** fields of all subclasses (that's why it is cold STI);
+- STI table have to have field named `type` of any string type which will be able to store class name of your models;
+- parent class should have definition for `type` field;
+
+> Currently type field is not configurable and hardcoded to name `type`.
+
+To extract from DB several subclasses in one request - just use parent class to query:
+
+```crystal
+Profile.all.where { _login.like("%eter%") }
+```
+
+Each retrieved object will respect values in `type` field and appropriate class object will be builded (including invoking of `after_initialize` callbacks).

--- a/spec/adapter/mysql_spec.cr
+++ b/spec/adapter/mysql_spec.cr
@@ -1,7 +1,8 @@
 require "../spec_helper"
 mysql_only do
   describe Jennifer::Adapter::Mysql do
-    adapter = Jennifer::Adapter.adapter
+    described_class = Jennifer::Adapter::Mysql
+    adapter = Jennifer::Adapter.adapter.as(Jennifer::Adapter::Mysql)
 
     describe "#index_exists?" do
       it "returns true if table has index with given name" do
@@ -10,6 +11,18 @@ mysql_only do
 
       it "returns false if table has no given index" do
         adapter.index_exists?("addresses", "contacts_description_index").should be_false
+      end
+    end
+
+    describe "#translate_type" do
+      it "returns sql type associated with given synonim" do
+        adapter.translate_type(:string).should eq("varchar")
+      end
+    end
+
+    describe "#default_type_size" do
+      it "returns default type size for given alias" do
+        adapter.default_type_size(:string).should eq(254)
       end
     end
   end

--- a/spec/adapter/result_parsers_spec.cr
+++ b/spec/adapter/result_parsers_spec.cr
@@ -1,0 +1,25 @@
+require "../spec_helper"
+
+describe Jennifer::Adapter::ResultParsers do
+  adapter = Jennifer::Adapter.adapter
+
+  describe "#result_to_hash" do
+    pending "converts result set to hash with string keys" do
+    end
+  end
+
+  describe "#result_to_array" do
+    pending "add" do
+    end
+  end
+
+  describe "#result_to_array_by_names" do
+    pending "add" do
+    end
+  end
+
+  describe "#table_row_hash" do
+    pending "add" do
+    end
+  end
+end

--- a/spec/config.cr
+++ b/spec/config.cr
@@ -1,5 +1,39 @@
+require "logger"
+
+class ArrayLogger < Logger
+  property silent : Bool
+  getter container = [] of {sev: String, msg: String}
+
+  def initialize(@io : IO?, @silent = true)
+    @level = Severity::INFO
+    @formatter = DEFAULT_FORMATTER
+    @progname = ""
+    @closed = false
+    @mutex = Mutex.new
+    @formatter = Formatter.new do |_, _, _, msg, io|
+      io << msg
+    end
+  end
+
+  def clear
+    @container.clear
+  end
+
+  private def write(severity, datetime, progname, message)
+    progname_to_s = progname.to_s
+    message_to_s = message.to_s
+    @mutex.synchronize do
+      new_message = String.build do |io|
+        formatter.call(severity, datetime, progname_to_s, message_to_s, io)
+      end
+      @container << {sev: severity.to_s, msg: new_message}
+    end
+  end
+end
+
 module Spec
   @@adapter = ""
+  @@logger : ArrayLogger?
 
   def self.adapter
     @@adapter
@@ -7,6 +41,10 @@ module Spec
 
   def self.adapter=(v)
     @@adapter = v
+  end
+
+  def self.logger
+    @@logger ||= ArrayLogger.new(STDOUT)
   end
 end
 
@@ -25,8 +63,9 @@ require "../src/jennifer"
 def set_default_configuration
   Jennifer::Config.reset_config
   Jennifer::Config.configure do |conf|
-    # conf.logger.level = Logger::DEBUG
-    conf.logger.level = Logger::ERROR
+    conf.logger = Spec.logger
+    conf.logger.level = Logger::DEBUG
+    # conf.logger.level = Logger::ERROR
     conf.host = "localhost"
     conf.adapter = Spec.adapter
     conf.migration_files_path = "./examples/migrations"

--- a/spec/model/mapping_spec.cr
+++ b/spec/model/mapping_spec.cr
@@ -3,6 +3,30 @@ require "../spec_helper"
 describe Jennifer::Model::Mapping do
   select_regexp = /[\S\s]*SELECT contacts\.\*/i
 
+  describe "::build" do
+    context "loading STI objects from request" do
+      it "creates proper objects" do
+        Factory.create_twitter_profile
+        Factory.create_facebook_profile
+        match_array(Profile.all.to_a.map(&.class), [FacebookProfile, TwitterProfile])
+      end
+
+      it "raises exception if invalid type was given" do
+        p = Factory.create_facebook_profile
+        p.update_column("type", "asdasd")
+        expect_raises(Jennifer::UnknownSTIType) do
+          Profile.all.to_a
+        end
+      end
+
+      it "creates base class if type field is blank" do
+        p = Factory.create_facebook_profile
+        p.update_column("type", "")
+        Profile.all.first!.class.to_s.should eq("Profile")
+      end
+    end
+  end
+
   describe "#reload" do
     it "assign all values from db to existing object" do
       c1 = Factory.create_contact

--- a/src/jennifer/adapter/base.cr
+++ b/src/jennifer/adapter/base.cr
@@ -149,15 +149,17 @@ module Jennifer
           s << Config.adapter << "://" << auth_part << "@" << host_part
           s << "/" << Config.db if options.includes?(:db)
           s << "?"
+          {% begin %}
           [
             {% for arg in Config::CONNECTION_URI_PARAMS %}
-              "{{arg.id}}=#{Config.{{arg.id}}}"
-            {% end %},
-          ].join(",", s)
+              "{{arg.id}}=#{Config.{{arg.id}}}",
+            {% end %}
+          ].join("&", s)
+          {% end %}
         end
       end
 
-      def self.extract_arguments(hash : Hash)
+      def self.extract_arguments(hash : Hash) : NamedTuple(args: Array(Jennifer::DBAny), fields: Array(String))
         args = [] of DBAny
         fields = [] of String
         hash.each do |key, value|

--- a/src/jennifer/exceptions.cr
+++ b/src/jennifer/exceptions.cr
@@ -124,4 +124,10 @@ module Jennifer
       exception.message =~ EXTRACT_WORDS_REG
     end
   end
+
+  class UnknownSTIType < BaseException
+    def initialize(parent_klass, type)
+      @message = "Unknown STI type \"#{type}\" for #{parent_klass}"
+    end
+  end
 end

--- a/src/jennifer/model/base.cr
+++ b/src/jennifer/model/base.cr
@@ -61,12 +61,6 @@ module Jennifer
         context.star
       end
 
-      def self.build(pull : DB::ResultSet)
-        o = new(pull)
-        o.__after_initialize_callback
-        o
-      end
-
       def self.build(values : Hash(Symbol, ::Jennifer::DBAny) | NamedTuple)
         o = new(values)
         o.__after_initialize_callback

--- a/src/jennifer/model/base.cr
+++ b/src/jennifer/model/base.cr
@@ -147,6 +147,9 @@ module Jennifer
         raise Jennifer::UnknownRelation.new(self.class, name)
       end
 
+      private def init_attributes(values : Hash)
+      end
+
       abstract def primary
       abstract def attribute(name)
       abstract def set_attribute(name, value)

--- a/src/jennifer/model/relation_definition.cr
+++ b/src/jennifer/model/relation_definition.cr
@@ -380,7 +380,7 @@ module Jennifer
 
         macro def set_inverse_of(name : String, object)
           \{% begin %}
-            \{% relations = @type.constant("RELATION_NAMES") %}
+            \{% relations = RELATION_NAMES %}
             \{% if relations.size > 0 %}
               case name
               \{% for rel in relations %}
@@ -397,12 +397,12 @@ module Jennifer
 
         macro def append_relation(name : String, hash)
           \{% begin %}
-            \{% relations = @type.constant("RELATION_NAMES") %}
+            \{% relations = RELATION_NAMES %}
             \{% if relations.size > 0 %}
               case name
               \{% for rel in relations %}
-                when \{{rel}}
-                  append_\{{rel.id}}(hash)
+              when \{{rel}}
+                append_\{{rel.id}}(hash)
               \{% end %}
               else
                 super(name, hash)
@@ -413,7 +413,7 @@ module Jennifer
 
         macro def relation_retrieved(name : String)
           \{% begin %}
-            \{% relations = @type.constant("RELATION_NAMES") %}
+            \{% relations = RELATION_NAMES %}
             \{% if relations.size > 0 %}
               case name
               \{% for rel in relations %}
@@ -430,7 +430,7 @@ module Jennifer
 
         macro def __refresh_relation_retrieves
           \{% begin %}
-            \{% relations = @type.constant("RELATION_NAMES") %}
+            \{% relations = RELATION_NAMES %}
             \{% for rel in relations %}
               @__\{{rel.id}}_retrieved = false
             \{% end %}

--- a/src/jennifer/model/sti_mapping.cr
+++ b/src/jennifer/model/sti_mapping.cr
@@ -2,6 +2,8 @@ module Jennifer
   module Model
     module STIMapping
       macro sti_mapping(properties)
+        STI = true
+
         def self.sti_condition
           c("type") == {{@type.id.stringify}}
         end

--- a/src/jennifer/model/sti_mapping.cr
+++ b/src/jennifer/model/sti_mapping.cr
@@ -100,7 +100,7 @@ module Jennifer
 
         def initialize(values : Hash(String, ::Jennifer::DBAny))
           # TODO: try to make the "type" field customizable
-          values["type"] = "{{@type.id}}"
+          values["type"] = "{{@type.id}}" if values["type"]?.nil?
           super(values)
           {{properties.keys.map { |key| "@#{key.id}" }.join(", ").id}} = _sti_extract_attributes(values)
         end
@@ -118,6 +118,18 @@ module Jennifer
         {% else %}
           WITH_DEFAULT_CONSTRUCTOR = false
         {% end %}
+
+        def reload
+          raise ::Jennifer::RecordNotFound.new("It is not persisted yet") if new_record?
+          this = self
+          self.class.all.where { this.class.primary == this.primary }.limit(1).each_result_set do |rs|
+            values = ::Jennifer::Adapter.adapter.result_to_hash(rs)
+            init_attributes(values)
+          end
+          __refresh_changes
+          __refresh_relation_retrieves
+          self
+        end
 
         def changed?
           super ||
@@ -143,22 +155,8 @@ module Jennifer
           hash
         end
 
-        def update_column(name, value : Jennifer::DBAny)
-          case name.to_s
-          {% for key, value in properties %}
-          when "{{key.id}}"
-            if value.is_a?({{value[:parsed_type].id}})
-              local = value.as({{value[:parsed_type].id}})
-              @{{key.id}} = local
-            else
-              raise ::Jennifer::BaseException.new("rong type for #{name} : #{value.class}")
-            end
-          {% end %}
-          end
-          super
-        end
-
         def update_columns(values : Hash(String | Symbol, Jennifer::DBAny))
+          missing_values = {} of String | Symbol => Jennifer::DBAny
           values.each do |name, value|
             case name.to_s
             {% for key, value in properties %}
@@ -166,14 +164,16 @@ module Jennifer
               if value.is_a?({{value[:parsed_type].id}})
                 local = value.as({{value[:parsed_type].id}})
                 @{{key.id}} = local
+                @{{key.id}}_changed = true
               else
                 raise ::Jennifer::BaseException.new("Wrong type for #{name} : #{value.class}")
               end
             {% end %}
+            else
+              missing_values[name] = value
             end
           end
-
-          super
+          super(missing_values)
         end
 
         def set_attribute(name, value)
@@ -242,6 +242,11 @@ module Jennifer
 
         def self.all
           ::Jennifer::QueryBuilder::ModelQuery({{@type}}).build(table_name).where { _type == {{@type.stringify}} }
+        end
+
+        private def init_attributes(values : Hash)
+          super
+          {{properties.keys.map { |key| "@#{key.id}" }.join(", ").id}} = _sti_extract_attributes(values)
         end
 
         private def __refresh_changes

--- a/src/jennifer/query_builder/model_query.cr
+++ b/src/jennifer/query_builder/model_query.cr
@@ -85,7 +85,7 @@ module Jennifer
                     break
                   else
                     existence[i][h[pfn].to_s] = true
-                    obj.append_relation(@relations[i], h)
+                    obj.as(T).append_relation(@relations[i], h)
                   end
                 end
               else


### PR DESCRIPTION
- allows to load sti children classes using parent one during retrieving records from the db (e.g. `Parent.all.to_a` will return array of all subclasses depending on the `type` column)
- fixes several bugs in mysql adapter
- fixes `Model::Base#update_columns`
- fixes `Migration::TableBuilder::ChangeEnum` for postgres adapter
- extend tests suite