### PR TITLE
Add custom sql function support

### DIFF
--- a/docs/query_dsl.md
+++ b/docs/query_dsl.md
@@ -154,6 +154,40 @@ Contact.all.where do
 end
 ```
 
+#### Functions
+
+There is special mechanism to define sql functions like `CURRENT_DATE`, `ABS` or `CONCAT`. There is already a predefined list of such functions so you can use them in the expression builder context:
+
+```crystal
+Contact.all.where { ceil(_balance) > 10 }
+```
+
+Here is the list of such functions:
+
+* lower
+* upper
+* current_timestamp
+* current_date
+* current_time
+* now
+* concat
+* abs
+* ceil
+* floor
+* round
+
+To define own function:
+
+```crystal
+Jennifer::QueryBuilder::Function.define("ceil", arity: 1) do
+  def as_sql(generator)
+    "CEIL(#{operand_sql(operands[0], generator)})"
+  end
+end
+```
+
+It is necessary to define `#as_sql` method, which returns function sql. `#operands` is an array of given function arguments. `#operand_sql` is a helper method to automatically parse how a given argument should be inserted to the sql.
+
 #### Smart arguments parsing
 
 Next methods provide flexible api for passing arguments:

--- a/spec/query_builder/all_spec.cr
+++ b/spec/query_builder/all_spec.cr
@@ -3,23 +3,26 @@ require "../spec_helper"
 describe Jennifer::QueryBuilder::All do
   described_class = Jennifer::QueryBuilder::All
   query = Contact.all.where { _id == 2 }
+  expression = Factory.build_expression
 
   describe "#as_sql" do
     it "wrap sql with ALL operator" do
-      all = Factory.build_expression.all(query)
-      all.as_sql.should match(/ALL \(SELECT .*\)/m)
+      expression.all(query).as_sql.should match(/ALL \(SELECT .*\)/m)
     end
 
     it "nested request includes template argument placeholders" do
-      all = Factory.build_expression.all(query)
-      all.as_sql.should match(/id = %s/)
+      expression.all(query).as_sql.should match(/id = %s/)
     end
   end
 
   describe "#sql_args" do
     it "returns arguments from nested query" do
-      all = Factory.build_expression.all(query)
-      all.sql_args.should eq([2])
+      expression.all(query).sql_args.should eq([2])
     end
+  end
+
+  describe "#filterable?" do
+    it { expression.all(Query["contacts"].where { _name == "asd" }).filterable?.should be_true }
+    it { expression.all(Query["contacts"]).filterable?.should be_false }
   end
 end

--- a/spec/query_builder/any_spec.cr
+++ b/spec/query_builder/any_spec.cr
@@ -3,23 +3,26 @@ require "../spec_helper"
 describe Jennifer::QueryBuilder::Any do
   described_class = Jennifer::QueryBuilder::Any
   query = Contact.all.where { _id == 2 }
+  expression = Factory.build_expression
 
   describe "#as_sql" do
     it "wrap sql with ANY operator" do
-      any = Factory.build_expression.any(query)
-      any.as_sql.should match(/ANY \(SELECT .*\)/m)
+      expression.any(query).as_sql.should match(/ANY \(SELECT .*\)/m)
     end
 
     it "nested request includes template argument placeholders" do
-      any = Factory.build_expression.any(query)
-      any.as_sql.should match(/id = %s/)
+      expression.any(query).as_sql.should match(/id = %s/)
     end
   end
 
   describe "#sql_args" do
     it "returns arguments from nested query" do
-      any = Factory.build_expression.any(query)
-      any.sql_args.should eq([2])
+      expression.any(query).sql_args.should eq([2])
     end
+  end
+
+  describe "#filterable?" do
+    it { expression.any(Query["contacts"].where { _name == "asd" }).filterable?.should be_true }
+    it { expression.any(Query["contacts"]).filterable?.should be_false }
   end
 end

--- a/spec/query_builder/criteria_spec.cr
+++ b/spec/query_builder/criteria_spec.cr
@@ -126,13 +126,13 @@ describe Jennifer::QueryBuilder::Criteria do
   end
 
   describe "#&" do
-    it "retruns AND operator" do
+    it "returns AND operator" do
       (Factory.build_criteria & Factory.build_criteria).should be_a(Jennifer::QueryBuilder::And)
     end
   end
 
   describe "#|" do
-    it "retruns OR operator" do
+    it "returns OR operator" do
       (Factory.build_criteria | Factory.build_criteria).should be_a(Jennifer::QueryBuilder::Or)
     end
   end
