### PR TITLE
Refactor relation definition macros

### DIFF
--- a/spec/model/relation_definition_spec.cr
+++ b/spec/model/relation_definition_spec.cr
@@ -129,6 +129,15 @@ describe Jennifer::Model::RelationDefinition do
           query_count.should eq(count + 1)
         end
       end
+
+      context "new record" do
+        it "doesn't hit the db" do
+          c = Factory.build_contact
+          count = query_count
+          c.addresses
+          query_count.should eq(count)
+        end
+      end
     end
 
     describe "#add_/relation_name/" do
@@ -232,6 +241,15 @@ describe Jennifer::Model::RelationDefinition do
         a.contact
         query_count.should eq(count + 1)
       end
+
+      context "new record" do
+        it "doesn't hit the db" do
+          c = Factory.build_contact
+          count = query_count
+          c.addresses
+          query_count.should eq(count)
+        end
+      end
     end
 
     describe "#add_/relation_name/" do
@@ -316,6 +334,15 @@ describe Jennifer::Model::RelationDefinition do
           count = query_count
           c.main_address!.contact
           query_count.should eq(count + 1)
+        end
+      end
+
+      context "new record" do
+        it "doesn't hit the db" do
+          c = Factory.build_contact
+          count = query_count
+          c.addresses
+          query_count.should eq(count)
         end
       end
     end
@@ -407,6 +434,15 @@ describe Jennifer::Model::RelationDefinition do
         query_count.should eq(count + 1)
         c.countries
         query_count.should eq(count + 1)
+      end
+
+      context "new record" do
+        it "doesn't hit the db" do
+          c = Factory.build_contact
+          count = query_count
+          c.addresses
+          query_count.should eq(count)
+        end
       end
     end
 

--- a/src/jennifer/model/base.cr
+++ b/src/jennifer/model/base.cr
@@ -129,18 +129,6 @@ module Jennifer
         o
       end
 
-      def set_inverse_of(name : String, object)
-        raise Jennifer::UnknownRelation.new(self.class, name)
-      end
-
-      def append_relation(name : String, hash)
-        raise Jennifer::UnknownRelation.new(self.class, name)
-      end
-
-      def relation_retrieved(name : String)
-        raise Jennifer::UnknownRelation.new(self.class, name)
-      end
-
       private def init_attributes(values : Hash)
       end
 

--- a/src/jennifer/model/relation_definition.cr
+++ b/src/jennifer/model/relation_definition.cr
@@ -116,7 +116,7 @@ module Jennifer
 
         # returns array of related objects
         def {{name.id}}
-          if !@__{{name.id}}_retrieved && @{{name.id}}.empty?
+          if !@__{{name.id}}_retrieved && @{{name.id}}.empty? && !new_record?
             set_{{name.id}}_relation({{name.id}}_query.to_a.as(Array({{klass}})))
           end
           @{{name.id}}
@@ -208,7 +208,7 @@ module Jennifer
         end
 
         def {{name.id}}
-          if !@__{{name.id}}_retrieved && @{{name.id}}.empty?
+          if !@__{{name.id}}_retrieved && @{{name.id}}.empty? && !new_record?
             set_{{name.id}}_relation({{name.id}}_query.to_a.as(Array({{klass}})))
           end
           @{{name.id}}
@@ -266,7 +266,7 @@ module Jennifer
         end
 
         def {{name.id}}
-          if !@__{{name.id}}_retrieved && @{{name.id}}.nil?
+          if !@__{{name.id}}_retrieved && @{{name.id}}.nil? && !new_record?
             @__{{name.id}}_retrieved = true
             @{{name.id}} = {{name.id}}_reload
           end
@@ -340,7 +340,7 @@ module Jennifer
         end
 
         def {{name.id}}
-          if !@__{{name.id}}_retrieved && @{{name.id}}.nil?
+          if !@__{{name.id}}_retrieved && @{{name.id}}.nil? && !new_record?
             set_{{name.id}}_relation({{name.id}}_reload)
           end
           @{{name.id}}

--- a/src/jennifer/model/relation_definition.cr
+++ b/src/jennifer/model/relation_definition.cr
@@ -1,6 +1,21 @@
 module Jennifer
   module Model
     module RelationDefinition
