### PR TITLE
Add fix for CriteriaContainer yilding nilable

### DIFF
--- a/src/jennifer/query_builder/criteria_container.cr
+++ b/src/jennifer/query_builder/criteria_container.cr
@@ -15,7 +15,8 @@ module Jennifer
 
       def each
         @key_bucket.each do |internal_key, criteria|
-          yield({criteria, @value_bucket[internal_key]})
+          # NOTE: somewhy compiling with Amber makes Hash(String, String)#[] to return String?
+          yield({criteria, @value_bucket[internal_key].not_nil!})
         end
       end
 


### PR DESCRIPTION
Somewhy in Amber `Jennifer::QueryBuilder::CriteriaContainer`'s `@bucket : Hash(String, String)` returns `String | Nil` from the `#[]` method call. For now Have no idea why does this happen.