### PR TITLE
Remove line breaks in sql

### DIFF
--- a/spec/adapter/sql_generator_spec.cr
+++ b/spec/adapter/sql_generator_spec.cr
@@ -49,7 +49,7 @@ describe "Jennifer::Adapter::SQLGenerator" do
 
   describe "::from_clause" do
     it "build correct from clause" do
-      sb { |io| described_class.from_clause(io, Contact.all) }.should eq("FROM contacts\n")
+      sb { |io| described_class.from_clause(io, Contact.all) }.should eq("FROM contacts ")
     end
   end
 
@@ -129,7 +129,7 @@ describe "Jennifer::Adapter::SQLGenerator" do
     context "condition exists" do
       it "includes its sql" do
         sb { |io| described_class.where_clause(io, Contact.where { _id == 1 }) }
-          .should eq("WHERE contacts.id = %s\n")
+          .should eq("WHERE contacts.id = %s ")
       end
     end
 

--- a/spec/query_builder/join_spec.cr
+++ b/spec/query_builder/join_spec.cr
@@ -65,7 +65,7 @@ describe Jennifer::QueryBuilder::LateralJoin do
 
   describe "#as_sql" do
     it "includes source request definition" do
-      lateral_join.as_sql.should match(/ \(SELECT tests\.\*\nFROM tests\nWHERE tests\.id = %s\n\) ON /m)
+      lateral_join.as_sql.should match(/ \(SELECT tests\.\* FROM tests WHERE tests\.id = %s \) ON /m)
     end
 
     it "calls to_sql on @on" do

--- a/spec/query_builder/query_spec.cr
+++ b/spec/query_builder/query_spec.cr
@@ -226,12 +226,12 @@ describe Jennifer::QueryBuilder::Query do
   describe "#from" do
     it "accepts plain query" do
       select_clause(Factory.build_query(table: "contacts").from("select * from contacts where id > 2"))
-        .should eq("SELECT contacts.*\nFROM ( select * from contacts where id > 2 ) ")
+        .should eq("SELECT contacts.* FROM ( select * from contacts where id > 2 ) ")
     end
 
     it "accepts query object" do
       select_clause(Factory.build_query(table: "contacts").from(Contact.where { _id > 2 }))
-        .should eq("SELECT contacts.*\nFROM ( SELECT contacts.*\nFROM contacts\nWHERE contacts.id > %s\n ) ")
+        .should eq("SELECT contacts.* FROM ( SELECT contacts.* FROM contacts WHERE contacts.id > %s  ) ")
     end
   end
 

--- a/src/jennifer/adapter/base_sql_generator.cr
+++ b/src/jennifer/adapter/base_sql_generator.cr
@@ -92,7 +92,7 @@ module Jennifer
         String.build do |s|
           s << "UPDATE " << query.table << " SET "
           options.map { |k, v| "#{k.to_s}= #{esc}" }.join(", ", s)
-          s << "\n"
+          s << ' '
           body_section(s, query)
         end
       end
@@ -102,7 +102,7 @@ module Jennifer
         String.build do |s|
           s << "UPDATE " << q.table << " SET "
           modifications.map { |field, value| "#{field.to_s} = #{field.to_s} #{value[:operator]} #{esc}" }.join(", ", s)
-          s << "\n"
+          s << ' '
           body_section(s, q)
         end
       end
@@ -146,14 +146,14 @@ module Jennifer
         else
           io << query._raw_select.not_nil!
         end
-        io << "\n"
+        io << ' '
 
         from_clause(io, query)
       end
 
       def self.from_clause(io : String::Builder, query, from = nil)
         io << "FROM "
-        return io << (from || query._table) << "\n" unless query._from
+        return io << (from || query._table) << ' ' unless query._from
         io << "( " <<
           if query._from.is_a?(String)
             query._from
@@ -171,12 +171,12 @@ module Jennifer
         return if !query._groups || query._groups.empty?
         io << "GROUP BY "
         query._groups.not_nil!.each.join(", ", io) { |c| io << c.as_sql(self) }
-        io << "\n"
+        io << ' '
       end
 
       def self.having_clause(io : String::Builder, query)
         return unless query._having
-        io << "HAVING " << query._having.not_nil!.as_sql(self) << "\n"
+        io << "HAVING " << query._having.not_nil!.as_sql(self) << ' '
       end
 
       def self.join_clause(io : String::Builder, query)
@@ -190,19 +190,19 @@ module Jennifer
 
       def self.where_clause(io : String::Builder, tree)
         return unless tree
-        io << "WHERE " << tree.not_nil!.as_sql(self) << "\n"
+        io << "WHERE " << tree.not_nil!.as_sql(self) << ' '
       end
 
       def self.limit_clause(io : String::Builder, query)
-        io.print "LIMIT ", query._limit.not_nil!, "\n" if query._limit
-        io.print "OFFSET ", query._offset.not_nil!, "\n" if query._offset
+        io.print "LIMIT ", query._limit.not_nil!, ' ' if query._limit
+        io.print "OFFSET ", query._offset.not_nil!, ' ' if query._offset
       end
 
       def self.order_clause(io : String::Builder, query)
         return if !query._order || query._order.empty?
         io << "ORDER BY "
-        query._order.join(", ", io) { |(k, v), _| io.print k.as_sql(self), " ", v.upcase }
-        io << "\n"
+        query._order.join(", ", io) { |(k, v), _| io.print k.as_sql(self), ' ', v.upcase }
+        io << ' '
       end
 
       # ======== utils

--- a/src/jennifer/adapter/mysql/sql_generator.cr
+++ b/src/jennifer/adapter/mysql/sql_generator.cr
@@ -23,7 +23,7 @@ module Jennifer
         esc = escape_string(1)
         String.build do |s|
           s << "UPDATE " << query.table
-          s << "\n"
+          s << ' '
           _joins = query._joins
 
           unless _joins.nil?

--- a/src/jennifer/adapter/postgres/sql_generator.cr
+++ b/src/jennifer/adapter/postgres/sql_generator.cr
@@ -28,7 +28,7 @@ module Jennifer
         String.build do |s|
           s << "UPDATE " << query._table << " SET "
           options.map { |k, v| "#{k.to_s}= #{esc}" }.join(", ", s)
-          s << "\n"
+          s << ' '
 
           from_clause(s, query, query._joins![0].table_name(self)) if query._joins
           where_clause(s, query.tree)


### PR DESCRIPTION
# What does this PR do?

Replaces `\n` character in sql with whitespace.

# Any background context you want to provide?

`\n` in logs breaks any log analyzing software. So It is more common to use whitespace for separating different parts of a query (even if it is less readable).

# Release notes

**SqlGenerator**

- now uses whitespace character instead of `\n` as query part separator