+      def __refresh_relation_retrieves
+      end
+
+      def set_inverse_of(name : String, object)
+        raise Jennifer::UnknownRelation.new(self.class, name)
+      end
+
+      def append_relation(name : String, hash)
+        raise Jennifer::UnknownRelation.new(self.class, name)
+      end
+
+      def relation_retrieved(name : String)
+        raise Jennifer::UnknownRelation.new(self.class, name)
+      end
+
       macro nullify_dependency(name, relation_type)
         def __nullify_callback_{{name.id}}
           rel = \{{@type}}.relation({{name.id.stringify}})
@@ -56,322 +71,320 @@ module Jennifer
         {% end %}
       end
 
-      macro included
-        macro has_many(name, klass, request = nil, foreign = nil, primary = nil, dependent = :nullify, inverse_of = nil)
-          \{% inverse_of_str = inverse_of.id.stringify %}
+      macro has_many(name, klass, request = nil, foreign = nil, primary = nil, dependent = :nullify, inverse_of = nil)
+        {% inverse_of_str = inverse_of.id.stringify %}
 
-          ::Jennifer::Model::RelationDefinition.declare_dependent(\{{name}}, \{{dependent}}, :has_many)
+        ::Jennifer::Model::RelationDefinition.declare_dependent({{name}}, {{dependent}}, :has_many)
 
-          @@relations["\{{name.id}}"] =
-            ::Jennifer::Relation::HasMany(\{{klass}}, \{{@type}}).new("\{{name.id}}", \{{foreign}}, \{{primary}},
-              \{{klass}}.all\{% if request %}.exec \{{request}} \{% end %})
+        @@relations["{{name.id}}"] =
+          ::Jennifer::Relation::HasMany({{klass}}, {{@type}}).new("{{name.id}}", {{foreign}}, {{primary}},
+            {{klass}}.all{% if request %}.exec {{request}} {% end %})
 
-          \{% RELATION_NAMES << "#{name.id}" %}
+        {{"{% RELATION_NAMES << #{name.id.stringify} %}".id}}
 
-          @\{{name.id}} = [] of \{{klass}}
-          @__\{{name.id}}_retrieved = false
+        @{{name.id}} = [] of {{klass}}
+        @__{{name.id}}_retrieved = false
 
-          # :nodoc:
-          private def set_\{{name.id}}_relation(object : Array)
-            @__\{{name.id}}_retrieved = true
-            @\{{name.id}} = object
-            \{% if inverse_of %}
-              object.each(&.set_inverse_of(\{{inverse_of_str}}, self))
-            \{% end %}
-          end
-
-          # :nodoc:
-          private def set_\{{name.id}}_relation(object)
-            @__\{{name.id}}_retrieved = true
-            @\{{name.id}} << object
-            \{% if inverse_of %}
-              object.set_inverse_of(\{{inverse_of_str}}, self)
-            \{% end %}
-          end
-
-          # returns relation metaobject
-          def self.\{{name.id}}_relation
-            @@relations["\{{name.id}}"].as(::Jennifer::Relation::HasMany(\{{klass}}, \{{@type}}))
-          end
-
-          # returns relation query for the object
-          def \{{name.id}}_query
-            primary_value = \{{ primary ? primary.id : "primary".id }}
-            \{{@type}}.relation(\{{name.id.stringify}}).query(primary_value).as(::Jennifer::QueryBuilder::ModelQuery(\{{klass}}))
-          end
-
-          # returns array of related objects
-          def \{{name.id}}
-            if !@__\{{name.id}}_retrieved && @\{{name.id}}.empty?
-              set_\{{name.id}}_relation(\{{name.id}}_query.to_a.as(Array(\{{klass}})))
-            end
-            @\{{name.id}}
-          end
-
-          # builds related object from hash and adds to relation
-          def append_\{{name.id}}(rel : Hash)
-            obj = \{{klass}}.build(rel, false)
-            set_\{{name.id}}_relation(\{{klass}}.build(rel, false))
-          end
-
-          def append_\{{name.id}}(rel : \{{klass}})
-            set_\{{name.id}}_relation(rel)
-          end
-
-          def __\{{name.id}}_retrieved
-            @__\{{name.id}}_retrieved = true
-          end
-
-          # removes given object from relation array
-          def remove_\{{name.id}}(rel : \{{klass}})
-            index = @\{{name.id}}.index { |e| e.primary == rel.primary }
-            if index
-              \{{@type}}.\{{name.id}}_relation.remove(self, rel)
-              @\{{name.id}}.delete_at(index)
-            end
-            rel
-          end
-
-          # Insert given object to db and relation; doesn't support `inverse_of` option
-          def add_\{{name.id}}(rel : Hash)
-            @\{{name.id}} << \{{@type}}.\{{name.id}}_relation.insert(self, rel).as(\{{klass}})
-          end
-
-          def add_\{{name.id}}(rel : \{{klass}})
-            @\{{name.id}} << \{{@type}}.\{{name.id}}_relation.insert(self, rel)
-          end
-
-          def \{{name.id}}_reload
-            @\{{name.id}} = \{{name.id}}_query.to_a.as(Array(\{{klass}}))
-          end
+        # :nodoc:
+        private def set_{{name.id}}_relation(object : Array)
+          @__{{name.id}}_retrieved = true
+          @{{name.id}} = object
+          {% if inverse_of %}
+            object.each(&.set_inverse_of({{inverse_of_str}}, self))
+          {% end %}
         end
 