@@ -172,6 +172,10 @@ describe Jennifer::QueryBuilder::Criteria do
     it "returns empty array" do
       Factory.build_criteria.sql_args.empty?.should be_true
     end
+  end
+
+  describe "#filterable?" do
+    it { Factory.build_criteria.filterable?.should be_false }
   end
 
   describe "#alias" do

--- a/spec/query_builder/function_spec.cr
+++ b/spec/query_builder/function_spec.cr
@@ -1,0 +1,232 @@
+require "../spec_helper"
+
+Jennifer::QueryBuilder::Function.define("dummy") do
+  def as_sql(generator)
+    "dummy(#{operands_to_sql(generator)})"
+  end
+end
+
+describe Jennifer::QueryBuilder::Function do
+  describe "ExpressionBuilder context" do
+    it "is accessible using defined name" do
+      Factory.build_expression.dummy.as_sql.should eq("dummy()")
+      Factory.build_expression.dummy(1).as_sql.should eq("dummy(%s)")
+    end
+  end
+
+  describe "#set_relation" do
+    pending "add" do
+    end
+  end
+
+  describe "#alias_tables" do
+    pending "add" do
+    end
+  end
+
+  describe "#change_table" do
+    pending "add" do
+    end
+  end
+
+  describe "#sql_args" do
+    it { DummyFunction.new(1, "asd").sql_args.should eq([1, "asd"] of Jennifer::DBAny) }
+    it { DummyFunction.new.sql_args.should eq([] of Jennifer::DBAny) }
+    it { DummyFunction.new(Factory.build_criteria).sql_args.should eq([] of Jennifer::DBAny) }
+  end
+
+  describe "#filterable?" do
+    context "with filterable sql node" do
+      it { DummyFunction.new(Factory.build_expression.sql("asd", 2)).filterable?.should be_true }
+      it { DummyFunction.new(Factory.build_criteria).filterable?.should be_false }
+    end
+
+    context "with filterable argument" do
+      it { DummyFunction.new(1).filterable?.should be_true }
+    end
+
+    it { DummyFunction.new.filterable?.should be_false }
+  end
+
+  # Functions ====================
+
+  describe "LowerFunction" do
+    describe "#as_sql" do
+      it do
+        Jennifer::QueryBuilder::LowerFunction.new("ASD").as_sql.should eq("LOWER(%s)")
+      end
+    end
+
+    it do
+      Factory.create_contact(name: "asd")
+      Jennifer::Query["contacts"].where { _name == lower("ASD") }.exists?.should be_true
+    end
+
+    it do
+      Factory.create_contact(name: "ASD")
+      Jennifer::Query["contacts"].where { lower(_name) == "asd" }.exists?.should be_true
+    end
+
+    it do
+      Jennifer::Query["contacts"].where { _name == lower("ASD") }.exists?.should be_false
+    end
+  end
+
+  describe "UpperFunction" do
+    describe "#as_sql" do
+      it do
+        Jennifer::QueryBuilder::UpperFunction.new("ASD").as_sql.should eq("UPPER(%s)")
+      end
+    end
+
+    it do
+      Factory.create_contact(name: "ASD")
+      Jennifer::Query["contacts"].where { _name == upper("asd") }.exists?.should be_true
+    end
+
+    it do
+      Factory.create_contact(name: "asd")
+      Jennifer::Query["contacts"].where { upper(_name) == "ASD" }.exists?.should be_true
+    end
+
+    it do
+      Jennifer::Query["contacts"].where { _name == upper("asd") }.exists?.should be_false
+    end
+  end
+
+  describe "CurrentTimestampFunction" do
+    describe "#as_sql" do
+      it do
+        Jennifer::QueryBuilder::CurrentTimestampFunction.new.as_sql.should eq("CURRENT_TIMESTAMP")
+      end
+    end
+
+    it "doesn't fail" do
+      Jennifer::Query["contacts"].where { _created_at <= current_timestamp }.exists?
+    end
+  end
+
+  describe "CurrentDateFunction" do
+    describe "#as_sql" do
+      it do
+        Jennifer::QueryBuilder::CurrentDateFunction.new.as_sql.should eq("CURRENT_DATE")
+      end
+    end
+
+    it do
+      Factory.create_contact
+      Jennifer::Query["contacts"].select { [current_date.alias("current_d")] }.first!.current_d(Time).should eq(Time.epoch(Time.now.epoch).date)
+    end
+  end
+
+  describe "CurrentTimeFunction" do
+    describe "#as_sql" do
+      it do
+        Jennifer::QueryBuilder::CurrentTimeFunction.new.as_sql.should eq("CURRENT_TIME")
+      end
+    end
+
+    it do
+      Factory.create_contact
+      time = Time.now
+      current_t = time - time.at_beginning_of_day - 1.second
+      next_t = time - time.at_beginning_of_day + 1.second
+
+      Jennifer::Query["contacts"].where { (current_time >= current_t) & (current_time <= next_t) }.count.should eq(1)
+    end
+  end
+
+  describe "NowFunction" do
+    describe "#as_sql" do
+      it do
+        Jennifer::QueryBuilder::NowFunction.new.as_sql.should eq("NOW()")
+      end
+    end
+
+    it do
+      Factory.create_contact
+      time = db_specific(
+        mysql: -> { Time.now + Time.now.offset.seconds },
+        postgres: -> { Time.utc_now }
+      )
+      Jennifer::Query["contacts"].select { [now.alias("now")] }.first!.now(Time).should be_close(time, 1.second)
+    end
+  end
+
+  describe "ConcatFunction" do
+    describe "#as_sql" do
+      it do
+        Jennifer::QueryBuilder::ConcatFunction.new("asd", 1).as_sql.should eq("CONCAT(%s, %s)")
+      end
+    end
+
+    it do
+      Factory.create_contact(name: "sur", description: "name sur")
+      Jennifer::Query["contacts"].where { _description == concat(sql("'name '", false), _name) }.count.should eq(1)
+    end
+  end
+
+  describe "AbsFunction" do
+    describe "#as_sql" do
+      it do
+        Jennifer::QueryBuilder::AbsFunction.new(1).as_sql.should eq("ABS(%s)")
+      end
+    end
+
+    it do
+      Factory.create_facebook_profile(contact_id: -10)
+      Query["profiles"].select { [abs(_contact_id).alias("id")] }.first!.id(Int).should eq(10)
+    end
+  end
+
+  describe "CeilFunction" do
+    describe "#as_sql" do
+      it do
+        Jennifer::QueryBuilder::CeilFunction.new(1).as_sql.should eq("CEIL(%s)")
+      end
+    end
+
+    it do
+      Factory.create_contact
+      res = Query["contacts"].select { [ceil(sql("-2.1", false)).alias("v")] }.first!
+      db_specific(
+        mysql: -> { res.v(Int64).should eq(-2) },
+        postgres: -> { res.v(PG::Numeric).should eq(-2) }
+      )
+    end
+  end
+
+  describe "FloorFunction" do
+    describe "#as_sql" do
+      it do
+        Jennifer::QueryBuilder::FloorFunction.new(1).as_sql.should eq("FLOOR(%s)")
+      end
+    end
+
+    it do
+      Factory.create_contact
+      res = Query["contacts"].select { [floor(sql("-2.1", false)).alias("v")] }.first!
+      db_specific(
+        mysql: -> { res.v(Int64).should eq(-3) },
+        postgres: -> { res.v(PG::Numeric).should eq(-3) }
+      )
+    end
+  end
+
+  describe "RoundFunction" do
+    describe "#as_sql" do
+      it do
+        Jennifer::QueryBuilder::RoundFunction.new(1).as_sql.should eq("ROUND(%s)")
+      end
+    end
+
+    it do
+      Factory.create_contact
+      res = Query["contacts"].select { [round(sql("-2.1", false)).alias("v")] }.first!
+      db_specific(
+        mysql: -> { res.v(Float64).should eq(-2) },
+        postgres: -> { res.v(PG::Numeric).should eq(-2) }
+      )
+    end
+  end
+end

