### PR TITLE
Refactor generated relation methods

### DIFF
--- a/spec/model/base_spec.cr
+++ b/spec/model/base_spec.cr
@@ -385,14 +385,6 @@ describe Jennifer::Model::Base do
     end
   end
 
-  describe "::relations" do
-    it "returns hash of relation objects" do
-      rels = Contact.relations
-      rels.is_a?(Hash).should be_true
-      rels.empty?.should be_false
-    end
-  end
-
   describe "#destroy" do
     it "deletes from db" do
       contact = Factory.create_contact

--- a/spec/model/relation_definition_spec.cr
+++ b/spec/model/relation_definition_spec.cr
@@ -69,9 +69,9 @@ describe Jennifer::Model::RelationDefinition do
   end
 
   describe "%has_many" do
-    it "adds relation name to RELATION_NAMES constant" do
-      Contact::RELATION_NAMES.size.should eq(6)
-      Contact::RELATION_NAMES[0].should eq("addresses")
+    it "adds relation name to RELATIONS constant" do
+      Contact::RELATIONS.size.should eq(6)
+      Contact::RELATIONS.has_key?("addresses").should be_true
     end
 
     context "query" do
@@ -126,6 +126,14 @@ describe Jennifer::Model::RelationDefinition do
           a = Factory.create_address(contact_id: c.id)
           count = query_count
           c.addresses[0].contact
+          query_count.should eq(count + 1)
+        end
+
+        it "sets owner during building collection 2" do
+          c = Factory.create_contact
+          a = Factory.create_facebook_profile(contact_id: c.id)
+          count = query_count
+          c.facebook_profiles[0].contact
           query_count.should eq(count + 1)
         end
       end
@@ -198,9 +206,9 @@ describe Jennifer::Model::RelationDefinition do
   end
 
   describe "%belongs_to" do
-    it "adds relation name to RELATION_NAMES constant" do
-      Address::RELATION_NAMES.size.should eq(1)
-      Address::RELATION_NAMES[0].should eq("contact")
+    it "adds relation name to RELATIONS constant" do
+      Address::RELATIONS.size.should eq(1)
+      Address::RELATIONS.has_key?("contact").should be_true
     end
 
     context "query" do
@@ -285,8 +293,8 @@ describe Jennifer::Model::RelationDefinition do
   end
 
   describe "%has_one" do
-    it "adds relation name to RELATION_NAMES constant" do
-      Contact::RELATION_NAMES[0].should eq("addresses")
+    it "adds relation name to RELATIONS constant" do
+      Contact::RELATIONS.has_key?("addresses").should be_true
     end
 
     context "query" do
@@ -333,6 +341,14 @@ describe Jennifer::Model::RelationDefinition do
           a = Factory.create_address(contact_id: c.id, main: true)
           count = query_count
           c.main_address!.contact
+          query_count.should eq(count + 1)
+        end
+
+        it "sets owner during building collection 2" do
+          c = Factory.create_contact
+          a = Factory.create_passport(contact_id: c.id)
+          count = query_count
+          c.passport!.contact
           query_count.should eq(count + 1)
         end
       end
@@ -497,6 +513,30 @@ describe Jennifer::Model::RelationDefinition do
         country.__contacts_clean
         q.exists?.should be_false
       end
+    end
+  end
+
+  describe "#relation_retrieved" do
+    describe "sti" do
+      context "with unknown relation" do
+        it { expect_raises(Jennifer::UnknownRelation) { Factory.create_facebook_profile.relation_retrieved("unknown") } }
+      end
+
+      context "with own relation" do
+        it { Factory.create_facebook_profile.relation_retrieved("facebook_contacts") }
+      end
+
+      context "with parent relation" do
+        it { Factory.create_facebook_profile.relation_retrieved("contact") }
+      end
+    end
+
+    context "with unknown relation" do
+      it { expect_raises(Jennifer::UnknownRelation) { Factory.create_contact.relation_retrieved("unknown") } }
+    end
+
+    context "with own relation" do
+      it { Factory.create_contact.relation_retrieved("passport") }
     end
   end
 end

--- a/spec/models.cr
+++ b/spec/models.cr
@@ -61,11 +61,11 @@ class Contact < ApplicationRecord
   {% end %}
 
   has_many :addresses, Address, inverse_of: :contact
-  has_many :facebook_profiles, FacebookProfile
+  has_many :facebook_profiles, FacebookProfile, inverse_of: :contact
   has_and_belongs_to_many :countries, Country
   has_and_belongs_to_many :facebook_many_profiles, FacebookProfile, association_foreign: :profile_id
   has_one :main_address, Address, {where { _main }}, inverse_of: :contact
-  has_one :passport, Passport
+  has_one :passport, Passport, inverse_of: :contact
 
   validates_inclusion :age, 13..75
   validates_length :name, minimum: 1
@@ -142,7 +142,7 @@ class Profile < ApplicationRecord
     login: String,
     contact_id: Int32?,
     type: String,
-    virtual_parent_field: { type: String?, virtual: true }
+    virtual_parent_field: {type: String?, virtual: true}
   )
 
   getter commit_callback_called = false
@@ -159,7 +159,7 @@ end
 class FacebookProfile < Profile
   mapping(
     uid: String?, # for testing purposes
-    virtual_child_field: { type: Int32?, virtual: true }
+    virtual_child_field: {type: Int32?, virtual: true}
   )
 
   getter fb_commit_callback_called = false
