### PR TITLE
Add criteria container for query orders

### DIFF
--- a/src/jennifer/adapter/base_sql_generator.cr
+++ b/src/jennifer/adapter/base_sql_generator.cr
@@ -198,7 +198,7 @@ module Jennifer
       def self.order_clause(io : String::Builder, query)
         return if !query._order || query._order.empty?
         io << "ORDER BY "
-        query._order.not_nil!.join(", ", io) { |(k, v)| io.print k.as_sql(self), " ", v.upcase }
+        query._order.join(", ", io) { |(k, v), _| io.print k.as_sql(self), " ", v.upcase }
         io << "\n"
       end
 

--- a/src/jennifer/query_builder/criteria.cr
+++ b/src/jennifer/query_builder/criteria.cr
@@ -1,4 +1,5 @@
 require "./json_selector"
+require "./criteria_container"
 
 module Jennifer
   module QueryBuilder
@@ -14,10 +15,7 @@ module Jennifer
       def initialize(@field : String, @table : String, @relation = nil)
       end
 
-      # NOTE: workaround for passing criteria to the hash as a key - somewhy any Criteria is realized as same one
-      def hash
-        "#{@field}#{@table}".hash
-      end
+      def_hash @field, @table
 
       def set_relation(table : String, name : String)
         @relation = name if @relation.nil? && @table == table
@@ -65,7 +63,7 @@ module Jennifer
       end
 
       def ==(value : Rightable)
-        # NOTE: here crystal improperly resolves override methods with Nilargument
+        # NOTE: here crystal improperly resolves override methods with Nil argument
         if !value.nil?
           Condition.new(self, :==, value)
         else

--- a/src/jennifer/query_builder/criteria_container.cr
+++ b/src/jennifer/query_builder/criteria_container.cr
@@ -1,0 +1,69 @@
+module Jennifer
+  module QueryBuilder
+    struct CriteriaContainer
+      include Enumerable({Criteria, String})
+
+      @value_bucket : Hash(String, String)
+      @key_bucket : Hash(String, Criteria)
+
+      def initialize
+        @value_bucket = {} of String => String
+        @key_bucket = {} of String => Criteria
+      end
+
+      def_clone
+
+      def each
+        @key_bucket.each do |internal_key, criteria|
+          yield({criteria, @value_bucket[internal_key]})
+        end
+      end
+
+      def keys
+        @key_bucket.values
+      end
+
+      def values
+        @value_bucket.values
+      end
+
+      def []=(key : Criteria, value : String)
+        internal_key = key_value(key)
+
+        @value_bucket[internal_key] = value
+        @key_bucket[internal_key] = key
+        key
+      end
+
+      def [](key : Criteria)
+        internal_key = key_value(key)
+        @value_bucket[internal_key]
+      end
+
+      def []?(key : Criteria)
+        internal_key = key_value(key)
+        @value_bucket[internal_key]?
+      end
+
+      def clear
+        @value_bucket.clear
+        @key_bucket.clear
+      end
+
+      def empty?
+        @key_bucket.empty?
+      end
+
+      def remove(key : Criteria)
+        internal_key = key_value(key)
+
+        @value_bucket.remove(internal_key)
+        @key_bucket.remove(internal_key)
+      end
+
+      private def key_value(criteria : Criteria)
+        criteria.field + ":::" + criteria.table
+      end
+    end
+  end
+end

--- a/src/jennifer/query_builder/query.cr
+++ b/src/jennifer/query_builder/query.cr
@@ -42,7 +42,7 @@ module Jennifer
       def initialize
         @do_nothing = false
         @expression = ExpressionBuilder.new(@table)
-        @order = {} of Criteria => String
+        @order = CriteriaContainer.new
         @relations = [] of String
         @groups = [] of Criteria
         @relation_used = false
@@ -59,7 +59,7 @@ module Jennifer
           @{{segment.id}} = other.@{{segment.id}}.clone unless except.includes?({{segment}})
         {% end %}
 
-        @order = except.includes?("order") ? {} of Criteria => String : other.@order.clone
+        @order = except.includes?("order") ? CriteriaContainer.new : other.@order.clone
         @joins = other.@joins.clone unless except.includes?("join")
         @unions = other.@unions.clone unless except.includes?("union")
         @groups = except.includes?("group") ? [] of Criteria : other.@groups.clone


### PR DESCRIPTION
- add `CriteriaContainer` to holder query orders - `Criteria#==` method is used for query dsl so can't be used to compare objects