### PR TITLE
Migration version now is parsed from file name

### DIFF
--- a/examples/migrations/20170122152105921_add_passport.cr
+++ b/examples/migrations/20170122152105921_add_passport.cr
@@ -1,4 +1,4 @@
-class Passport20170122152105921 < Jennifer::Migration::Base
+class AddPassport < Jennifer::Migration::Base
   def up
     create_table(:passports, false) do |t|
       t.string(:enn, {:primary => true, :size => 5})

--- a/examples/migrations/20170410221437549_add_join_table.cr
+++ b/examples/migrations/20170410221437549_add_join_table.cr
@@ -1,4 +1,4 @@
-class AddJoinTable20170410221437549 < Jennifer::Migration::Base
+class AddJoinTable < Jennifer::Migration::Base
   def up
     create_table(:countries) do |t|
       t.string(:name)

--- a/examples/migrations/20170815112803321_add_model_with_one_field.cr
+++ b/examples/migrations/20170815112803321_add_model_with_one_field.cr
@@ -1,4 +1,4 @@
-class ModelWithOneField20170815112803321 < Jennifer::Migration::Base
+class AddModelWithOneField20170815112803321 < Jennifer::Migration::Base
   def up
     create_table(:one_field_models) do |t|
     end

--- a/examples/migrations/20170916095004544_add_view.cr
+++ b/examples/migrations/20170916095004544_add_view.cr
@@ -1,4 +1,4 @@
-class AddView20170916095004544 < Jennifer::Migration::Base
+class AddView < Jennifer::Migration::Base
   def up
     # TODO: allow escaping arguments instead of prepared statement
     create_view(:male_contacts, Jennifer::Query["contacts"].where { sql("gender = 'male'") })

--- a/src/jennifer/adapter/base.cr
+++ b/src/jennifer/adapter/base.cr
@@ -208,9 +208,9 @@ module Jennifer
       # migration ========================
 
       def ready_to_migrate!
-        return if table_exists?(Migration::Base::TABLE_NAME)
-        schema_processor.build_create_table(Migration::Base::TABLE_NAME) do |t|
-          t.string(:version, {:size => 17})
+        return if table_exists?(Migration::Version.table_name)
+        schema_processor.build_create_table(Migration::Version.table_name) do |t|
+          t.string(:version, {:size => 17, :null => false})
         end
       end
 

--- a/src/jennifer/adapter/base_sql_generator.cr
+++ b/src/jennifer/adapter/base_sql_generator.cr
@@ -1,8 +1,16 @@
 module Jennifer
   module Adapter
-    class BaseSQLGenerator
-      ARRAY_ESCAPE = "\\\\\\\\"
+    abstract class BaseSQLGenerator
+      ARRAY_ESCAPE           = "\\\\\\\\"
       ARGUMENT_ESCAPE_STRING = "%s"
+
+      module ClassMethods
+        # Generates query for inserting new record to db
+        abstract def insert(obj : Model::Base)
+        abstract def json_path(path : QueryBuilder::JSONSelector)
+      end
+
+      extend ClassMethods
 
       # Generates insert query
       def self.insert(table, hash)
@@ -11,12 +19,6 @@ module Jennifer
           hash.keys.join(", ", s)
           s << ") VALUES (" << escape_string(hash.size) << ")"
         end
-      end
-
-      # Generates query for inserting new record to db
-      def self.insert(obj : Model::Base)
-        # NOTE: is overrided by each adapter
-        raise "Not implemented"
       end
 
       def self.bulk_insert(table : String, field_names : Array(String), rows : Int32)
@@ -224,10 +226,6 @@ module Jennifer
         else
           operator.to_s
         end
-      end
-
-      def self.json_path(path : QueryBuilder::JSONSelector)
-        raise "Not Implemented"
       end
 
       def self.quote(value : Nil)

--- a/src/jennifer/migration/runner.cr
+++ b/src/jennifer/migration/runner.cr
@@ -3,39 +3,34 @@ module Jennifer
     module Runner
       MIGRATION_DATE_FORMAT = "%Y%m%d%H%M%S%L"
 
-      def self.migrate(count)
+      @@migration_classes = {} of String => Base.class
+      @@pending_versions = [] of String
+
+      def self.migration_classes
+        if @@migration_classes.empty?
+          Base.migrations.each { |m| @@migration_classes[m.version] = m }
+        end
+        @@migration_classes
+      end
+
+      def self.pending_versions
+        if @@pending_versions.empty?
+          @@pending_versions = (migration_classes.keys - Version.list).sort!
+        end
+        @@pending_versions
+      end
+
+      # Invokes migrations. *count* with negative or zero value will invoke all pending migrations.
+      def self.migrate(count : Int)
         performed = false
         default_adapter.ready_to_migrate!
-        return if ::Jennifer::Migration::Base.migrations.empty?
-        interpolation = {} of String => typeof(Base.migrations[0])
-        Base.migrations.each { |m| interpolation[m.version] = m }
+        return if Base.migrations.empty? || pending_versions.empty?
+        assert_outdated_pending_migrations
 
