### PR TITLE
Add foreign key support

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -45,7 +45,7 @@ $ crystal sam.cr -- db:rollback
 ```shell
 $ crystal sam.cr -- db:rollback n
 ```
-- rollback untill version `a`
+- rollback until version `a`
 ```shell
 $ crystal sam.cr -- db:rollback -v a
 ```
@@ -66,6 +66,7 @@ $ crystal sam.cr -- db:schema:load
 #### Migration DSL
 
 Generator will create template file for you with next name  pattern "timestamp_your_underscored_migration_name.cr". Empty file looks like this:
+
 ```crystal
 class YourCamelcasedMigrationName20170119011451314 < Jennifer::Migration::Base
   def up
@@ -143,10 +144,10 @@ All those methods accepts additional options:
 - `:auto_increment` - marks field to use auto increment (properly works only with `Int32` fields, another crystal types have cut functionality for it);
 - `:array` - mark field to be array type (postgres only)
 
-Also there is `#field` method which allows to directly define sql type (very suitable for snums in postgres).
+Also there is `#field` method which allows to directly define sql type.
 
+To drop table just write:
 
-To drop table just write
 ```crystal
 drop_table(:addresses) # drops if exists
 ```
@@ -164,14 +165,18 @@ drop_materialized_view("female_contacts")
 ```
 
 To alter existing table use next methods:
+
  - `#change_column(name, [new_name], options)` - to change column definition; postgres has slighly another implementation of this than mysql one - check source code for details;
  - `#add_column(name, type, options)` - add new column;
  - `#drop_column(name)` - drops existing column
  - `#add_index(name : String, field : Symbol, type : Symbol, order : Symbol?, length : Int32?)` - adds new index (postgres doesn't support length parameter and only support `:unique` type);
  - `#drop_index(name : String)` - drops existing index;
+ - `#add_foreign_key(from_table, to_table, column = nil, primary_key = nil, name = nil)` - adds foreign key constraint;
+ - `drop_foreign_key(from_table, to_table, name = nil)` - drops foreign key constraint;
  - `#rename_table(new_name)` - renames table.
 
 Also next support methods are available:
+
 - `#table_exists?(name)`
 - `#index_exists?(table, name)`
 - `#column_exists?(table, name)`
@@ -210,20 +215,22 @@ Also plain SQL could be executed as well:
 ```crystal
 execute("ALTER TABLE addresses CHANGE street st VARCHAR(20)")
 ```
+
 All changes are executed one by one so you also could add data changes here (in `up` method) but if execution of `up` method fails - `down` method will be called and all process will stop - be ready for such behavior.
 
 To be sure that your db is up to date before run tests of your application, add `Jennifer::Migration::Runner.migrate`.
 
 #### Enum
 
-Now enums are supported as well but it has different implementation for adapters. For mysql is enought just write down all values:
+Now enums are supported as well but it has different implementation for adapters. For mysql is enough just write down all values:
+
 ```crystal
 create_table(:contacts) do |t|
   t.enum(:gender, values: ["male", "female"])
 end
 ```
 
-Postgres provide much more flexible and complex behaviour. Using it you need to create it firstly:
+Postgres provide much more flexible and complex behavior. Using it you need to create it firstly:
 
 ```crystal
 create_enum(:gender_enum, ["male", "female"])
@@ -237,4 +244,5 @@ change_enum(:gender_enum, {:add_values => ["unknown"]})
 change_enum(:gender_enum, {:rename_values => ["unknown", "other"]})
 change_enum(:gender_enum, {:remove_values => ["other"]})
 ```
+
 For more details check source code and PostgreSQL docs.

--- a/examples/migrations/20170119011451314_create_contacts.cr
+++ b/examples/migrations/20170119011451314_create_contacts.cr
@@ -1,4 +1,4 @@
-class TestMigration20170119011451314 < Jennifer::Migration::Base
+class CreateContacts20170119011451314 < Jennifer::Migration::Base
   def up
     {% if env("DB") == "postgres" || env("DB") == nil %}
       create_enum(:gender_enum, ["male", "female"])

--- a/examples/migrations/20170119011507724_create_address.cr
+++ b/examples/migrations/20170119011507724_create_address.cr
@@ -1,13 +1,18 @@
-class TestMigration20170119011507724 < Jennifer::Migration::Base
+class CreateAddress20170119011507724 < Jennifer::Migration::Base
   def up
     create_table(:addresses) do |t|
       t.integer :contact_id, {:null => true}
       t.string :street
       t.bool :main, {:default => false}
+
+      t.foreign_key :contacts
     end
+
+    # add_foreign_key :addresses, :contacts
   end
 
   def down
+    drop_foreign_key :addresses, :contacts
     drop_table :addresses
   end
 end

--- a/examples/migrations/20170912145453751_add_index.cr
+++ b/examples/migrations/20170912145453751_add_index.cr
@@ -6,7 +6,7 @@ class AddIndex20170912145453751 < Jennifer::Migration::Base
   end
 
   def down
-    change_table(:countries) do |t|
+    change_table(:addresses) do |t|
       t.drop_index "addresses_street_index"
     end
   end

--- a/spec/adapter/base_spec.cr
+++ b/spec/adapter/base_spec.cr
@@ -121,9 +121,9 @@ describe Jennifer::Adapter::Base do
 
   describe "#truncate" do
     it "clean up db" do
-      Factory.create_contact
-      adapter.truncate(Contact.table_name)
-      Contact.all.count.should eq(0)
+      Factory.create_address
+      adapter.truncate(Address.table_name)
+      Address.all.count.should eq(0)
     end
   end
 
@@ -160,7 +160,7 @@ describe Jennifer::Adapter::Base do
       adapter.column_exists?("contacts", "id").should be_true
     end
 
-    it "returns false if table has no such olumn" do
+    it "returns false if table has no such column" do
       adapter.column_exists?("contacts", "some_field").should be_false
     end
 
@@ -298,7 +298,7 @@ describe Jennifer::Adapter::Base do
       typeof(res).should eq(Array(Array(String)))
     end
 
-    it "retrieaves given amount of fields" do
+    it "retrieves given amount of fields" do
       Factory.create_contact
       res = adapter.query_array("SELECT name, description FROM contacts", String?, 2)
       res[0].should eq(["Deepthi", nil])

--- a/spec/model/relation_definition_spec.cr
+++ b/spec/model/relation_definition_spec.cr
@@ -1,12 +1,12 @@
 require "../spec_helper"
 
 describe Jennifer::Model::RelationDefinition do
-  describe "%nullify_dependecy" do
-    it "adds before_desctroy callback" do
+  describe "%nullify_dependency" do
+    it "adds before_destroy callback" do
       ContactWithDependencies::CALLBACKS[:destroy][:before].includes?("__nullify_callback_facebook_profiles").should be_true
     end
 
-    it "doen't invoke callbacks on associated model" do
+    it "doesn't invoke callbacks on associated model" do
       c = Factory.create_contact
       Factory.create_facebook_profile(contact_id: c.id)
       c = ContactWithDependencies.all.last!
@@ -18,7 +18,7 @@ describe Jennifer::Model::RelationDefinition do
   end
 
   describe "%delete_dependency" do
-    it "adds before_desctroy callback" do
+    it "adds before_destroy callback" do
       ContactWithDependencies::CALLBACKS[:destroy][:before].includes?("__delete_callback_addresses").should be_true
     end
 
@@ -35,7 +35,7 @@ describe Jennifer::Model::RelationDefinition do
   end
 
   describe "%destroy_dependency" do
-    it "adds before_desctroy callback" do
+    it "adds before_destroy callback" do
       ContactWithDependencies::CALLBACKS[:destroy][:before].includes?("__destroy_callback_passports").should be_true
     end
 
@@ -52,7 +52,7 @@ describe Jennifer::Model::RelationDefinition do
   end
 
   describe "%restrict_with_exception_dependency" do
-    it "adds before_desctroy callback" do
+    it "adds before_destroy callback" do
       ContactWithDependencies::CALLBACKS[:destroy][:before].includes?("__restrict_with_exception_callback_twitter_profiles").should be_true
     end
 
@@ -216,7 +216,7 @@ describe Jennifer::Model::RelationDefinition do
         Address.relation("contact").condition_clause.as_sql.should eq("contacts.id = addresses.contact_id")
       end
 
-      context "when desclaration has additional block" do
+      context "when declaration has additional block" do
         it "sets correct query part" do
           query = JohnPassport.relation("contact").condition_clause
           query.as_sql.should match(/contacts\.id = passports\.contact_id AND contacts\.name = %s/)
@@ -227,10 +227,11 @@ describe Jennifer::Model::RelationDefinition do
 
     describe "#/relation_name/_query" do
       it "returns query object" do
-        a = Factory.create_address(contact_id: 1)
+        c = Factory.create_contact
+        a = Factory.create_address(contact_id: c.id)
         q = a.contact_query
         q.as_sql.should match(/contacts.id = %s/)
-        q.sql_args.should eq(db_array(a.contact_id))
+        q.sql_args.should eq(db_array(c.id))
       end
     end
 
@@ -302,7 +303,7 @@ describe Jennifer::Model::RelationDefinition do
         Contact.relation("passport").condition_clause.as_sql.should eq("passports.contact_id = contacts.id")
       end
 
-      context "when desclaration has additional block" do
+      context "when declaration has additional block" do
         it "sets correct query part" do
           sql_reg = /addresses\.contact_id = contacts\.id AND addresses\.main/
           Contact.relation("main_address").condition_clause.as_sql.should match(sql_reg)

--- a/spec/query_builder/model_query_spec.cr
+++ b/spec/query_builder/model_query_spec.cr
@@ -19,6 +19,14 @@ describe Jennifer::QueryBuilder::ModelQuery do
       Address.all.destroy
       Address.destroy_counter.should eq(count + 2)
     end
+
+    it do
+      id = Factory.create_address.id
+      count = Address.destroy_counter
+      Address.destroy(id)
+      # Address.all.destroy
+      Address.destroy_counter.should eq(count + 1)
+    end
   end
 
   describe "#patch" do

--- a/src/jennifer/adapter/base.cr
+++ b/src/jennifer/adapter/base.cr
@@ -166,6 +166,11 @@ module Jennifer
         [table1.to_s, table2.to_s].sort.join("_")
       end
 
+      # Generates foreign key name for given tables.
+      def self.foreign_key_name(table1, table2)
+        "fk_cr_#{join_table_name(table1, table2)}"
+      end
+
       def self.connection_string(*options)
         auth_part = Config.user
         auth_part += ":#{Config.password}" if Config.password && !Config.password.empty?

--- a/src/jennifer/adapter/postgres/migration/table_builder/change_enum.cr
+++ b/src/jennifer/adapter/postgres/migration/table_builder/change_enum.cr
@@ -27,11 +27,13 @@ module Jennifer
               temp_name = "#{@name}_temp"
               schema_processor.define_enum(temp_name, new_values)
               @effected_tables.each do |row|
-                @adapter.exec <<-SQL
-                  ALTER TABLE #{row[0]} 
-                  ALTER COLUMN #{row[1]} TYPE #{temp_name} 
-                  USING (#{row[1]}::text::#{temp_name})
-                SQL
+                query = String.build do |s|
+                  s << "ALTER TABLE " << row[0]
+                  s << " ALTER COLUMN " << row[1] << " TYPE " << temp_name
+                  s << " USING (" << row[1] << "::text::" << temp_name << ")"
+                end
+                @adapter.exec query
+
                 schema_processor.drop_enum(@name)
                 rename(temp_name, @name)
               end

--- a/src/jennifer/adapter/schema_processor.cr
+++ b/src/jennifer/adapter/schema_processor.cr
@@ -89,6 +89,14 @@ module Jennifer
         Migration::TableBuilder::DropIndex.new(@adapter, table_name, name).process
       end
 
+      def build_add_foreign_key(from_table, to_table, column = nil, primary_key = nil, name = nil)
+        Migration::TableBuilder::CreateForeignKey.new(@adapter, from_table.to_s, to_table.to_s, column, primary_key, name).process
+      end
+
+      def build_drop_foreign_key(from_table, to_table, name = nil)
+        Migration::TableBuilder::DropForeignKey.new(@adapter, from_table.to_s, to_table.to_s, name).process
+      end
+
       # ============================
       # Schema manipulating methods
       # ============================
@@ -157,18 +165,6 @@ module Jennifer
         adapter.exec buffer
       end
 
-      def create_enum(name, options)
-        raise BaseException.new("Current adapter doesn't support this method.")
-      end
-
-      def drop_enum(name, options)
-        raise BaseException.new("Current adapter doesn't support this method.")
-      end
-
-      def change_enum(name, options)
-        raise BaseException.new("Current adapter doesn't support this method.")
-      end
-
       def create_view(name, query, silent = true)
         buff = String.build do |s|
           s << "CREATE "
@@ -186,6 +182,24 @@ module Jennifer
           s << name
         end
         adapter.exec buff
+      end
+
+      def add_foreign_key(from_table, to_table, column, primary_key, name)
+        query = String.build do |s|
+          s << "ALTER TABLE " << from_table
+          s << " ADD CONSTRAINT " << name
+          s << " FOREIGN KEY (" << column << ") REFERENCES "
+          s << to_table << "(" << primary_key << ")"
+        end
+        adapter.exec query
+      end
+
+      def drop_foreign_key(from_table, name)
+        query = String.build do |s|
+          s << "ALTER TABLE " << from_table
+          s << "DROP FOREIGN KEY " << name
+        end
+        adapter.exec query
       end
 
       private def adapter_class

--- a/src/jennifer/migration/base.cr
+++ b/src/jennifer/migration/base.cr
@@ -37,7 +37,8 @@ module Jennifer
 
       delegate create_table, create_join_table, drop_join_table, exec, drop_table,
         change_table, create_view, create_materialized_view, drop_materialized_view,
-        drop_view, add_index, create_enum, drop_enum, change_enum,
+        drop_view, add_index, drop_index, create_enum, drop_enum, change_enum,
+        add_foreign_key, drop_foreign_key,
         to: schema_processor, prefix: "build_"
 
       def adapter_class

--- a/src/jennifer/migration/table_builder/base.cr
+++ b/src/jennifer/migration/table_builder/base.cr
@@ -11,13 +11,13 @@ module Jennifer
 
         delegate schema_processor, table_exists?, index_exists?, column_exists?, to: adapter
 
-        getter fields, adapter : Adapter::Base
+        getter adapter : Adapter::Base
 
-        @name : String | Symbol
+        @name : String
 
-        def initialize(@adapter, @name)
-          @fields = {} of String => DB_OPTIONS
-          @indexes = [] of CreateIndex
+        def initialize(@adapter, name : String | Symbol)
+          @name = name.to_s
+          @commands = [] of Base
         end
 
         def name
@@ -25,6 +25,10 @@ module Jennifer
         end
 
         abstract def process
+
+        def process_commands
+          @commands.each(&.process)
+        end
 
         def to_s
           "#{@name} -> #{self.class.to_s}"

--- a/src/jennifer/migration/table_builder/create_foreign_key.cr
+++ b/src/jennifer/migration/table_builder/create_foreign_key.cr
@@ -1,0 +1,19 @@
+module Jennifer
+  module Migration
+    module TableBuilder
+      class CreateForeignKey < Base
+        getter from_table : String, to_table : String, column : String, primary_key : String
+
+        def initialize(adapter, @from_table, @to_table, column, primary_key, name)
+          @column = (column || Inflector.foreign_key(Inflector.singularize(@to_table))).to_s
+          @primary_key = (primary_key || "id").to_s
+          super(adapter, (name || adapter.class.foreign_key_name(@from_table, @to_table)).to_s)
+        end
+
+        def process
+          schema_processor.add_foreign_key(from_table, to_table, column, primary_key, name)
+        end
+      end
+    end
+  end
+end

--- a/src/jennifer/migration/table_builder/create_index.cr
+++ b/src/jennifer/migration/table_builder/create_index.cr
@@ -2,15 +2,15 @@ module Jennifer
   module Migration
     module TableBuilder
       class CreateIndex < Base
-        getter index_name : String, _fields : Array(Symbol), type : Symbol?,
+        getter index_name : String, fields : Array(Symbol), type : Symbol?,
           lengths : Hash(Symbol, Int32), orders : Hash(Symbol, Symbol)
 
-        def initialize(adapter, table_name, @index_name, @_fields, @type, @lengths, @orders)
+        def initialize(adapter, table_name, @index_name, @fields, @type, @lengths, @orders)
           super(adapter, table_name)
         end
 
         def process
-          schema_processor.add_index(@name, @index_name, _fields, @type, orders, @lengths)
+          schema_processor.add_index(@name, @index_name, fields, @type, orders, @lengths)
         end
       end
     end

--- a/src/jennifer/migration/table_builder/drop_foreign_key.cr
+++ b/src/jennifer/migration/table_builder/drop_foreign_key.cr
@@ -1,0 +1,17 @@
+module Jennifer
+  module Migration
+    module TableBuilder
+      class DropForeignKey < Base
+        getter from_table : String, to_table : String
+
+        def initialize(adapter, @from_table, @to_table, name)
+          super(adapter, (name || adapter.class.foreign_key_name(@from_table, @to_table)).to_s)
+        end
+
+        def process
+          schema_processor.drop_foreign_key(from_table, name)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# What does this PR do?

Adds functionality regarding database foreign key constraint. ATM it supports only one field foreign key.

# Any background context you want to provide?

This increases the flexibility of database migration DSL.

# Release notes

**Migration**

- adds `Migration::TableBuilder::CreateForeignKey` & `Migration::TableBuilder::DropForeignKey`
- adds `Migration::Base#add_foreign_key` & `Migration::Base#drop_foreign_key`
- adds `Migration::TableBuilder::ChangeTable#add_foreign_key` & `Migration::TableBuilder::ChangeTable#drop_foreign_key`
