### PR TITLE
Add model parameter converters

### DIFF
--- a/spec/model/base_spec.cr
+++ b/spec/model/base_spec.cr
@@ -192,6 +192,14 @@ describe Jennifer::Model::Base do
           match_fields(contact, name: "Deepthi", age: 18, gender: "female")
         end
       end
+
+      context "with string encoded values" do
+        it "builds object with converted values" do
+          c = Contact.build(Contact.build_params({"name" => "a", "age" => "999", "gender" => "female", "ballance" => "12345.456"}))
+          c.name.should eq("a")
+          c.age.should eq(999)
+        end
+      end
     end
 
     context "from named tuple" do

--- a/spec/model/mapping_spec.cr
+++ b/spec/model/mapping_spec.cr
@@ -463,7 +463,7 @@ describe Jennifer::Model::Mapping do
           c.name.should eq("123")
         end
 
-        it "raises exeption if value has wrong type" do
+        it "raises exception if value has wrong type" do
           c = Factory.create_contact
           expect_raises(::Jennifer::BaseException) do
             c.update_column(:name, 123)

--- a/spec/model/parameter_converter_spec.cr
+++ b/spec/model/parameter_converter_spec.cr
@@ -1,0 +1,53 @@
+require "../spec_helper"
+
+describe Jennifer::Model::ParameterConverter do
+  converter = Jennifer::Model::ParameterConverter.new
+
+  describe "#parse" do
+    it { converter.parse("1", "String?").is_a?(String).should be_true }
+    it { converter.parse("1", "Int16").is_a?(Int16).should be_true }
+    it { converter.parse("1", "Int32").is_a?(Int32).should be_true }
+    it { converter.parse("1", "Primary32").is_a?(Int32).should be_true }
+    it { converter.parse("1", "Primary64").is_a?(Int64).should be_true }
+    it { converter.parse("1", "Float64").is_a?(Float64).should be_true }
+    it { converter.parse("1", "Float32?").class.should eq(Float32) }
+    it { converter.parse("1", "Bool").is_a?(Bool).should be_true }
+    it { converter.parse("1", "JSON::Any?").is_a?(JSON::Any).should be_true }
+    it { converter.parse("2010-12-10", "Time?").is_a?(Time).should be_true }
+    it { converter.parse("1", "Numeric?").is_a?(PG::Numeric).should be_true }
+    it { converter.parse(%(["1"]), "Array(String)").class.should eq(Array(String)) }
+  end
+
+  postgres_only do
+    describe "#to_numeric" do
+      it { converter.to_numeric("1").to_s.should eq("1") }
+      it { converter.to_numeric("12345").to_s.should eq("12345") }
+      it { converter.to_numeric("9999").to_s.should eq("9999") }
+      it { converter.to_numeric("-1").to_s.should eq("-1") }
+      it { converter.to_numeric("1.12345").to_s.should eq("1.12345") }
+      it { converter.to_numeric("-1.12345").to_s.should eq("-1.12345") }
+    end
+  end
+
+  describe "#to_time" do
+    it { converter.to_time("2010-10-10").should eq(Time.new(2010, 10, 10)) }
+    it { converter.to_time("2010-10-10 20:10:10").should eq(Time.new(2010, 10, 10, 20, 10, 10)) }
+  end
+
+  describe "#to_b" do
+    it { converter.to_b("1").should be_true }
+    it { converter.to_b("true").should be_true }
+    it { converter.to_b("t").should be_true }
+    it { converter.to_b("0").should be_false }
+    it { converter.to_b("").should be_false }
+  end
+
+  describe "#to_array" do
+    it { converter.to_array("[1]", "Array(Int32)").should eq([1]) }
+    it { converter.to_array("[1]", "Array(Int16)").should eq([1i16]) }
+    it { converter.to_array("[1]", "Array(Int64)").should eq([1i64]) }
+    it { converter.to_array(%(["1"]), "Array(String)").should eq(["1"]) }
+    it { converter.to_array("[1.0]", "Array(Float32)").should eq([1f32]) }
+    it { converter.to_array("[1.0]", "Array(Float64)").should eq([1.0]) }
+  end
+end

--- a/src/jennifer/adapter.cr
+++ b/src/jennifer/adapter.cr
@@ -5,7 +5,7 @@ module Jennifer
   alias AnyArgument = AnyResult | Array(AnyResult)
 
   alias DBAny = Array(Int32) | Array(Char) | Array(Float32) | Array(Float64) |
-                Array(Int16) | Array(Int32) | Array(Int64) | Array(String) |
+                Array(Int16) | Array(Int64) | Array(String) |
                 Bool | Char | Float32 | Float64 | Int8 | Int16 | Int32 | Int64 | JSON::Any | PG::Geo::Box |
                 PG::Geo::Circle | PG::Geo::Line | PG::Geo::LineSegment | PG::Geo::Path | PG::Geo::Point |
                 PG::Geo::Polygon | PG::Numeric | Slice(UInt8) | String | Time | UInt32 | Nil

--- a/src/jennifer/adapter/shared/types.cr
+++ b/src/jennifer/adapter/shared/types.cr
@@ -2,6 +2,8 @@
 # all adapters
 module PG
   struct Numeric
+    def initialize(ndigits, weight, sign, dscale, digits)
+    end
   end
 
   module Geo