-        macro has_and_belongs_to_many(name, klass, request = nil, foreign = nil, primary = nil, join_table = nil, association_foreign = nil)
-          @@relations["\{{name.id}}"] =
-            ::Jennifer::Relation::ManyToMany(\{{klass}}, \{{@type}}).new("\{{name.id}}", \{{foreign}}, \{{primary}},
-              \{{klass}}.all\{% if request %}.exec \{{request}} \{% end %}, \{{join_table}}, \{{association_foreign}})
-
-          \{% RELATION_NAMES << "#{name.id}" %}
-
-          before_destroy :__\{{name.id}}_clean
-
-          # Cleans up all join table records for given relation
-          def __\{{name.id}}_clean
-            relation = self.class.\{{name.id}}_relation
-            this = self
-            ::Jennifer::Adapter.adapter.delete(::Jennifer::QueryBuilder::Query.new(relation.join_table!).where do
-              c(relation.foreign_field) == this.attribute(relation.primary_field)
-            end)
-          end
-
-          @\{{name.id}} = [] of \{{klass}}
-          @__\{{name.id}}_retrieved = false
-
-          # :nodoc:
-          private def set_\{{name.id}}_relation(object : Array)
-            @__\{{name.id}}_retrieved = true
-            @\{{name.id}} = object
-          end
-
-          # :nodoc:
-          private def set_\{{name.id}}_relation(object)
-            @__\{{name.id}}_retrieved = true
-            @\{{name.id}} << object
-          end
-
-          def self.\{{name.id}}_relation
-            @@relations["\{{name.id}}"].as(::Jennifer::Relation::ManyToMany(\{{klass}}, \{{@type}}))
-          end
-
-          def \{{name.id}}_query
-            primary_field =
-              \{% if primary %}
-                \{{primary.id}}
-              \{% else %}
-                primary
-              \{% end %}
-            @@relations["\{{name.id}}"].query(primary_field).as(::Jennifer::QueryBuilder::ModelQuery(\{{klass}}))
-          end
-
-          def \{{name.id}}
-            if !@__\{{name.id}}_retrieved && @\{{name.id}}.empty?
-              set_\{{name.id}}_relation(\{{name.id}}_query.to_a.as(Array(\{{klass}})))
-            end
-            @\{{name.id}}
-          end
-
-          def append_\{{name.id}}(rel : Hash)
-            set_\{{name.id}}_relation(\{{klass}}.build(rel, false))
-          end
-
-          def append_\{{name.id}}(rel : \{{klass}})
-            set_\{{name.id}}_relation(rel)
-          end
-
-          def __\{{name.id}}_retrieved
-            @__\{{name.id}}_retrieved = true
-          end
-
-          def remove_\{{name.id}}(rel : \{{klass}})
-            index = @\{{name.id}}.index { |e| e.primary == rel.primary }
-            if index
-              \{{@type}}.\{{name.id}}_relation.remove(self, rel)
-              @\{{name.id}}.delete_at(index)
-            end
-            rel
-          end
-
-          # ... ; doesn't support `inverse_of` option
-          def add_\{{name.id}}(rel : Hash)
-            @\{{name.id}} << \{{@type}}.\{{name.id}}_relation.insert(self, rel)
-          end
-
-          def add_\{{name.id}}(rel : \{{klass}})
-            @\{{name.id}} << \{{@type}}.\{{name.id}}_relation.insert(self, rel)
-          end
-
-          def \{{name.id}}_reload
-            @\{{name.id}} = \{{name.id}}_query.to_a.as(Array(\{{klass}}))
-          end
+        # :nodoc:
+        private def set_{{name.id}}_relation(object)
+          @__{{name.id}}_retrieved = true
+          @{{name.id}} << object
+          {% if inverse_of %}
+            object.set_inverse_of({{inverse_of_str}}, self)
+          {% end %}
         end
 
