### PR TITLE
Fix issue in mapping DB values when using `numeric_converter` with nullable fields

### DIFF
--- a/src/jennifer/model/mapping.cr
+++ b/src/jennifer/model/mapping.cr
@@ -272,7 +272,11 @@ module Jennifer
                 begin
                   %var{key.id} =
                     {% if value[:numeric_converter] %}
-                      pull.read(PG::Numeric).{{value[:numeric_converter].id}}
+                      {% if value[:null] %}
+                        pull.read(PG::Numeric?).try &.{{value[:numeric_converter].id}}
+                      {% else %}
+                        pull.read(PG::Numeric).{{value[:numeric_converter].id}}
+                      {% end %}
                     {% else %}
                       pull.read({{value[:parsed_type].id}})
                     {% end %}


### PR DESCRIPTION
This fixes

`Expected PG::Numeric but got Nil`

when using numeric_converter in a nullable field, like

```Crystal
price: {type: Float64, numeric_converter: :to_f64, null: true}
```