### PR TITLE
Allow to specify document subpart for reading configuration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,7 +48,20 @@ Jennifer::Config.configure do |conf|
 end
 ```
 
-All configs:
+If your configurations aren't stored on the top level - you can manipulate which document subpart will be used to parse parameters:
+
+```crystal
+Jennifer::Config.read("./spec/fixtures/database.yml", &.["database"]["development"])
+```
+
+Also configuration can be parsed directly from URI:
+
+```crystal
+db_uri = "mysql://root@somehost/some_database?max_pool_size=111&initial_pool_size=222&max_idle_pool_size=333&retry_attempts=444&checkout_timeout=555&retry_delay=666"
+Jennifer::Config.from_uri(db)
+```
+
+## Supported configuation parameters
 
 | config | default value |
 | --- | --- |
@@ -72,14 +85,7 @@ All configs:
 
 > `port = -1` will provide connection URI without port mention
 
-Also configuration can be parsed directly from URI:
-
-```crystal
-db_uri = "mysql://root@somehost/some_database?max_pool_size=111&initial_pool_size=222&max_idle_pool_size=333&retry_attempts=444&checkout_timeout=555&retry_delay=666"
-Jennifer::Config.from_uri(db)
-```
-
-#### Logging
+## Logging
 
 Jennifer uses regular Crystal logging mechanism so you could specify your own logger or formatter:
 

--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -1,22 +1,24 @@
 require "./spec_helper"
 
 describe Jennifer::Config do
+  config = Jennifer::Config.config
+
   describe "::read" do
     it "reads data from yaml file" do
-      begin
-        Jennifer::Config.read("./spec/fixtures/database.yml")
-        Jennifer::Config.config.db.should eq("jennifer_develop")
-      ensure
-        Jennifer::Config.config.db = "jennifer_test"
-      end
+      config.read("./spec/fixtures/database.yml")
+      config.db.should eq("jennifer_develop")
+    end
+
+    it "" do
+      config.read("./spec/fixtures/database_with_nesting.yml", &.["database"]["development"])
+      config.db.should eq("jennifer_develop")
     end
   end
 
   describe "::from_uri" do
     it "should parse uri string" do
       db_uri = "mysql://root:password@somehost:3306/some_database"
-      Jennifer::Config.from_uri(db_uri)
-      config = Jennifer::Config
+      config.from_uri(db_uri)
       config.adapter.should eq("mysql")
       config.user.should eq("root")
       config.password.should eq("password")
@@ -27,11 +29,11 @@ describe Jennifer::Config do
 
     it "expects adapter and database at very least" do
       expect_raises(Jennifer::InvalidConfig, /No database configured/) do
-        Jennifer::Config.configure {|c| c.db = ""}
+        config.configure { |c| c.db = "" }
       end
 
       expect_raises(Jennifer::InvalidConfig, /No adapter configured/) do
-        Jennifer::Config.configure do |c|
+        config.configure do |c|
           c.db = "somedb"
           c.adapter = ""
         end
@@ -40,19 +42,19 @@ describe Jennifer::Config do
 
     it "should ignore port if not supplied" do
       db_uri = "mysql://root@somehost/some_database"
-      Jennifer::Config.from_uri(db_uri)
-      Jennifer::Config.port.should eq(-1)
+      config.from_uri(db_uri)
+      config.port.should eq(-1)
     end
 
     it "should parse connection params from the uri" do
       db_uri = "mysql://root@somehost/some_database?max_pool_size=111&initial_pool_size=222&max_idle_pool_size=333&retry_attempts=444&checkout_timeout=555&retry_delay=666"
-      Jennifer::Config.from_uri(db_uri)
-      Jennifer::Config.max_pool_size.should eq(111)
-      Jennifer::Config.initial_pool_size.should eq(222)
-      Jennifer::Config.max_idle_pool_size.should eq(333)
-      Jennifer::Config.retry_attempts.should eq(444)
-      Jennifer::Config.checkout_timeout.should eq(555)
-      Jennifer::Config.retry_delay.should eq(666)
+      config.from_uri(db_uri)
+      config.max_pool_size.should eq(111)
+      config.initial_pool_size.should eq(222)
+      config.max_idle_pool_size.should eq(333)
+      config.retry_attempts.should eq(444)
+      config.checkout_timeout.should eq(555)
+      config.retry_delay.should eq(666)
     end
   end
 end

--- a/spec/fixtures/database_with_nesting.yml
+++ b/spec/fixtures/database_with_nesting.yml
@@ -1,0 +1,15 @@
+database:
+  defaults : &defaults
+    host: localhost
+    adapter: postgres
+    user: developer
+    password: 1qazxsw2
+    migration_files_path: ./examples/migrations
+
+  development:
+    db: jennifer_develop
+    <<: *defaults
+
+  test:
+    db: jennifer_test
+    <<: *defaults

--- a/src/jennifer/config.cr
+++ b/src/jennifer/config.cr
@@ -156,7 +156,14 @@ module Jennifer
 
     def self.read(path : String, env : String | Symbol = :development)
       _env = env.to_s
-      source = YAML.parse(File.read(path))[_env]
+      read(path) { |document| document[_env] }
+    end
+
+    # Reads configuration file by given ~path~ and yields it's content to block. Returned document is realized
+    # as configurations.
+    def self.read(path : String)
+      source = yield YAML.parse(File.read(path))
+
       {% for field in STRING_FIELDS %}
         @@{{field.id}} = source["{{field.id}}"].as_s if source["{{field.id}}"]?
       {% end %}


### PR DESCRIPTION
- now `Jennifer::Config::read` accepts block which returned value will be parsed for setting configuration parameters