-        macro belongs_to(name, klass, request = nil, foreign = nil, primary = nil, join_table = nil, join_foreign = nil, dependent = :none)
-          ::Jennifer::Model::RelationDefinition.declare_dependent(\{{name}}, \{{dependent}}, :belongs_to)
-
-          @@relations["\{{name.id}}"] =
-            ::Jennifer::Relation::BelongsTo(\{{klass}}, \{{@type}}).new("\{{name.id}}", \{{foreign}}, \{{primary}},
-              \{{klass}}.all\{% if request %}.exec \{{request}} \{% end %})
-
-          \{% RELATION_NAMES << "#{name.id}" %}
-
-          @\{{name.id}} : \{{klass}}?
-          @__\{{name.id}}_retrieved = false
-
-          def self.\{{name.id}}_relation
-            @@relations["\{{name.id}}"].as(::Jennifer::Relation::BelongsTo(\{{klass}}, \{{@type}}))
-          end
-
-          def \{{name.id}}
-            if !@__\{{name.id}}_retrieved && @\{{name.id}}.nil?
-              @__\{{name.id}}_retrieved = true
-              @\{{name.id}} = \{{name.id}}_reload
-            end
-            @\{{name.id}}
-          end
-
-          def \{{name.id}}!
-            \{{name.id}}.not_nil!
-          end
-
-          def \{{name.id}}_query
-            foreign_field = \{{ (foreign ? foreign : "attribute(#{klass}.singular_table_name + \"_id\")").id }}
-            @@relations["\{{name.id}}"].query(foreign_field).as(::Jennifer::QueryBuilder::ModelQuery(\{{klass}}))
-          end
-
-          def \{{name.id}}_reload
-            @\{{name.id}} = \{{name.id}}_query.first.as(\{{klass}}?)
-          end
-
-          def append_\{{name.id}}(rel : Hash)
-            @__\{{name.id}}_retrieved = true
-            @\{{name.id}} = \{{klass}}.build(rel, false)
-          end
-
-          def append_\{{name.id}}(rel : \{{klass}})
-            @__\{{name.id}}_retrieved = true
-            @\{{name.id}} = rel
-          end
-
-          def __\{{name.id}}_retrieved
-            @__\{{name.id}}_retrieved = true
-          end
-
-          def remove_\{{name.id}}
-            \{{@type}}.\{{name.id}}_relation.remove(self)
-            @\{{name.id}} = nil
-          end
-
-          def add_\{{name.id}}(rel : Hash)
-            @\{{name.id}} = \{{@type}}.\{{name.id}}_relation.insert(self, rel)
-          end
-
-          def add_\{{name.id}}(rel : \{{klass}})
-            @\{{name.id}} = \{{@type}}.\{{name.id}}_relation.insert(self, rel)
-          end
+        # returns relation metaobject
+        def self.{{name.id}}_relation
+          @@relations["{{name.id}}"].as(::Jennifer::Relation::HasMany({{klass}}, {{@type}}))
         end
 
-        macro has_one(name, klass, request = nil, foreign = nil, primary = nil, join_table = nil, join_foreign = nil, dependent = :nullify, inverse_of = nil)
-          ::Jennifer::Model::RelationDefinition.declare_dependent(\{{name}}, \{{dependent}}, :has_one)
+        # returns relation query for the object
+        def {{name.id}}_query
+          primary_value = {{ primary ? primary.id : "primary".id }}
+          {{@type}}.relation({{name.id.stringify}}).query(primary_value).as(::Jennifer::QueryBuilder::ModelQuery({{klass}}))
+        end
 
-          @@relations["\{{name.id}}"] =
-            ::Jennifer::Relation::HasOne(\{{klass}}, \{{@type}}).new("\{{name.id}}", \{{foreign}}, \{{primary}},
-              \{{klass}}.all\{% if request %}.exec \{{request}} \{% end %})
-
-          \{% RELATION_NAMES << "#{name.id}" %}
-
-          @\{{name.id}} : \{{klass}}?
-          @__\{{name.id}}_retrieved = false
-
-          # :nodoc:
-          private def set_\{{name.id}}_relation(object)
-            @__\{{name.id}}_retrieved = true
-            @\{{name.id}} = object
-            \{% if inverse_of %}
-              object.not_nil!.set_inverse_of(\{{inverse_of.id.stringify}}, self) if object
-            \{% end %}
+        # returns array of related objects
+        def {{name.id}}
+          if !@__{{name.id}}_retrieved && @{{name.id}}.empty?
+            set_{{name.id}}_relation({{name.id}}_query.to_a.as(Array({{klass}})))
           end