--- a/spec/query_builder/grouping_spec.cr
+++ b/spec/query_builder/grouping_spec.cr
@@ -6,7 +6,7 @@ describe Jennifer::QueryBuilder::Grouping do
   c2 = Factory.build_criteria == 2
 
   describe "#as_sql" do
-    it "wrap sql with paranthesis" do
+    it "wrap sql with parenthesis" do
       g = described_class.new(c1 & c2)
       g.as_sql.should match(/\(tests\.f1 AND tests\.f1 = %s\)/)
     end
@@ -17,5 +17,10 @@ describe Jennifer::QueryBuilder::Grouping do
       g = described_class.new(c1 & c2)
       g.sql_args.should eq([2])
     end
+  end
+
+  describe "#filterable?" do
+    it { described_class.new(c1 & c1).filterable?.should be_false }
+    it { described_class.new(c1 & c2).filterable?.should be_true }
   end
 end

--- a/spec/query_builder/join_spec.cr
+++ b/spec/query_builder/join_spec.cr
@@ -1,6 +1,8 @@
 require "../spec_helper"
 
 describe Jennifer::QueryBuilder::Join do
+  expression = Factory.build_expression
+
   describe "#as_sql" do
     it "includes table name" do
       Factory.build_join.as_sql.should match(/ tests ON /)