@@ -194,8 +194,8 @@ class Country < Jennifer::Model::Base
   has_and_belongs_to_many :contacts, Contact
   has_many :cities, City, inverse_of: :country
 
-  {% for callback in %i(before_save after_save after_create before_create after_initialize 
-                        before_destroy after_destroy before_update after_update) %}
+  {% for callback in %i(before_save after_save after_create before_create after_initialize
+                       before_destroy after_destroy before_update after_update) %}
     getter {{callback.id}}_attr = false
 
     {{callback.id}} {{callback}}_check
@@ -239,15 +239,15 @@ class OneFieldModel < Jennifer::Model::Base
 end
 
 # ===================
-# synthetic models 
+# synthetic models
 # ===================
 
 class CountryWithTransactionCallbacks < ApplicationRecord
   table_name "countries"
 
   mapping({
-    id: Primary32,
-    name: String
+    id:   Primary32,
+    name: String,
   })
 
   {% for action in [:create, :save, :destroy, :update] %}
@@ -269,8 +269,8 @@ class CountryWithValidationCallbacks < ApplicationRecord
   table_name "countries"
 
   mapping({
-    id: Primary32,
-    name: String
+    id:   Primary32,
+    name: String,
   })
 
   before_validation :raise_skip, :before_validation_method
@@ -389,7 +389,7 @@ class AbstractContactModel < Jennifer::Model::Base
   mapping({
     id:   Primary32,
     name: String?,
-    age: Int32
+    age:  Int32,
   }, false)
 end
 
@@ -406,11 +406,11 @@ end
 
 class MaleContact < Jennifer::View::Base
   mapping({
-    id:     Primary32,
-    name:   String,
-    gender: String,
-    age:    Int32,
-    created_at: Time?
+    id:         Primary32,
+    name:       String,
+    gender:     String,
+    age:        Int32,
+    created_at: Time?,
   }, false)
 
   scope :main { where { _age < 50 } }
@@ -426,11 +426,11 @@ class FakeFemaleContact < Jennifer::View::Base
   view_name "female_contacs"
 
   mapping({
-    id:     Primary32,
-    name:   String,
-    gender: String,
-    age:    Int32,
-    created_at: Time?
+    id:         Primary32,
+    name:       String,
+    gender:     String,
+    age:        Int32,
+    created_at: Time?,
   }, false)
 end
 

--- a/src/jennifer/model/base.cr
+++ b/src/jennifer/model/base.cr
@@ -13,13 +13,6 @@ module Jennifer
       include Validation
       include Callback
 
-      module ClassMethods
-        abstract def relations
-        abstract def relation(name)
-      end
-
-      extend ClassMethods
-
       @@table_name : String?
       @@foreign_key_name : String?
       @@actual_table_field_count : Int32?
@@ -242,14 +235,8 @@ module Jennifer
         ::Jennifer::Model::Callback.inherited_hook
         ::Jennifer::Model::RelationDefinition.inherited_hook
 
-        @@relations = {} of String => ::Jennifer::Relation::IRelation
-
         after_save :__refresh_changes
         before_save :__check_if_changed
-
-        def self.relations
-          @@relations
-        end
 
         def self.superclass
           {{@type.superclass}}
@@ -260,9 +247,9 @@ module Jennifer
           ::Jennifer::Model::Callback.finished_hook
 
           def self.relation(name : String)
-            @@relations[name]
+            RELATIONS[name]
           rescue e : KeyError
-            raise Jennifer::UnknownRelation.new(self, e)
+            super(name)
           end
         end
       end

--- a/src/jennifer/model/resource.cr
+++ b/src/jennifer/model/resource.cr
@@ -16,6 +16,12 @@ module Jennifer
       include Scoping
       include RelationDefinition
 
+      module ClassMethods
+        abstract def relation(name)
+      end
+
+      extend ClassMethods
+
       alias Supportable = DBAny | self
 
       @@expression_builder : QueryBuilder::ExpressionBuilder?
@@ -87,11 +93,11 @@ module Jennifer
         context.star
       end
 
-      def append_relation(name : String, hash)
-        raise Jennifer::UnknownRelation.new(self.class, name)
+      def self.relation(name)
+        raise Jennifer::UnknownRelation.new(self, name)
       end
 
-      def relation_retrieved(name : String)
+      def append_relation(name : String, hash)
         raise Jennifer::UnknownRelation.new(self.class, name)
       end
 

--- a/src/jennifer/view/base.cr
+++ b/src/jennifer/view/base.cr
@@ -52,19 +52,18 @@ module Jennifer
         true
       end
 
+      def self.relation(name)
+        raise Jennifer::UnknownRelation.new(self, KeyError.new(name))
+      end
+
       macro inherited
         AFTER_INITIALIZE_CALLBACKS = [] of String
-
-        # NOTE: stub for query builder
-        @@relations = {} of String => ::Jennifer::Relation::IRelation
-        def self.relations
-          @@relations
-        end
+        RELATIONS = {} of String => ::Jennifer::Relation::IRelation
 
         def self.relation(name : String)
-          @@relations[name]
+          RELATIONS[name]
         rescue e : KeyError
-          raise Jennifer::UnknownRelation.new(self, e)
+          super(name)
         end
 
         # NOTE: override regular behavior - used fields count instead of


### PR DESCRIPTION
- small refactoring of methods generated by relation definition macros.
- removes `Jennifer::Model::Base#relations`
- now relation objects are stored in constants