+          @{{name.id}}
+        end
 
-          def self.\{{name.id}}_relation
-            @@relations["\{{name.id}}"].as(::Jennifer::Relation::HasOne(\{{klass}}, \{{@type}}))
-          end
+        # builds related object from hash and adds to relation
+        def append_{{name.id}}(rel : Hash)
+          obj = {{klass}}.build(rel, false)
+          set_{{name.id}}_relation({{klass}}.build(rel, false))
+        end
 
-          def \{{name.id}}
-            if !@__\{{name.id}}_retrieved && @\{{name.id}}.nil?
-              set_\{{name.id}}_relation(\{{name.id}}_reload)
-            end
-            @\{{name.id}}
-          end
+        def append_{{name.id}}(rel : {{klass}})
+          set_{{name.id}}_relation(rel)
+        end
 
-          def \{{name.id}}!
-            \{{name.id}}.not_nil!
-          end
+        def __{{name.id}}_retrieved
+          @__{{name.id}}_retrieved = true
+        end
 
-          def \{{name.id}}_query
-            primary_field = \{{ (primary ? primary : "primary").id }}
-            @@relations["\{{name.id}}"].query(primary_field).as(::Jennifer::QueryBuilder::ModelQuery(\{{klass}}))
+        # removes given object from relation array
+        def remove_{{name.id}}(rel : {{klass}})
+          index = @{{name.id}}.index { |e| e.primary == rel.primary }
+          if index
+            {{@type}}.{{name.id}}_relation.remove(self, rel)
+            @{{name.id}}.delete_at(index)
           end
+          rel
+        end
 
-          def \{{name.id}}_reload
-            @\{{name.id}} = \{{name.id}}_query.first.as(\{{klass}}?)
-          end
+        # Insert given object to db and relation; doesn't support `inverse_of` option
+        def add_{{name.id}}(rel : Hash)
+          @{{name.id}} << {{@type}}.{{name.id}}_relation.insert(self, rel).as({{klass}})
+        end
 
-          # ... ; doesn't support `inverse_of` option
-          def append_\{{name.id}}(rel : Hash)
-            @__\{{name.id}}_retrieved = true
-            @\{{name.id}} = \{{klass}}.build(rel, false)
-          end
+        def add_{{name.id}}(rel : {{klass}})
+          @{{name.id}} << {{@type}}.{{name.id}}_relation.insert(self, rel)
+        end
 
-          def append_\{{name.id}}(rel : \{{klass}})
-            @__\{{name.id}}_retrieved = true
-            @\{{name.id}} = rel
-          end
+        def {{name.id}}_reload
+          @{{name.id}} = {{name.id}}_query.to_a.as(Array({{klass}}))
+        end
+      end
 
-          def __\{{name.id}}_retrieved
-            @__\{{name.id}}_retrieved = true
-          end
+      macro has_and_belongs_to_many(name, klass, request = nil, foreign = nil, primary = nil, join_table = nil, association_foreign = nil)
+        @@relations["{{name.id}}"] =
+          ::Jennifer::Relation::ManyToMany({{klass}}, {{@type}}).new("{{name.id}}", {{foreign}}, {{primary}},
+            {{klass}}.all{% if request %}.exec {{request}} {% end %}, {{join_table}}, {{association_foreign}})
 
-          def remove_\{{name.id}}
-            \{{@type}}.\{{name.id}}_relation.remove(self)
-            @\{{name.id}} = nil
-          end
+        {{"{% RELATION_NAMES << #{name.id.stringify} %}".id}}
 
-          def add_\{{name.id}}(rel : Hash)
-            @\{{name.id}} = \{{@type}}.\{{name.id}}_relation.insert(self, rel)
-          end
+        before_destroy :__{{name.id}}_clean
 
