### PR TITLE
Update method enhancement

### DIFF
--- a/docs/callbacks.md
+++ b/docs/callbacks.md
@@ -68,6 +68,8 @@ The following methods trigger callbacks:
 - save
 - save!
 - save_without_transaction
+- update
+- update!
 
 The `after_initialize` callback is triggered each time record is initialized using method `::build`.
 
@@ -77,7 +79,6 @@ The following methods allows to skip some callbacks or process without them:
 
 - validate
 - invalid?
-- update
 - save(skip_validation: true)
 - destroy_without_transaction (no transaction callback will be triggered)
 - save_without_transaction (no transaction callback will be triggered)

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -54,7 +54,6 @@ Not all methods which hit db perform validation. They are:
 - modify
 - increment
 - decrement
-- update
 
 > NOTE: `#invalid?` method will only check if `#errors` is empty.
 

--- a/spec/model/mapping_spec.cr
+++ b/spec/model/mapping_spec.cr
@@ -487,7 +487,7 @@ describe Jennifer::Model::Mapping do
           c.name.should eq("123")
         end
 
-        it "raises exeption if value has wrong type" do
+        it "raises exception if value has wrong type" do
           c = Factory.build_contact
           expect_raises(::Jennifer::BaseException) do
             c.set_attribute(:name, 123)

--- a/spec/query_builder/model_query_spec.cr
+++ b/spec/query_builder/model_query_spec.cr
@@ -112,6 +112,35 @@ describe Jennifer::QueryBuilder::ModelQuery do
     end
   end
 
+  describe "#patch" do
+    it "triggers validation" do
+      Factory.create_contact(age: 20)
+      Contact.all.patch(age: 12)
+      Contact.all.where { _age == 12 }.exists?.should be_false
+    end
+
+    it do
+      Factory.create_contact(age: 20)
+      Contact.all.patch(age: 30)
+      Contact.all.where { _age == 30 }.exists?.should be_true
+    end
+  end
+
+  describe "#patch!" do
+    it "raises exception if is invalid" do
+      Factory.create_contact(age: 20)
+      expect_raises(Jennifer::RecordInvalid) do
+        Contact.all.patch!(age: 12)
+      end
+    end
+
+    it do
+      Factory.create_contact(age: 20)
+      Contact.all.patch!(age: 30)
+      Contact.all.where { _age == 30 }.exists?.should be_true
+    end
+  end
+
   describe "#select_args" do
     it "returns array of join and condition args" do
       Contact.where { _id == 2 }.join(Address) { _name == "asd" }.select_args.should eq(db_array("asd", 2))

--- a/src/jennifer/model/base.cr
+++ b/src/jennifer/model/base.cr
@@ -156,17 +156,39 @@ module Jennifer
         {% end %}
       end
 
-      def update_attributes(hash : Hash)
+      def update(hash : Hash | NamedTuple)
+        update_attributes(hash)
+        save
+      end
+
+      def update(**opts)
+        update(opts)
+      end
+
+      def update!(hash : Hash | NamedTuple)
+        update_attributes(hash)
+        save!
+      end
+
+      def update!(**opts)
+        update!(opts)
+      end
+
+      def update_attributes(hash : Hash | NamedTuple)
         hash.each { |k, v| set_attribute(k, v) }
       end
 
+      def update_attributes(**opts)
+        update_attributes(opts)
+      end
+
       # Perform destroy without starting a transaction
-        def destroy_without_transaction
-          return false if new_record? || !__before_destroy_callback
-          @destroyed = true if delete
-          __after_destroy_callback if @destroyed  
-          @destroyed
-        end
+      def destroy_without_transaction
+        return false if new_record? || !__before_destroy_callback
+        @destroyed = true if delete
+        __after_destroy_callback if @destroyed  
+        @destroyed
+      end
 
       # Deletes object from DB without calling callbacks.
       def delete

--- a/src/jennifer/model/mapping.cr
+++ b/src/jennifer/model/mapping.cr
@@ -197,10 +197,6 @@ module Jennifer
           initialize(values)
         end
 
-        # TODO: think about next method
-        # def attributes=(values : Hash)
-        # end
-
         def self.build(pull : DB::ResultSet)
           \{% begin %}
             \{% klasses = @type.all_subclasses.select { |s| s.constant("STI") == true } %}

--- a/src/jennifer/query_builder/executables.cr
+++ b/src/jennifer/query_builder/executables.cr
@@ -63,7 +63,6 @@ module Jennifer
         adapter.modify(self, options)
       end
 
-      # TODO: load objects and perform all callbacks and validation
       def update(options : Hash)
         adapter.update(self, options)
       end

--- a/src/jennifer/query_builder/i_model_query.cr
+++ b/src/jennifer/query_builder/i_model_query.cr
@@ -103,11 +103,11 @@ module Jennifer
         relation(name)
       end
 
-      # NOTE: Not implemented yet
-      def eager_load(rels : Array(String), aliases = [] of String?)
-        @relations << name.to_s
-        raise "Not implemented"
-      end
+      # TODO: add eager load with aliases
+      # def eager_load(rels : Array(String), aliases = [] of String?)
+      #   @relations << name.to_s
+      #   raise "Not implemented"
+      # end
 
       def relation(name, type = :left)
         model_class.relation(name.to_s).join_condition(self, type)
@@ -121,9 +121,27 @@ module Jennifer
         super(model_class.primary, batch_size, start, direction) { |record| yield record }
       end
 
-      # Loads all records and call `#destroy` on the each
+      # Triggers `#destroy` on the each matched object
       def destroy
-        to_a.each(&.destroy)
+        find_each(&.destroy)
+      end
+
+      # Triggers `#update` on the each matched object
+      def patch(options : Hash | NamedTuple)
+        find_each(&.update(options))
+      end
+
+      def patch(**opts)
+        patch(opts)
+      end
+
+      # Triggers `#update!` on the each matched object
+      def patch!(options : Hash | NamedTuple)
+        find_each(&.update!(options))
+      end
+
+      def patch!(**opts)
+        patch!(opts)
       end
 
       # ========= private ==============


### PR DESCRIPTION
adds following methods
- `Model::Base#update`
- `Model::Base#update!`
- `QueryBuilder::ModelQuery#path`
- `QueryBuilder::ModelQuery#path!`
- now - `QueryBuilder::ModelQuery#destroy` uses `#find_each` instead of `#to_a`