@@ -57,6 +59,24 @@ describe Jennifer::QueryBuilder::Join do
         args[0].should eq("asd")
       end
     end
+  end
+
+  describe "#filterable?" do
+    context "with filterable condition" do
+      it { Factory.build_join(on: expression._id > 1).filterable?.should be_true }
+    end
+
+    context "with query as a source" do
+      it { Factory.build_join(table: Query["tests2"].where { _id == "asd" }).filterable?.should be_true }
+
+      it do
+        condition = expression._id == expression._id
+        table = Query["tests2"].where { _id == _age }
+        Factory.build_join(on: condition, table: table).filterable?.should be_false
+      end
+    end
+
+    it { Factory.build_join(on: expression._id == expression._id).filterable?.should be_false }
   end
 end
 

--- a/spec/query_builder/logic_operator_spec.cr
+++ b/spec/query_builder/logic_operator_spec.cr
@@ -3,13 +3,44 @@ require "../spec_helper"
 describe Jennifer::QueryBuilder::LogicOperator do
   described_class = Jennifer::QueryBuilder::LogicOperator
   expression = Factory.build_expression
+  c1 = Factory.build_criteria(field: "f1")
+  c2 = Factory.build_criteria(field: "f2")
 
-  context "complex expression with grouping" do
-    it "puts paranthesis around proper elemets" do
-      c1 = Factory.build_criteria(field: "f1")
-      c2 = Factory.build_criteria(field: "f2")
+  describe "complex expression with grouping" do
+    it "puts parenthesis around proper elements" do
       c3 = Factory.build_criteria(field: "f3")
       (c1 & expression.g(c2 | c3)).as_sql.should eq("tests.f1 AND (tests.f2 OR tests.f3)")
+    end
+  end
+
+  describe "#as_sql" do
+    it { ((c1 == 2 ) & (c2 == c1)).as_sql.should eq("tests.f1 = %s AND tests.f2 = tests.f1") }
+  end
+
+  describe "#sql_args" do
+    it { ((c1 == 2 ) & (c2 == c1)).sql_args.should eq([2]) }
+  end
+
+  describe "#filterable?" do
+    it { ((c1 == 2 ) & (c2 == c1)).filterable?.should be_true }
+    it { (c2 == c1).filterable?.should be_false }
+  end
+
+  describe "And" do
+    describe "#operator" do
+      it { Jennifer::QueryBuilder::And.new(Factory.build_criteria.to_condition, Factory.build_criteria.to_condition).operator.should eq("AND") }
+    end
+  end
+
+  describe "Or" do
+    describe "#operator" do
+      it { Jennifer::QueryBuilder::Or.new(Factory.build_criteria.to_condition, Factory.build_criteria.to_condition).operator.should eq("OR") }
+    end
+  end
+
+  describe "Xor" do
+    describe "#operator" do
+      it { Jennifer::QueryBuilder::Xor.new(Factory.build_criteria.to_condition, Factory.build_criteria.to_condition).operator.should eq("XOR") }
     end
   end
 end

--- a/spec/query_builder/raw_sql_spec.cr
+++ b/spec/query_builder/raw_sql_spec.cr
@@ -23,4 +23,9 @@ describe Jennifer::QueryBuilder::RawSql do
       args.should eq(db_array(12))
     end
   end
+
+  describe "#filterable?" do
+    it { described_class.new("sql", [1]).filterable?.should be_true }
+    it { described_class.new("sql").filterable?.should be_false }
+  end
 end

--- a/src/jennifer.cr
+++ b/src/jennifer.cr
@@ -80,6 +80,10 @@ end
 
 struct Time
   def_clone
+
+  struct Span
+    def_clone
+  end
 end
 
 class Time::Location

--- a/src/jennifer/adapter.cr
+++ b/src/jennifer/adapter.cr
@@ -8,7 +8,7 @@ module Jennifer
                 Array(Int16) | Array(Int64) | Array(String) |
                 Bool | Char | Float32 | Float64 | Int8 | Int16 | Int32 | Int64 | JSON::Any | PG::Geo::Box |
                 PG::Geo::Circle | PG::Geo::Line | PG::Geo::LineSegment | PG::Geo::Path | PG::Geo::Point |