-          def add_\{{name.id}}(rel : \{{klass}})
-            @\{{name.id}} = \{{@type}}.\{{name.id}}_relation.insert(self, rel)
+        # Cleans up all join table records for given relation
+        def __{{name.id}}_clean
+          relation = self.class.{{name.id}}_relation
+          this = self
+          ::Jennifer::Adapter.adapter.delete(::Jennifer::QueryBuilder::Query.new(relation.join_table!).where do
+            c(relation.foreign_field) == this.attribute(relation.primary_field)
+          end)
+        end
+
+        @{{name.id}} = [] of {{klass}}
+        @__{{name.id}}_retrieved = false
+
+        # :nodoc:
+        private def set_{{name.id}}_relation(object : Array)
+          @__{{name.id}}_retrieved = true
+          @{{name.id}} = object
+        end
+
+        # :nodoc:
+        private def set_{{name.id}}_relation(object)
+          @__{{name.id}}_retrieved = true
+          @{{name.id}} << object
+        end
+
+        def self.{{name.id}}_relation
+          @@relations["{{name.id}}"].as(::Jennifer::Relation::ManyToMany({{klass}}, {{@type}}))
+        end
+
+        def {{name.id}}_query
+          primary_field =
+            {% if primary %}
+              {{primary.id}}
+            {% else %}
+              primary
+            {% end %}
+          @@relations["{{name.id}}"].query(primary_field).as(::Jennifer::QueryBuilder::ModelQuery({{klass}}))
+        end
+
+        def {{name.id}}
+          if !@__{{name.id}}_retrieved && @{{name.id}}.empty?
+            set_{{name.id}}_relation({{name.id}}_query.to_a.as(Array({{klass}})))
           end