-        pending = interpolation.keys - Version.all.pluck(:version).map(&.as(String))
-        return if pending.empty?
-        brocken = Version.where { _version.in(pending) }.pluck(:version).map(&.as(String))
-        unless brocken.empty?
-          puts "Can't run migrations because some of them are older then relase version.\nThey are:"
-          brocken.sort.each do |v|
-            puts "- #{v}"
-          end
-          return
-        end
-
-        i = 0
-        pending.sort.each do |p|
+        pending_versions.each_with_index do |p, i|
           return if count > 0 && i >= count
+          process_up_migration(migration_classes[p].new)
           performed = true
-          klass = interpolation[p]
-          puts "Migration #{klass}"
-          instance = klass.new
-          begin
-            instance.up
-          rescue e
-            puts "rollbacked"
-            puts e.message
-            raise e
-          end
-          Version.create({version: p})
         end
       rescue e
         puts e.message
@@ -64,9 +59,7 @@ module Jennifer
       def self.rollback(options : Hash(Symbol, DBAny))
         processed = true
         default_adapter.ready_to_migrate!
-        return if ::Jennifer::Migration::Base.migrations.empty? || !Version.all.exists?
-        interpolation = {} of String => typeof(Base.migrations[0])
-        Base.migrations.each { |m| interpolation[m.version] = m }
+        return if Base.migrations.empty? || !Version.all.exists?
 
         versions =
           if options[:count]?
@@ -79,11 +72,8 @@ module Jennifer
           end
 
         versions.each do |v|
-          klass = interpolation[v]
-          klass.new.down
-          Version.all.where { _version == v }.delete
+          process_down_migration(migration_classes[v].new)
           processed = true
-          puts "Droped migration #{v}"
         end
       rescue e
         puts e.message
@@ -92,19 +82,40 @@ module Jennifer
         default_adapter_class.generate_schema if processed
       end
 
+      def self.assert_outdated_pending_migrations
+        return unless Version.all.exists?
+        db_version = Version.all.order(version: :desc).limit(1).pluck(:version)[0].as(String)
+        brocken = pending_versions.select { |version| version < db_version }
+        unless brocken.empty?
+          message = <<-MESSAGE
+          Can't run migrations because some of them are older then relase version.
+          They are:
+          #{brocken.map { |v| "- #{v}" }.join("\n")}
+          MESSAGE
+          raise message
+        end
+      end
+
       def self.load_schema
-        # TODO: load schema for each adapter
+        # TODO: add loading schema for each adapter
         default_adapter_class.load_schema
       end
 
-      def self.generate(name)
+      def self.generate(name : String)
         time = Time.now.to_s(MIGRATION_DATE_FORMAT)
-        migration_name = name.camelcase + time
-        str = "class #{migration_name} < Jennifer::Migration::Base\n  def up\n  end\n\n  def down\n  end\nend\n"
-        File.write(File.join(Config.migration_files_path.to_s, "#{time}_#{name.underscore}.cr"), str)
+        migration_name = name.camelcase
+        str = <<-MIGRATION
+        class #{migration_name} < Jennifer::Migration::Base
+          def up
+          end
+
+          def down
+          end
+        end
+
+        MIGRATION
+        File.write(File.join(Config.migration_files_path.to_s, "#{time}_#{migration_name}.cr"), str)
         puts "Migration #{migration_name} was generated"
-      rescue e
-        puts e.message
       end
 
       def self.default_adapter
@@ -113,6 +124,48 @@ module Jennifer
 
       def self.default_adapter_class
         Adapter.default_adapter_class
+      end
+
+      private def self.process_up_migration(migration)
+        migration_processed = false
+        begin
+          transaction { migration.up }
+          Version.create(version: migration.class.version)
+          migration_processed = true
+          puts "Migration #{migration.class}"
+        ensure
+          transaction do
+            case Config.migration_failure_handler_method
+            when "reverse_direction"
+              migration.down
+            when "callback"
+              migration.after_up_failure
+            end
+          end
+        end
+      end
+
+      private def self.process_down_migration(migration)
+        migration_processed = false
+        begin
+          transaction { migration.down }
+          Version.all.where { _version == migration.class.version }.delete
+          migration_processed = true
+          puts "Droped migration #{migration.class}"
+        ensure
+          transaction do
+            case Config.migration_failure_handler_method
+            when "reverse_direction"
+              migration.up
+            when "callback"
+              migration.after_down_failure
+            end
+          end
+        end
+      end
+
+      private def self.transaction
+        Model::Base.transaction { yield }
       end
     end
   end

--- a/src/jennifer/migration/version.cr
+++ b/src/jennifer/migration/version.cr
@@ -10,6 +10,10 @@ module Jennifer
       def self.has_table?
         false
       end
+
+      def self.list
+        all.pluck(:version).map(&.as(String))
+      end
     end
   end
 end


### PR DESCRIPTION
- adds `Jennifer::Config.migration_failure_handler_method` configuration - represents which kind of method will be invoked if migration (any up or  down) is failed
- introduced failures callbacks: `#after_up_failure` & `#after_down_failure`
- now migration class name has no timestamp in name - version is retrieved from the file name
- any migration method and failure callbacks is wrapped into transaction