--- a/src/jennifer/model/base.cr
+++ b/src/jennifer/model/base.cr
@@ -5,6 +5,7 @@ require "./callback"
 require "./relation_definition"
 require "./scoping"
 require "./translation"
+require "./parameter_converter"
 
 module Jennifer
   module Model
@@ -61,6 +62,14 @@ module Jennifer
 
       def self.star
         context.star
+      end
+
+      def self.parameter_converter
+        @@converter ||= ParameterConverter.new
+      end
+
+      def self.build_params(hash : Hash(String, String)) : Hash(String, Jennifer::DBAny)
+        {} of String => Jennifer::DBAny
       end
 
       def self.build(values : Hash(Symbol, ::Jennifer::DBAny) | NamedTuple)

--- a/src/jennifer/model/mapping.cr
+++ b/src/jennifer/model/mapping.cr
@@ -266,6 +266,24 @@ module Jennifer
           WITH_DEFAULT_CONSTRUCTOR = false
         {% end %}
 
+        # Converts String based hash to `Hash(String, Jennifer::DBAny)`
+        def self.build_params(hash : Hash(String, String)) : Hash(String, Jennifer::DBAny)
+          converted_hash = super(hash)
+          hash.each do |key, value|
+            case key.to_s
+            {% for field, opts in properties %}
+            when {{field.id.stringify}}
+              if value.empty?
+                converted_hash[key] = nil
+              else
+                converted_hash[key] = parameter_converter.parse(value, {{opts[:stringified_type]}})
+              end
+            {% end %}
+            end 
+          end
+          converted_hash
+        end
+
         # Extracts arguments due to mapping from *pull* and returns tuple for
         # fields assignment. It stands on that fact result set has all defined fields in a raw
         # TODO: think about moving it to class scope

--- a/src/jennifer/model/parameter_converter.cr
+++ b/src/jennifer/model/parameter_converter.cr
@@ -1,0 +1,138 @@
+module Jennifer
+  module Model
+    class ParameterConverter
+      def parse(value, str_class)
+        case str_class
+        when /Array/
+          to_array(value, str_class)
+        when /String/
+          to_s(value)
+        when /Int16/
+          to_i16(value)
+        when /Int64/, /Primary64/
+          to_i64(value)
+        when /Int/, /Primary32/
+          to_i(value)
+        when /Float32/
+          to_f32(value)
+        when /Float/
+          to_f(value)
+        when /Bool/
+          to_b(value)
+        when /JSON/
+          to_json(value)
+        when /Time/
+          to_time(value)
+        when /Numeric/
+          to_numeric(value)
+        else
+          raise ArgumentError.new
+        end
+      end
+
+      def to_pr32(value)
+        to_i(value)
+      end
+
+      def to_pr64(value)
+        to_i64(value)
+      end
+
+      def to_s(value)
+        value
+      end
+
+      def to_i16(value)
+        value.to_i16
+      end
+
+      def to_i64(value)
+        value.to_i64
+      end
+
+      def to_i(value)
+        value.to_i
+      end
+
+      def to_f(value)
+        value.to_f
+      end
+
+      def to_f32(value)
+        value.to_f32
+      end
+
+      def to_b(value)
+        value == "true" || value == "1" || value == "t"
+      end
+
+      def to_json(value)
+        JSON.parse(value)
+      end
+
+      def to_time(value)
+        format = value =~ / / ? "%F %T" : "%F"
+        Time.parse(value, format)
+      end
+
+      def to_numeric(value)
+        value = value.strip
+        raise ArgumentError.new unless value =~ /-{0,1}\d+(.\d+){0,1}/
+        sign = 
+          if value[0] == '-'
+            value = value[1..-1]
+            0x4000
+          else
+            0i16
+          end
+
+        number = to_f(value)
+        size = value.size
+        weight = value.index('.') || -1
+        if weight == -1
+          int_part = value
+          digits = str_to_i16_array(int_part)
+          PG::Numeric.new(digits.size.to_i16, (digits.size - 1).to_i16, sign, 0i16, digits)
+        else
+          int_part = value[0...weight]
+          digits = str_to_i16_array(int_part)
+          int_digits_size = digits.size
+          str_to_i16_array(value[(weight + 1)..-1], digits)
+          PG::Numeric.new(digits.size.to_i16, (int_digits_size - 1).to_i16, sign, (digits.size - int_digits_size).to_i16, digits)
+        end
+      end
+
+      def to_array(value, str_class)
+        array = to_json(value)
+        case str_class
+        when /Int32/
+          array.map(&.as_i)
+        when /Float32/
+          array.map(&.as_f32)
+        when /Float64/
+          array.map(&.as_f)
+        when /Int16/
+          array.map(&.as_i.to_i16)
+        when /Int64/
+          array.map(&.as_i64)
+        when /String/
+          array.map(&.as_s)
+        else
+          raise ArgumentError.new
+        end
+      end
+
+      private def str_to_i16_array(value, out_array = Array(Int16).new(1))
+        weight = value.size
+        start_i, end_i = 0, 4
+        while true
+          out_array << value[start_i...end_i].to_i16
+          break if weight <= end_i
+          start_i = end_i
+          end_i += 4
+        end
+        out_array
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds `Jennifer::Model::Base.build_params` which allows to build `Hash(String, Jennifer::DBAny)` from `Hash(String, String)` respecting model attributes types.