### PR TITLE
Add custom errors container

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+# What does this PR do?
+
+# Any background context you want to provide?
+
+# Release notes
+
+Please fill corresponding section regarding this pull request notes below instead of modifying `CHANGELOG.md` file.
+
+**General**
+
+**QueryBuilder**
+
+**Model**
+
+**View**
+
+**Adapter**
+
+**Config**
+
+**SqlGenerator**
+
+**Migration**
+
+**Record**
+
+**Exceptions**
+
+> NOTE: please remove all redundant sections before posting request.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+# 0.5.1 (02-05-2018)
+
+**QueryBuilder**
+
+* fixes bug with compiling application without defined any model (as a result no `ModelQuery` class is defined as well)
+* allows to pass sql arguments to left hand condition statement
+* fixes bug with invalid order direction type interpretation (#124)
+
+**Adapter**
+
+* adds command interface layer for invoking console tool utilities (e.g. for dumping database schema)
+* adds docker command interface
+
+**Config**
+
+* makes `Config` to realize singleton pattern instead of holding all data as class variables
+* adds flag to skip dumping database schema after running migrations
+* fixes connection port definition (#121)
+
 # 0.5.0 (13-02-2018)
 
 * `ifrit/core` pact is required

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# Future release (__-__-2018)
+
 # 0.5.1 (02-05-2018)
 
 **QueryBuilder**

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add this to your application's `shard.yml`:
 dependencies:
   jennifer:
     github: imdrasil/jennifer.cr
-    version: "~> 0.4.3"
+    version: "~> 0.5.1"
 ```
 
 ### Requirements

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -20,7 +20,6 @@ user.validate!
 user.valid? # true
 ```
 
-> For validation purposes is used [accord](https://github.com/neovintage/accord) shard which provides some basic functionality.
 
 ## Trigger validation
 

--- a/shard.yml
+++ b/shard.yml
@@ -27,9 +27,6 @@ dependencies:
   inflector:
     github: phoffer/inflector.cr
     version: "~> 0.1.8"
-  accord:
-    github: neovintage/accord
-    version: "~> 1.1.0"
   ifrit:
     github: imdrasil/ifrit
     version: "~> 0.1.2"

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: jennifer
-version: 0.5.0
+version: 0.5.1
 
 authors:
   - Roman Kalnytskyi <moranibaca@gmail.com>

--- a/spec/model/errors_spec.cr
+++ b/spec/model/errors_spec.cr
@@ -1,0 +1,224 @@
+require "../spec_helper"
+
+describe Jennifer::Model::Errors do
+  # TODO: add test case descriptions
+
+  described_class = Jennifer::Model::Errors
+  facebook_profile = Factory.build_facebook_profile
+
+  describe "#include?" do
+    errors = described_class.new(facebook_profile)
+    errors.add(:uid)
+
+    it { errors.include?(:uid).should be_true }
+    it { errors.include?(:name).should be_false }
+  end
+
+  describe "#clear" do
+    it do
+      errors = described_class.new(facebook_profile)
+      errors.add(:uid)
+      errors.clear
+      errors.empty?.should be_true
+    end
+  end
+
+  describe "#delete" do
+    it do
+      errors = described_class.new(facebook_profile)
+      errors.add(:uid)
+      errors.add(:id)
+      errors.delete(:id)
+      errors.keys.should eq([:uid])
+    end
+  end
+
+  describe "#[]" do
+    it do
+      errors = described_class.new(facebook_profile)
+      errors.add(:uid, "some message")
+      errors.add(:uid, :exclusion)
+      errors[:uid].should eq(["some message", "is reserved"])
+    end
+  end
+
+  describe "#[]?" do
+    pending "add" do
+    end
+  end
+
+  describe "#each" do
+    it do
+      errors = described_class.new(facebook_profile)
+      errors.add(:uid)
+      errors.add(:uid, :exclusion)
+      errors.add(:id)
+      attributes = [] of Symbol
+      messages = [] of String
+      errors.each do |attr, message|
+        attributes << attr
+        messages << message
+      end
+      messages.should eq(["is invalid", "is reserved", "is invalid"])
+      attributes.should eq(%i(uid uid id))
+    end
+  end
+
+  describe "#size" do
+    it do
+      errors = described_class.new(facebook_profile)
+      errors.add(:uid)
+      errors.add(:uid, :exclusion)
+      errors.add(:id)
+      errors.size.should eq(3)
+    end
+  end
+
+  describe "#values" do
+    it do
+      errors = described_class.new(facebook_profile)
+      errors.add(:uid)
+      errors.add(:uid, :exclusion)
+      errors.add(:id)
+      errors.values.should eq(["is invalid", "is reserved", "is invalid"])
+    end
+  end
+
+  describe "#keys" do
+    it do
+      errors = described_class.new(facebook_profile)
+      errors.add(:uid)
+      errors.add(:uid, :exclusion)
+      errors.add(:id)
+      errors.keys.should eq(%i(uid id))
+    end
+  end
+
+  describe "#empty?" do
+    it do
+      errors = described_class.new(facebook_profile)
+      errors.add(:uid)
+      errors.empty?.should be_false
+    end
+
+    it do
+      errors = described_class.new(facebook_profile)
+      errors.empty?.should be_true
+    end
+  end
+
+  describe "#any?" do
+    it do
+      errors = described_class.new(facebook_profile)
+      errors.add(:uid)
+      errors.any?.should be_true
+    end
+
+    it do
+      errors = described_class.new(facebook_profile)
+      errors.any?.should be_false
+    end
+  end
+
+  describe "#blank?" do
+    pending "add" do
+    end
+  end
+
+  describe "#add" do
+    context "with text message" do
+      it do
+        errors = described_class.new(facebook_profile)
+        errors.add(:uid, "some text")
+        errors[:uid][0].should eq("some text")
+      end
+    end
+
+    context "with symbol message" do
+      it do
+        errors = described_class.new(facebook_profile)
+        errors.add(:uid)
+        errors[:uid][0].should eq("is invalid")
+      end
+
+      it do
+        errors = described_class.new(facebook_profile)
+        errors.add(:uid, :exclusion)
+        errors[:uid][0].should eq("is reserved")
+      end
+    end
+
+    context "with count" do
+      it do
+        errors = described_class.new(facebook_profile)
+        errors.add(:uid, :too_long, 2)
+        errors[:uid][0].should eq("is too long (maximum is 2 characters)")
+      end
+    end
+
+    context "with options" do
+      it do
+        errors = described_class.new(facebook_profile)
+        errors.add(:uid, :equal_to, options: { :value => 3})
+        errors[:uid][0].should eq("must be equal to 3")
+      end
+    end
+  end
+
+  describe "#full_messages" do
+    it do
+      errors = described_class.new(facebook_profile)
+      errors.add(:uid)
+      errors.add(:uid, :exclusion)
+      errors.add(:id)
+      errors.full_messages.should eq(["Uid is invalid", "Uid is reserved", "Id is invalid"])
+    end
+  end
+
+  describe "#to_a" do
+    pending "add" do
+    end
+  end
+
+  describe "#full_messages_for" do
+    pending "add" do
+    end
+  end
+
+  describe "#full_message" do
+    pending "add" do
+    end
+  end
+
+  describe "#generate_message" do
+    errors = described_class.new(facebook_profile)
+
+    context "without count" do
+      empty_options = {count: nil, options: {} of String => String}
+
+      it { errors.generate_message(:uid, :child_error, **empty_options).should eq("uid child error") }
+      it { errors.generate_message(:id, :child_error, **empty_options).should eq("model child error") }
+      it { errors.generate_message(:id, :parent_error, **empty_options).should eq("id parent error") }
+      it { errors.generate_message(:uid, :parent_error, **empty_options).should eq("model parent error") }
+      it { errors.generate_message(:name, :global_error, **empty_options).should eq("name global error") }
+      it { errors.generate_message(:id, :global_error, **empty_options).should eq("global error") }
+      it { errors.generate_message(:id, :unknown_message, **empty_options).should eq("unknown message") }
+    end
+
+    context "with count" do
+      it { errors.generate_message(:uid, :too_long, 1, {} of String => String).should eq("is too long (maximum is 1 character)") }
+      it { errors.generate_message(:uid, :too_long, 2, {} of String => String).should eq("is too long (maximum is 2 characters)") }
+    end
+
+    context "with options" do
+      it { errors.generate_message(:uid, :equal_to, nil, {:value => "asd"}).should eq("must be equal to asd")}
+    end
+  end
+
+  describe ".new" do
+    it do
+      described_class.new(Factory.build_contact)
+      described_class.new(Factory.build_address)
+    end
+  end
+end

--- a/spec/model/mapping_spec.cr
+++ b/spec/model/mapping_spec.cr
@@ -60,11 +60,11 @@ describe Jennifer::Model::Mapping do
         contact.save!
         fail("should raise validation exception")
       rescue ex : Jennifer::RecordInvalid
-        ex.errors.size.should eq(3)
-        raw_errors = ex.errors.@errors
-        validate_error(raw_errors[0], :age, "is not included in the list")
-        validate_error(raw_errors[1], :name, "is too long (maximum is 15 characters)")
-        validate_error(raw_errors[2], :description, "Too large description")
+        contact.errors.size.should eq(3)
+        raw_errors = contact.errors
+        raw_errors[:age].should eq(["is not included in the list"])
+        raw_errors[:name].should eq(["is too long (maximum is 15 characters)"])
+        raw_errors[:description].should eq(["Too large description"])
       end
     end
 
@@ -672,9 +672,4 @@ describe Jennifer::Model::Mapping do
       ((c.updated_at! - Time.now).total_seconds < 1).should be_true
     end
   end
-end
-
-def validate_error(error, attr, message)
-  error.attr.should eq(attr)
-  error.message.should eq(message)
 end

--- a/spec/model/translation_spec.cr
+++ b/spec/model/translation_spec.cr
@@ -2,11 +2,11 @@ require "../spec_helper"
 
 describe Jennifer::Model::Translation do
   describe "::human_attribute_name" do
-    context "when attributes has localication" do
+    context "when attributes has localization" do
       it { Contact.human_attribute_name(:id).should eq("tId") }
     end
 
-    context "when attributes have no localication" do
+    context "when attributes have no localization" do
       it { Contact.human_attribute_name(:tags).should eq("Tags") }
       it { Contact.human_attribute_name(:created_at).should eq("Created at") }
     end
@@ -23,19 +23,5 @@ describe Jennifer::Model::Translation do
     it { Passport.human(1).should eq("Passport") }
     it { Passport.human(2).should eq("Many Passports") }
     it { Country.human(2).should eq("Countries") }
-  end
-
-  describe "::human_error" do
-    context "without count" do
-      klass = FacebookProfile
-      
-      it { klass.human_error(:uid, :child_error).should eq("uid child error") }
-      it { klass.human_error(:id, :child_error).should eq("model child error") }
-      it { klass.human_error(:id, :parent_error).should eq("id parent error") }
-      it { klass.human_error(:uid, :parent_error).should eq("model parent error") }
-      it { klass.human_error(:name, :global_error).should eq("name global error") }
-      it { klass.human_error(:id, :global_error).should eq("global error") }
-      it { klass.human_error(:id, :unknown_message).should eq("unknown message") }
-    end
   end
 end

--- a/src/jennifer.cr
+++ b/src/jennifer.cr
@@ -1,6 +1,5 @@
 require "inflector"
 require "inflector/string"
-require "accord"
 
 require "ifrit/converter"
 require "ifrit/core"
@@ -24,6 +23,7 @@ require "./jennifer/adapter/base"
 require "./jennifer/relation/base"
 require "./jennifer/relation/*"
 
+require "./jennifer/model/errors"
 require "./jennifer/model/base"
 
 require "./jennifer/validator"

--- a/src/jennifer/exceptions.cr
+++ b/src/jennifer/exceptions.cr
@@ -79,7 +79,7 @@ module Jennifer
   class RecordInvalid < BaseException
     getter :errors
 
-    def initialize(@errors : Accord::ErrorList)
+    def initialize(@errors : Array(String))
       @message = "Object is invalid: #{errors.inspect}"
     end
   end

--- a/src/jennifer/locale/en.yml
+++ b/src/jennifer/locale/en.yml
@@ -1,6 +1,6 @@
 jennifer:
   errors:
-    # format: "%{attribute} %{message}"
+    format: "%{attribute} %{message}"
     messages:
       # model_invalid: "Validation failed: %{errors}"
       inclusion: "is not included in the list"

--- a/src/jennifer/model/authentication.cr
+++ b/src/jennifer/model/authentication.cr
@@ -41,7 +41,7 @@ module Jennifer
         end
 
         private def validate_{{password.id}}_presence
-          errors.add(:{{password.id}}, self.class.human_error({{password}}, :blank)) if {{password_hash.id}}.blank?
+          errors.add(:{{password.id}}, :blank) if {{password_hash.id}}.blank?
         end
       end
     end

--- a/src/jennifer/model/base.cr
+++ b/src/jennifer/model/base.cr
@@ -201,7 +201,7 @@ module Jennifer
       end
 
       def save!(skip_validation : Bool = false)
-        raise Jennifer::RecordInvalid.new(errors) unless save(skip_validation)
+        raise Jennifer::RecordInvalid.new(errors.to_a) unless save(skip_validation)
         true
       end
 

--- a/src/jennifer/model/errors.cr
+++ b/src/jennifer/model/errors.cr
@@ -1,0 +1,155 @@
+module Jennifer
+  module Model
+    class Errors
+      getter base : Resource
+      getter messages : Hash(Symbol, Array(String))
+
+      def initialize(@base)
+        @messages = Hash(Symbol, Array(String)).new { |hash, key| hash[key] = [] of String }
+      end
+
+      def_clone
+
+      protected def initialize_copy(other)
+        @messages = other.@messages.dup
+        @base = other.@base
+      end
+
+      # Returns `true` if the error messages include an error for the given key
+      # `attribute`, `false` otherwise.
+      def include?(attribute : Symbol)
+        messages.has_key?(attribute) && messages[attribute].present?
+      end
+
+      # Clear the error messages.
+      def clear
+        @messages.clear
+      end
+
+      # Delete messages for `key`. Returns the deleted messages.
+      def delete(key : Symbol)
+        messages.delete(key)
+      end
+
+      # When passed a symbol or a name of a method, returns an array of errors
+      # for the method.
+      def [](attribute : Symbol)
+        messages[attribute]
+      end
+
+      def []?(attribute : Symbol)
+        messages[attribute]?
+      end
+
+      # Iterates through each error key, value pair in the error messages hash.
+      # Yields the attribute and the error for that attribute. If the attribute
+      # has more than one error message, yields once for each error message.
+      def each
+        messages.each_key do |attribute|
+          messages[attribute].each { |error| yield attribute, error }
+        end
+      end
+
+      # Returns the number of error messages.
+      def size
+        values.flatten.size
+      end
+
+      # Returns all message values.
+      def values
+        errors = [] of String
+        messages.each do |attr, array|
+          errors += array unless array.empty?
+        end
+        errors
+      end
+
+      # Returns all message keys.
+      def keys
+        attrs = [] of Symbol
+        messages.each do |key, value|
+          attrs << key unless value.empty?
+        end
+        attrs
+      end
+
+      # Returns `true` if no errors are found, `false` otherwise.
+      # If the error message is a string it can be empty.
+      def empty?
+        size == 0
+      end
+
+      def any?
+        !empty?
+      end
+
+      def blank?
+        empty?
+      end
+
+      # Adds `message` to the error messages and used validator type to `details` on `attribute`.
+      # More than one error can be added to the same `attribute`.
+      # If no `message` is supplied, `:invalid` is assumed.
+      def add(attribute : Symbol, message : String | Symbol = :invalid, count : Int? = nil, options : Hash = {} of String => String)
+        messages[attribute] << generate_message(attribute, message, count, options)
+      end
+
+      def add(attribute : Symbol, message : String | Symbol = :invalid, options : Hash = {} of String => String)
+        add(attribute, message, nil, options)
+      end
+
+      # Returns all the full error messages in an array.
+      def full_messages
+        errors = [] of String
+        each { |attribute, message| errors << full_message(attribute, message) }
+        errors
+      end
+
+      def to_a
+        full_messages
+      end
+
+      # Returns all the full error messages for a given attribute in an array.
+      def full_messages_for(attribute : Symbol)
+        messages[attribute].map { |message| full_message(attribute, message) }
+      end
+
+      # Returns a full message for a given attribute.
+      def full_message(attribute : Symbol, message : String)
+        return message if attribute == :base
+        attr_name = @base.class.human_attribute_name(attribute)
+        I18n.translate("#{Translation::GLOBAL_SCOPE}.errors.format", default: "#{attribute} #{message}", options: { "attribute" => attr_name, "message" => message })
+      end
+
+      # Translates an error message in its default scope
+      def generate_message(attribute : Symbol, message : Symbol, count, options : Hash)
+        prefix = "#{Translation::GLOBAL_SCOPE}.errors."
+        opts = { count: count, options: options}
+        i18n_key = @base.class.i18n_key
+
+        path = "#{prefix}#{i18n_key}.attributes.#{attribute}.#{message}"
+        return I18n.translate(path, **opts) if I18n.exists?(path, count: count)
+        path = "#{prefix}#{i18n_key}.#{message}"
+        return I18n.translate(path, **opts) if I18n.exists?(path, count: count)
+
+        @base.class.lookup_ancestors do |ancestor|
+          path = "#{prefix}#{ancestor.i18n_key}.attributes.#{attribute}.#{message}"
+          return I18n.translate(path, **opts) if I18n.exists?(path, count: count)
+          path = "#{prefix}#{ancestor.i18n_key}.#{message}"
+          return I18n.translate(path, **opts) if I18n.exists?(path, count: count)
+        end
+
+        path = "#{prefix}#{attribute}.#{message}"
+        return I18n.translate(path, **opts) if I18n.exists?(path, count: count)
+        path = "#{prefix}messages.#{message}"
+        return I18n.translate(path, **opts) if I18n.exists?(path, count: count)
+
+        Inflector.humanize(message).downcase
+      end
+
+      def generate_message(attribute : Symbol, message : String, count, options : Hash)
+        message
+      end
+    end
+  end
+end

--- a/src/jennifer/model/resource.cr
+++ b/src/jennifer/model/resource.cr
@@ -5,22 +5,17 @@ require "./relation_definition"
 module Jennifer
   module Model
     abstract class Resource
-      module ClassMethods
+      module AbstractClassMethods
         abstract def table_name
         abstract def build(values, new_record : Bool)
-      end
-
-      extend Ifrit
-      extend Translation
-      extend ClassMethods
-      include Scoping
-      include RelationDefinition
-
-      module ClassMethods
         abstract def relation(name)
       end
 
-      extend ClassMethods
+      extend AbstractClassMethods
+      extend Ifrit
+      extend Translation
+      include Scoping
+      include RelationDefinition
 
       alias Supportable = DBAny | self
 
@@ -28,8 +23,8 @@ module Jennifer
 
       def inspect(io) : Nil
         {% begin %}
+          io << "#<" << {{@type.name.id.stringify}} << ":0x"
           {% if @type.constant("COLUMNS_METADATA") %}
-            io << "#<" << {{@type.name.id.stringify}} << ":0x"
             object_id.to_s(16, io)
             io << ' '
             {% for var, i in @type.constant("COLUMNS_METADATA").keys %}
@@ -39,11 +34,9 @@ module Jennifer
               io << "{{var.id}}: "
               @{{var.id}}.inspect(io)
             {% end %}
-            io << '>'
-            nil
-          {% else %}
-            super(io)
           {% end %}
+          io << '>'
+          nil
         {% end %}
       end
 

--- a/src/jennifer/model/translation.cr
+++ b/src/jennifer/model/translation.cr
@@ -24,34 +24,6 @@ module Jennifer
         Inflector.humanize(attribute)
       end
 
-      def human_error(attr, message, options : Hash = {} of String => String)
-        human_error(attr, message, nil, options)
-      end
-
-      def human_error(attr, message, count : Int?, options = {} of String => String)
-        prefix = "#{GLOBAL_SCOPE}.errors."
-        opts = { count: count, options: options}
-
-        path = "#{prefix}#{i18n_key}.attributes.#{attr}.#{message}"
-        return I18n.translate(path, **opts) if I18n.exists?(path, count: count)
-        path = "#{prefix}#{i18n_key}.#{message}"
-        return I18n.translate(path, **opts) if I18n.exists?(path, count: count)
-
-        lookup_ancestors do |ancestor|
-          path = "#{prefix}#{ancestor.i18n_key}.attributes.#{attr}.#{message}"
-          return I18n.translate(path, **opts) if I18n.exists?(path, count: count)
-          path = "#{prefix}#{ancestor.i18n_key}.#{message}"
-          return I18n.translate(path, **opts) if I18n.exists?(path, count: count)
-        end
-
-        path = "#{prefix}#{attr}.#{message}"
-        return I18n.translate(path, **opts) if I18n.exists?(path, count: count)
-        path = "#{prefix}messages.#{message}"
-        return I18n.translate(path, **opts) if I18n.exists?(path, count: count)
-        
-        Inflector.humanize(message).downcase
-      end
-
       # Returns localized model name.
       def human(count = nil)
         prefix = "#{GLOBAL_SCOPE}.#{i18n_scope}."
@@ -73,13 +45,14 @@ module Jennifer
         :models
       end
 
-      # Represents key whcih be used to search any related to current class localization information.
+      # Represents key which be used to search any related to current class localization information.
       def i18n_key
         return @@i18n_key unless @@i18n_key.empty?
         @@i18n_key = Inflector.underscore(Inflector.demodulize(to_s)).downcase
       end
 
-      private def lookup_ancestors(&block)
+      def lookup_ancestors(&block)
+        return unless responds_to?(:superclass)
         klass = superclass
         while true
           yield klass

--- a/src/jennifer/model/validation.cr
+++ b/src/jennifer/model/validation.cr
@@ -2,7 +2,7 @@ module Jennifer
   module Model
     module Validation
       def errors
-        @errors ||= Accord::ErrorList.new
+        @errors ||= Errors.new(self)
       end
 
       def valid?
@@ -17,7 +17,7 @@ module Jennifer
       end
 
       def validate!(skip = false) : Bool
-        errors.clear!
+        errors.clear
         return false if skip
         return false unless __before_validation_callback
         validate
@@ -45,7 +45,7 @@ module Jennifer
           {% if allow_blank %}
             return if @{{field.id}}.nil?
           {% else %}
-            return errors.add({{field}}, self.class.human_error({{field}}, :blank)) if @{{field.id}}.nil?
+            return errors.add({{field}}, :blank) if @{{field.id}}.nil?
           {% end %}
           @{{field.id}}.not_nil!
         end
@@ -79,7 +79,7 @@ module Jennifer
         def %validate_method
           value = _not_nil_validation({{field}}, {{allow_blank}})
           unless ({{in}}).includes?(value)
-            errors.add({{field}}, self.class.human_error({{field}}, :inclusion))
+            errors.add({{field}}, :inclusion)
           end
         end
       end
@@ -90,7 +90,7 @@ module Jennifer
         def %validate_method
           value = _not_nil_validation({{field}}, {{allow_blank}})
           if ({{in}}).includes?(value)
-            errors.add(:{{field.id}}, self.class.human_error({{field}}, :exclusion))
+            errors.add(:{{field.id}}, :exclusion)
           end
         end
       end
@@ -101,7 +101,7 @@ module Jennifer
         def %validate_method
           value = _not_nil_validation({{field}}, {{allow_blank}})
           unless {{value}} =~ value
-            errors.add({{field}}, self.class.human_error({{field}}, :invalid))
+            errors.add({{field}}, :invalid)
           end
         end
       end
@@ -114,21 +114,21 @@ module Jennifer
           size = value.not_nil!.size
           {% if options[:in] %}
             if ({{options[:in]}}).max < size
-              errors.add({{field}}, self.class.human_error({{field}}, :too_long, ({{options[:in]}}).max))
+              errors.add({{field}}, :too_long, ({{options[:in]}}).max)
             elsif ({{options[:in]}}).min > size
-              errors.add({{field}}, self.class.human_error({{field}}, :too_short, ({{options[:in]}}).min))
+              errors.add({{field}}, :too_short, ({{options[:in]}}).min)
             end
           {% elsif options[:is] %}
             if {{options[:is]}} != size
-              errors.add({{field}}, self.class.human_error({{field}}, :wrong_length, {{options[:is]}}))
+              errors.add({{field}}, :wrong_length, {{options[:is]}})
             end
           {% elsif options[:minimum] %}
             if {{options[:minimum]}} > size
-              errors.add({{field}}, self.class.human_error({{field}}, :too_short, {{options[:minimum]}}))
+              errors.add({{field}}, :too_short, {{options[:minimum]}})
             end
           {% elsif options[:maximum] %}
             if {{options[:maximum]}} < size
-              errors.add({{field}}, self.class.human_error({{field}}, :too_long, {{options[:maximum]}}))
+              errors.add({{field}}, :too_long, {{options[:maximum]}})
             end
           {% end %}
         end
@@ -147,7 +147,7 @@ module Jennifer
             query = query.where { primary != this.primary }
           end
 
-          errors.add({{field}}, self.class.human_error({{field}}, :taken)) if query.exists?
+          errors.add({{field}}, :taken) if query.exists?
         end
       end
 
@@ -157,7 +157,7 @@ module Jennifer
         def %validate_method
           value = @{{field.id}}
           if value.blank?
-            errors.add({{field}}, self.class.human_error({{field}}, :blank))
+            errors.add({{field}}, :blank)
           end
         end
       end
@@ -168,7 +168,7 @@ module Jennifer
         def %validate_method
           value = @{{field.id}}
           if value.present?
-            errors.add({{field}}, self.class.human_error({{field}}, :present))
+            errors.add({{field}}, :present)
           end
         end
       end
@@ -180,42 +180,42 @@ module Jennifer
           value = _not_nil_validation({{field}}, {{options[:allow_blank] || false}})
           {% if options[:greater_than] %}
             if {{options[:greater_than]}} >= value
-              errors.add({{field}}, self.class.human_error({{field}}, :greater_than, { :value => {{options[:greater_than]}} }))
+              errors.add({{field}}, :greater_than, { :value => {{options[:greater_than]}} })
             end
           {% end %}
           {% if options[:greater_than_or_equal_to] %}
             if {{options[:greater_than_or_equal_to]}} > value
-              errors.add({{field}}, self.class.human_error({{field}}, :greater_than_or_equal_to, { :value => {{options[:greater_than_or_equal_to]}} }))
+              errors.add({{field}}, :greater_than_or_equal_to, { :value => {{options[:greater_than_or_equal_to]}} })
             end
           {% end %}
           {% if options[:equal_to] %}
             if {{options[:equal_to]}} != value
-              errors.add({{field}}, self.class.human_error({{field}}, :equal_to, { :value => {{options[:equal_to]}} }))
+              errors.add({{field}}, :equal_to, { :value => {{options[:equal_to]}} })
             end
           {% end %}
           {% if options[:less_than] %}
             if {{options[:less_than]}} <= value
-              errors.add({{field}}, self.class.human_error({{field}}, :less_than, { :value => {{options[:less_than]}} }))
+              errors.add({{field}}, :less_than, { :value => {{options[:less_than]}} })
             end
           {% end %}
           {% if options[:less_than_or_equal_to] %}
             if {{options[:less_than_or_equal_to]}} < value
-              errors.add({{field}}, self.class.human_error({{field}}, :less_than_or_equal_to, { :value => {{options[:less_than_or_equal_to]}} }))
+              errors.add({{field}}, :less_than_or_equal_to, { :value => {{options[:less_than_or_equal_to]}} })
             end
           {% end %}
           {% if options[:other_than] %}
             if {{options[:other_than]}} == value
-              errors.add({{field}}, self.class.human_error({{field}}, :other_than, { :value => {{options[:other_than]}} }))
+              errors.add({{field}}, :other_than, { :value => {{options[:other_than]}} })
             end
           {% end %}
           {% if options[:odd] %}
             if value.even?
-              errors.add({{field}}, self.class.human_error({{field}}, :odd))
+              errors.add({{field}}, :odd)
             end
           {% end %}
           {% if options[:even] %}
             if value.odd?
-              errors.add({{field}}, self.class.human_error({{field}}, :even))
+              errors.add({{field}}, :even)
             end
           {% end %}
         end
@@ -228,7 +228,7 @@ module Jennifer
           value = @{{field.id}}
           {% condition = accept ? "!(#{accept}).includes?(value)" : "value != true && value != '1'" %}
           if {{condition.id}}
-            errors.add({{field}}, self.class.human_error({{field}}, :accepted))
+            errors.add({{field}}, :accepted)
           end
         end
       end
@@ -243,11 +243,8 @@ module Jennifer
           if value.compare(@{{field.id}}_confirmation.not_nil!, !{{case_sensitive}}) != 0
             errors.add(
               {{field}},
-              self.class.human_error(
-                {{field}},
-                :confirmation,
-                options: { :attribute => self.class.human_attribute_name(:{{field.id}}) }
-              )
+              :confirmation,
+              options: { :attribute => self.class.human_attribute_name(:{{field.id}}) }
             )
           end
         end

--- a/src/jennifer/validator.cr
+++ b/src/jennifer/validator.cr
@@ -1,12 +1,12 @@
 module Jennifer
   abstract class Validator
-    getter errors : Accord::ErrorList
+    getter errors : Model::Errors
 
     def initialize(@errors)
     end
 
     def validate(subject)
-      raise raise AbstractMethod.new("validate", self.class)
+      raise AbstractMethod.new("validate", self.class)
     end
 
     def validate(subject, **options)

--- a/src/jennifer/version.cr
+++ b/src/jennifer/version.cr
@@ -1,3 +1,3 @@
 module Jennifer
-  VERSION = "0.5.0"
+  VERSION = "0.5.1"
 end


### PR DESCRIPTION
# What does this PR do?

- added last 0.5.1 changes from master
- added custom error container for models

# Any background context you want to provide?

Introducing own container for holding error messages increase the flexibility of customizing error messages.

# Release notes

Please fill the corresponding section regarding this pull request notes below instead of modifying `CHANGELOG.md` file.

**General**

- removes `accord` dependency

**Model**

- introduces new `Jennifer::Model::Errors` class replacing `Accord::ErrorList` which mimics analogic rails one a lot;
- moves `Translation::human_error` method functionality to introduced `Errors` instance level;
- `Resource#inspect` will ignore any instance attributes if `COLUMNS_METADATA` is not defined