+          @{{name.id}}
+        end
+
+        def append_{{name.id}}(rel : Hash)
+          set_{{name.id}}_relation({{klass}}.build(rel, false))
+        end
+
+        def append_{{name.id}}(rel : {{klass}})
+          set_{{name.id}}_relation(rel)
+        end
+
+        def __{{name.id}}_retrieved
+          @__{{name.id}}_retrieved = true
+        end
+
+        def remove_{{name.id}}(rel : {{klass}})
+          index = @{{name.id}}.index { |e| e.primary == rel.primary }
+          if index
+            {{@type}}.{{name.id}}_relation.remove(self, rel)
+            @{{name.id}}.delete_at(index)
+          end
+          rel
+        end
+
+        # ... ; doesn't support `inverse_of` option
+        def add_{{name.id}}(rel : Hash)
+          @{{name.id}} << {{@type}}.{{name.id}}_relation.insert(self, rel)
+        end
+
+        def add_{{name.id}}(rel : {{klass}})
+          @{{name.id}} << {{@type}}.{{name.id}}_relation.insert(self, rel)
+        end
+
+        def {{name.id}}_reload
+          @{{name.id}} = {{name.id}}_query.to_a.as(Array({{klass}}))
+        end
+      end
+
+      macro belongs_to(name, klass, request = nil, foreign = nil, primary = nil, join_table = nil, join_foreign = nil, dependent = :none)
+        ::Jennifer::Model::RelationDefinition.declare_dependent({{name}}, {{dependent}}, :belongs_to)
+
+        @@relations["{{name.id}}"] =
+          ::Jennifer::Relation::BelongsTo({{klass}}, {{@type}}).new("{{name.id}}", {{foreign}}, {{primary}},
+            {{klass}}.all{% if request %}.exec {{request}} {% end %})
+
+        {{"{% RELATION_NAMES << #{name.id.stringify} %}".id}}
+
+        @{{name.id}} : {{klass}}?
+        @__{{name.id}}_retrieved = false
+
+        def self.{{name.id}}_relation
+          @@relations["{{name.id}}"].as(::Jennifer::Relation::BelongsTo({{klass}}, {{@type}}))
+        end
+
+        def {{name.id}}
+          if !@__{{name.id}}_retrieved && @{{name.id}}.nil?
+            @__{{name.id}}_retrieved = true
+            @{{name.id}} = {{name.id}}_reload
+          end
+          @{{name.id}}
+        end
+
+        def {{name.id}}!
+          {{name.id}}.not_nil!
+        end
+
+        def {{name.id}}_query
+          foreign_field = {{ (foreign ? foreign : "attribute(#{klass}.singular_table_name + \"_id\")").id }}
+          @@relations["{{name.id}}"].query(foreign_field).as(::Jennifer::QueryBuilder::ModelQuery({{klass}}))
+        end
+
+        def {{name.id}}_reload
+          @{{name.id}} = {{name.id}}_query.first.as({{klass}}?)
+        end
+
+        def append_{{name.id}}(rel : Hash)
+          @__{{name.id}}_retrieved = true
+          @{{name.id}} = {{klass}}.build(rel, false)
+        end
+
+        def append_{{name.id}}(rel : {{klass}})
+          @__{{name.id}}_retrieved = true
+          @{{name.id}} = rel
+        end
+
+        def __{{name.id}}_retrieved
+          @__{{name.id}}_retrieved = true
+        end
+
+        def remove_{{name.id}}
+          {{@type}}.{{name.id}}_relation.remove(self)
+          @{{name.id}} = nil
+        end
+
+        def add_{{name.id}}(rel : Hash)
+          @{{name.id}} = {{@type}}.{{name.id}}_relation.insert(self, rel)
+        end
+
+        def add_{{name.id}}(rel : {{klass}})
+          @{{name.id}} = {{@type}}.{{name.id}}_relation.insert(self, rel)
+        end
+      end
+
+      macro has_one(name, klass, request = nil, foreign = nil, primary = nil, join_table = nil, join_foreign = nil, dependent = :nullify, inverse_of = nil)
+        ::Jennifer::Model::RelationDefinition.declare_dependent({{name}}, {{dependent}}, :has_one)
+
+        @@relations["{{name.id}}"] =
+          ::Jennifer::Relation::HasOne({{klass}}, {{@type}}).new("{{name.id}}", {{foreign}}, {{primary}},
+            {{klass}}.all{% if request %}.exec {{request}} {% end %})
+
+        {{"{% RELATION_NAMES << #{name.id.stringify} %}".id}}
+
+        @{{name.id}} : {{klass}}?
+        @__{{name.id}}_retrieved = false
+
+        # :nodoc:
+        private def set_{{name.id}}_relation(object)
+          @__{{name.id}}_retrieved = true
+          @{{name.id}} = object
+          {% if inverse_of %}
+            object.not_nil!.set_inverse_of({{inverse_of.id.stringify}}, self) if object
+          {% end %}
+        end
+
+        def self.{{name.id}}_relation
+          @@relations["{{name.id}}"].as(::Jennifer::Relation::HasOne({{klass}}, {{@type}}))
+        end
+
+        def {{name.id}}
+          if !@__{{name.id}}_retrieved && @{{name.id}}.nil?
+            set_{{name.id}}_relation({{name.id}}_reload)
+          end
+          @{{name.id}}
+        end
+
+        def {{name.id}}!
+          {{name.id}}.not_nil!
+        end
+
+        def {{name.id}}_query
+          primary_field = {{ (primary ? primary : "primary").id }}
+          @@relations["{{name.id}}"].query(primary_field).as(::Jennifer::QueryBuilder::ModelQuery({{klass}}))
+        end
+
+        def {{name.id}}_reload
+          @{{name.id}} = {{name.id}}_query.first.as({{klass}}?)
+        end
+
+        # ... ; doesn't support `inverse_of` option
+        def append_{{name.id}}(rel : Hash)
+          @__{{name.id}}_retrieved = true
+          @{{name.id}} = {{klass}}.build(rel, false)
+        end
+
+        def append_{{name.id}}(rel : {{klass}})
+          @__{{name.id}}_retrieved = true
+          @{{name.id}} = rel
+        end
+
+        def __{{name.id}}_retrieved
+          @__{{name.id}}_retrieved = true
+        end
+
+        def remove_{{name.id}}
+          {{@type}}.{{name.id}}_relation.remove(self)
+          @{{name.id}} = nil
+        end
+
+        def add_{{name.id}}(rel : Hash)
+          @{{name.id}} = {{@type}}.{{name.id}}_relation.insert(self, rel)
+        end
+
+        def add_{{name.id}}(rel : {{klass}})
+          @{{name.id}} = {{@type}}.{{name.id}}_relation.insert(self, rel)
         end
       end
 
@@ -427,13 +440,13 @@ module Jennifer
           \{% end %}
         end
 
-
         def __refresh_relation_retrieves
           \{% begin %}
             \{% relations = RELATION_NAMES %}
             \{% for rel in relations %}
               @__\{{rel.id}}_retrieved = false
             \{% end %}
+            super
           \{% end %}
         end
       end


### PR DESCRIPTION
- move all relation macros out of `included` macro to module level;
- avoid relation loading for a new record