-                PG::Geo::Polygon | PG::Numeric | Slice(UInt8) | String | Time | UInt32 | Nil
+                PG::Geo::Polygon | PG::Numeric | Slice(UInt8) | String | Time | Time::Span | UInt32 | Nil
 
   module Adapter
     TYPES = %i(

--- a/src/jennifer/adapter/base_sql_generator.cr
+++ b/src/jennifer/adapter/base_sql_generator.cr
@@ -141,7 +141,7 @@ module Jennifer
           if !exact_fields.empty?
             exact_fields.join(", ", io) { |f| io << "#{table}.#{f}" }
           else
-            query._select_fields.not_nil!.join(", ", io) { |f| io << f.definition }
+            query._select_fields.not_nil!.join(", ", io) { |f| io << f.definition(self) }
           end
         else
           io << query._raw_select.not_nil!
@@ -240,7 +240,11 @@ module Jennifer
         value.to_s
       end
 
-      def self.escape_string(size : Int32 = 1)
+      def self.escape_string
+        ARGUMENT_ESCAPE_STRING
+      end
+
+      def self.escape_string(size : Int32)
         case size
         when 1
           ARGUMENT_ESCAPE_STRING
@@ -253,12 +257,16 @@ module Jennifer
         end
       end
 
-      def self.filter_out(arg : QueryBuilder::Criteria)
+      def self.filter_out(arg : Array, single : Bool = true)
+        single ? escape_string : arg.join(", ") { |a| filter_out(a) }
+      end
+
+      def self.filter_out(arg : QueryBuilder::SQLNode)
         arg.as_sql(self)
       end
 
       def self.filter_out(arg)
-        escape_string(1)
+        escape_string
       end
 
       # TODO: optimize array initializing

--- a/src/jennifer/query_builder/all.cr
+++ b/src/jennifer/query_builder/all.cr
@@ -2,11 +2,15 @@ module Jennifer
   module QueryBuilder
     class All < SQLNode
       getter query : Query
-      delegate sql_args, sql_args_count, to: @query
+      delegate sql_args, to: @query
 
       def_clone
 
       def initialize(@query)
+      end
+
+      def filterable?
+        query.filterable?
       end
 
       def as_sql(_sql_generator)

--- a/src/jennifer/query_builder/any.cr
+++ b/src/jennifer/query_builder/any.cr
@@ -2,11 +2,15 @@ module Jennifer
   module QueryBuilder
     class Any < SQLNode
       getter query : Query
-      delegate sql_args, sql_args_count, to: @query
+      delegate sql_args, to: @query
 
       def_clone
 
       def initialize(@query)
+      end
+
+      def filterable?
+        query.filterable?
       end
 
       def as_sql(_generator)

--- a/src/jennifer/query_builder/condition.cr
+++ b/src/jennifer/query_builder/condition.cr
@@ -5,13 +5,8 @@ module Jennifer
     class Condition
       include LogicOperator::Operators
 
-      RAW_OPERATORS = [:is, :is_not]
-
-      getter lhs : Criteria, rhs : Criteria::Rightable?, operator : Symbol = :bool
-
+      getter lhs : SQLNode, rhs : Criteria::Rightable?, operator : Symbol = :bool
       @negative = false
-
-      def_clone
 
       def initialize(field : String, table : String, relation = nil)
         @lhs = Criteria.new(field, table, relation)
@@ -23,6 +18,8 @@ module Jennifer
       def initialize(@lhs, @operator, @rhs)
       end
 
+      def_clone
+
       protected def initialize_copy(other)
         @rhs = other.@rhs.dup
         @lhs = other.@lhs.clone
@@ -32,17 +29,17 @@ module Jennifer
 
       def set_relation(table, name)
         @lhs.set_relation(table, name)
-        @rhs.as(Criteria).set_relation(table, name) if @rhs.is_a?(Criteria)
+        @rhs.as(SQLNode).set_relation(table, name) if @rhs.is_a?(SQLNode)
       end
 
       def alias_tables(aliases)
         @lhs.alias_tables(aliases)
-        @rhs.as(Criteria).alias_tables(aliases) if @rhs.is_a?(Criteria)
+        @rhs.as(SQLNode).alias_tables(aliases) if @rhs.is_a?(SQLNode)
       end
 
       def change_table(old_name, new_name)
         @lhs.change_table(old_name, new_name)
-        @rhs.as(Criteria).change_table(old_name, new_name) if @rhs.is_a?(Criteria)
+        @rhs.as(SQLNode).change_table(old_name, new_name) if @rhs.is_a?(SQLNode)
       end
 
       def not
@@ -65,9 +62,10 @@ module Jennifer
           when :bool
             _lhs
           when :in
-            "#{_lhs} IN(#{generator.escape_string(@rhs.as(Array).size)})"
+            "#{_lhs} IN(#{generator.filter_out(@rhs.as(Array), false)})"
           when :between
-            "#{_lhs} BETWEEN #{generator.escape_string(1)} AND #{generator.escape_string(1)}"
+            rhs = @rhs.as(Array)
+            "#{_lhs} BETWEEN #{generator.filter_out(rhs[0])} AND #{generator.filter_out(rhs[1])}"
           else
             "#{_lhs} #{generator.operator_to_sql(@operator)} #{parsed_rhs(generator)}"
           end
@@ -77,57 +75,46 @@ module Jennifer
 
       def sql_args : Array(DBAny)
         res = @lhs.sql_args
-        if filterable? && !(@operator == :is || @operator == :is_not)
-          if @operator == :in || @operator == :between
-            @rhs.as(Array).each do |e|
-              unless e.is_a?(Criteria)
-                res << e.as(DBAny)
-              else
-                res += e.sql_args
-              end
+        return res if @operator == :bool
+        if @rhs.is_a?(SQLNode)
+          res.concat(@rhs.as(SQLNode).sql_args)
+        elsif @rhs.is_a?(Array) && (@operator == :in || @operator == :between)
+          @rhs.as(Array).each do |e|
+            unless e.is_a?(SQLNode)
+              res << e.as(DBAny)
+            else
+              res.concat(e.sql_args)
             end
-          else
-            res << @rhs.as(DBAny)
           end
-        elsif @rhs.is_a?(Criteria)
-          res += @rhs.as(Criteria).sql_args
+        elsif @operator != :is && @operator != :is_not
+          res << @rhs.as(DBAny)
         end
         res
       end
 
-      def sql_args_count
-        count = @lhs.sql_args_count
-        if filterable? && !(@operator == :is || @operator == :is_not)
-          count = 0
-          if @operator == :in || @operator == :between
-            @rhs.as(Array).each do |e|
-              count += e.is_a?(Criteria) ? e.sql_args_count : 1
-            end
-          else
-            count += 1
-          end
-        elsif @rhs.is_a?(Criteria)
-          count += @rhs.as(Criteria).sql_args_count
+      def filterable?
+        if @lhs.filterable?
+          true
+        elsif @operator == :bool
+          false
+        elsif @rhs.is_a?(SQLNode)
+          @rhs.as(SQLNode).filterable?
+        elsif @operator == :is || @operator == :is_not
+          false
+        elsif @rhs.is_a?(Array)
+          @rhs.as(Array).any? { |e| !e.is_a?(SQLNode) || e.filterable? }
+        else
+          true
         end
-        count
-      end
-
-      private def filterable?
-        !(
-          @rhs.is_a?(Criteria) ||
-            @operator == :bool
-        )
       end
 
       private def parsed_rhs(generator)
-        if @rhs.is_a?(Criteria)
-          @rhs.as(Criteria).as_sql(generator)
+        if @rhs.is_a?(SQLNode)
+          @rhs.as(SQLNode).as_sql(generator)
         elsif @operator == :is || @operator == :is_not
           translate(generator)
-        elsif filterable?
-          generator.filter_out(@rhs)
         else
-          @rhs.to_s
+          generator.filter_out(@rhs)
         end
       end
 

--- a/src/jennifer/query_builder/criteria.cr
+++ b/src/jennifer/query_builder/criteria.cr
@@ -80,7 +80,7 @@ module Jennifer
       end
 
       def !=(value : Rightable)
-        # NOTE: here crystal improperly resolves override methods with Nilargument
+        # NOTE: here crystal improperly resolves override methods with Nil argument
         if !value.nil?
           Condition.new(self, :!=, value)
         else
@@ -137,12 +137,16 @@ module Jennifer
         @alias ? "#{identifier} AS #{@alias}" : identifier
       end
 
+      def definition(_sql_generator)
+        definition
+      end
+
       def sql_args : Array(DBAny)
         [] of DBAny
       end
 
-      def sql_args_count
-        0
+      def filterable?
+        false
       end
 
       def to_condition

--- a/src/jennifer/query_builder/function.cr
+++ b/src/jennifer/query_builder/function.cr
@@ -1,0 +1,178 @@
+module Jennifer
+  module QueryBuilder
+    abstract class Function < Criteria
+      getter operands = [] of Criteria::Rightable
+
+      def initialize(*args)
+        @field = ""
+        @table = ""
+        args.each do |arg|
+          operands << arg.as(Criteria::Rightable)
+        end
+      end
+
+      def definition(sql_generator)
+        identifier = as_sql(sql_generator)
+        @alias ? "#{identifier} AS #{@alias}" : identifier
+      end
+
+      def definition
+        definition(Adapter.default_adapter.sql_generator)
+      end
+
+      # NOTE: can't be abstract because is already implemented by super class
+      def clone
+        raise AbstractMethod.new(:clone, {{@type}})
+      end
+
+      def set_relation(table, name)
+        operands.each do |operand|
+          operand.as(SQLNode).set_relation(table, name) if operand.is_a?(SQLNode)
+        end
+      end
+
+      def alias_tables(aliases)
+        operands.each do |operand|
+          if operand.is_a?(SQLNode)
+            operand.as(SQLNode).alias_tables(aliases)
+          end
+        end
+      end
+
+      def change_table(old_name, new_name)
+        operands.each do |operand|
+          operand.as(SQLNode).change_table(old_name, new_name) if operand.is_a?(SQLNode)
+        end
+      end
+
+      def sql_args
+        res = [] of DBAny
+        operands.each do |operand|
+          if operand.is_a?(SQLNode)
+            res.concat(operand.sql_args)
+          else
+            res << operand.as(DBAny)
+          end
+        end
+        res
+      end
+
+      def filterable?
+        @operands.any? { |operand| !operand.is_a?(SQLNode) || operand.as(SQLNode).filterable? }
+      end
+
+      private def operands_to_sql(generator)
+        operands.join(", ") do |operand|
+          operand_sql(operand, generator)
+        end
+      end
+
+      private def operand_sql(operand, generator)
+        if operand.is_a?(SQLNode)
+          operand.as_sql(generator)
+        else
+          generator.escape_string
+        end
+      end
+
+      # Defines new function class.
+      # - `name` - function name; use used to generate function class name if it isn't specified
+      # - `klass` - function class name; optional
+      # - `arity` - describes function arity; -1 stands for any count
+      macro define(name, klass = nil, arity = -1)
+        {% klass = name.camelcase + "Function" if klass == nil %}
+        {% args_string = "*args" %}
+        {% if arity > -1 %}
+          {% args_string = "" %}
+          {% for i in (0...arity) %}
+            {% args_string = args_string + ", " if i != 0 %}
+            {% args_string = args_string + "arg#{i}" %}
+          {% end %}
+        {% end %}
+        {% args_string = args_string.id %}
+
+        class ::Jennifer::QueryBuilder::ExpressionBuilder
+          def {{name.id}}({{args_string}})
+            {{klass.id}}.new({{args_string}})
+          end
+        end
+
+        class {{klass.id}} < ::Jennifer::QueryBuilder::Function
+          def_clone
+
+          protected def initialize_copy(other)
+            @operands = other.@operands.dup
+          end
+
+          {{yield}}
+        end
+      end
+    end
+
+    Function.define("lower", arity: 1) do
+      def as_sql(generator)
+        "LOWER(#{operand_sql(operands[0], generator)})"
+      end
+    end
+
+    Function.define("upper", arity: 1) do
+      def as_sql(generator)
+        "UPPER(#{operand_sql(operands[0], generator)})"
+      end
+    end
+
+    Function.define("current_timestamp", arity: 0) do
+      def as_sql(generator)
+        "CURRENT_TIMESTAMP"
+      end
+    end
+
+    Function.define("current_date", arity: 0) do
+      def as_sql(generator)
+        "CURRENT_DATE"
+      end
+    end
+
+    Function.define("current_time", arity: 0) do
+      def as_sql(generator)
+        "CURRENT_TIME"
+      end
+    end
+
+    Function.define("now", arity: 0) do
+      def as_sql(generator)
+        "NOW()"
+      end
+    end
+
+    Function.define("concat") do
+      def as_sql(generator)
+        "CONCAT(#{operands_to_sql(generator)})"
+      end
+    end
+
+    Function.define("abs", arity: 1) do
+      def as_sql(generator)
+        "ABS(#{operand_sql(operands[0], generator)})"
+      end
+    end
+
+    Function.define("ceil", arity: 1) do
+      def as_sql(generator)
+        "CEIL(#{operand_sql(operands[0], generator)})"
+      end
+    end
+
+    Function.define("floor", arity: 1) do
+      def as_sql(generator)
+        "FLOOR(#{operand_sql(operands[0], generator)})"
+      end
+    end
+
+    Function.define("round", arity: 1) do
+      def as_sql(generator)
+        "ROUND(#{operand_sql(operands[0], generator)})"
+      end
+    end
+  end
+end

--- a/src/jennifer/query_builder/grouping.cr
+++ b/src/jennifer/query_builder/grouping.cr
@@ -1,5 +1,6 @@
 module Jennifer
   module QueryBuilder
+    # Presents group of logic operations.
     class Grouping < SQLNode
       include LogicOperator::Operators
 
@@ -7,9 +8,15 @@ module Jennifer
 
       def_clone
 
-      delegate sql_args, sql_args_count, to: @condition
-
       def initialize(@condition)
+      end
+
+      def sql_args
+        condition.sql_args
+      end
+
+      def filterable?
+        condition.filterable?
       end
 
       def as_sql(generator)

--- a/src/jennifer/query_builder/join.cr
+++ b/src/jennifer/query_builder/join.cr
@@ -21,6 +21,10 @@ module Jennifer
         !@aliass.nil?
       end
 
+      def filterable?
+        @on.filterable? || (@table.is_a?(Query) && @table.as(Query).filterable?)
+      end
+
       def as_sql
         as_sql(Adapter.default_adapter.sql_generator)
       end
@@ -63,10 +67,6 @@ module Jennifer
 
       def sql_args
         @table.is_a?(String) ? @on.sql_args : @table.as(Query).sql_args + @on.sql_args
-      end
-
-      def sql_args_count
-        @table.is_a?(String) ? @on.sql_args_count : @table.as(Query).sql_args_count + @on.sql_args_count
       end
     end
 

--- a/src/jennifer/query_builder/logic_operator.cr
+++ b/src/jennifer/query_builder/logic_operator.cr
@@ -66,7 +66,7 @@ module Jennifer
       def as_sql
         as_sql(Adapter.default_adapter.sql_generator)
       end
-      
+
       def as_sql(generator)
         @lhs.as_sql(generator) + " " + operator + " " + @rhs.as_sql(generator)
       end
@@ -75,13 +75,12 @@ module Jennifer
         @lhs.sql_args + @rhs.sql_args
       end
 
-      def sql_args_count
-        @lhs.sql_args_count + @rhs.sql_args_count
+      def filterable?
+        @lhs.filterable? || @rhs.filterable?
       end
 
       def ==(other : LogicOperator)
-        @lhs == other.lhs &&
-          @rhs == other.rhs
+        @lhs == other.lhs && @rhs == other.rhs
       end
     end
 

--- a/src/jennifer/query_builder/raw_sql.cr
+++ b/src/jennifer/query_builder/raw_sql.cr
@@ -35,8 +35,8 @@ module Jennifer
         @params
       end
 
-      def sql_args_count
-        @params.size
+      def filterable?
+        @params.any?
       end
     end
   end

--- a/src/jennifer/query_builder/sql_node.cr
+++ b/src/jennifer/query_builder/sql_node.cr
@@ -3,13 +3,10 @@ module Jennifer
     abstract class SQLNode
       abstract def as_sql(sql_generator)
       abstract def sql_args : Array
+      abstract def filterable?
 
       def as_sql
         as_sql(Adapter.default_adapter.sql_generator)
-      end
-
-      def sql_args_count : Int32
-        sql_args.size
       end
 
       def set_relation(table, name)


### PR DESCRIPTION
# What does this PR do?

Adds functionality for defining own sql functions. This allows easilly adding any kind of db-related function support into application.

# Release notes

**General**

- adds `Time::Span` to supported types

**QueryBuilder**

- allows listing any `SQLNode` instance in SELECT clause (like raw sql or funcitons)
- removes redundant `SQLNode#sql_args_count`
- adds `SQLNode#filterable?` function which presents if node has filterable sql parameter
- refactors `Condition#sql_arg`
- adds `Function` base abstract class for defining custom sql functions
- adds `lower`, `upper`, `current_timestamp`, `current_date`, `current_time`, `now`, `concat`, `abs`, `ceil`, `floor`, `round`
- adds `Join#filterble?` and `Query#filterable?`