### PR TITLE
Replace ifrit typed macros with standard language construction

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 
 # Release notes
 
-Please fill corresponding section regarding this pull request notes below instead of modifying `CHANGELOG.md` file.
+Please fill the corresponding section regarding this pull request notes below instead of modifying `CHANGELOG.md` file. Please remove all redundant sections before posting request.
 
 **General**
 
@@ -25,5 +25,3 @@ Please fill corresponding section regarding this pull request notes below instea
 **Record**
 
 **Exceptions**
-
-> NOTE: please remove all redundant sections before posting request.

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -20,7 +20,6 @@ user.validate!
 user.valid? # true
 ```
 
-
 ## Trigger validation
 
 The following methods triggers validations and will save the object only if all validations will pass:

--- a/src/jennifer/migration/table_builder/change_table.cr
+++ b/src/jennifer/migration/table_builder/change_table.cr
@@ -23,17 +23,17 @@ module Jennifer
 
         def change_column(old_name, new_name, type : Symbol? = nil, options = DB_OPTIONS.new)
           @changed_columns[old_name.to_s] =
-            sym_hash_cast(options, AAllowedTypes).merge(sym_hash({
+            sym_hash_cast(options, AAllowedTypes).merge(
+            {
               :new_name => new_name,
               :type     => type,
-            }, EAllowedTypes))
+            } of Symbol => EAllowedTypes)
           self
         end
 
         def add_column(name, type : Symbol, options = DB_OPTIONS.new)
-          @fields[name.to_s] = sym_hash_cast(options, AAllowedTypes).merge(sym_hash({
-            :type => type,
-          }, AAllowedTypes))
+          @fields[name.to_s] =
+            sym_hash_cast(options, AAllowedTypes).merge({ :type => type } of Symbol => AAllowedTypes)
           self
         end
 

--- a/src/jennifer/migration/table_builder/create_table.cr
+++ b/src/jennifer/migration/table_builder/create_table.cr
@@ -9,20 +9,20 @@ module Jennifer
 
         {% for method in Jennifer::Adapter::TYPES %}
           def {{method.id}}(name, options = DB_OPTIONS.new)
-            defaults = sym_hash({:type => {{method}}}, AAllowedTypes)
+            defaults = { :type => {{method}} } of Symbol => AAllowedTypes
             @fields[name.to_s] = defaults.merge(options)
             self
           end
         {% end %}
 
         def enum(name, values = [] of String, options = DB_OPTIONS.new)
-          hash = sym_hash({:type => :enum, :values => typed_array_cast(values, EAllowedTypes)}, AAllowedTypes).merge(options)
+          hash = ({ :type => :enum, :values => typed_array_cast(values, EAllowedTypes) } of Symbol => AAllowedTypes).merge(options)
           @fields[name.to_s] = hash
           self
         end
 
         def field(name, data_type, options = DB_OPTIONS.new)
-          @fields[name.to_s] = sym_hash({:sql_type => data_type}, AAllowedTypes).merge(options)
+          @fields[name.to_s] = ({ :sql_type => data_type } of Symbol => AAllowedTypes).merge(options)
           self
         end
 

--- a/src/jennifer/query_builder/criteria.cr
+++ b/src/jennifer/query_builder/criteria.cr
@@ -89,7 +89,7 @@ module Jennifer
       end
 
       def between(left : Rightable, right : Rightable)
-        Condition.new(self, :between, Ifrit.typed_array([left, right], DBAny))
+        Condition.new(self, :between, [left, right] of DBAny)
       end
 
       def is(value : Symbol | Bool | Nil)


### PR DESCRIPTION
# What does this PR do?

Replaces `Ifrit.typed_hash` macro usage in favor of standard language construction `{...} of K => V`. 

# Any background context you want to provide?

This will reduce (very slightly) compile time and runtime. Also, standard constructions are much preferable than synthetic macro.

# Release notes

**General**

- removes `Ifrit.typed_hash` and `Ifrit.typed_array` usage;
