### PR TITLE
Add field converters

### DIFF
--- a/docs/model_mapping.md
+++ b/docs/model_mapping.md
@@ -106,14 +106,25 @@ end
 
 | argument | description |
 | --- | --- |
-| `:type` | crystal data type (don't use question mark - for now you can use only `:null` option) |
+| `:type` | crystal data type |
 | `:primary` | mark field as primary key (default is `false`) |
 | `:null` | allows field to be `nil` (default is `false` for all fields except primary key |
-| `:default` | default value which be set during creating **new** object |
+| `:default` | default value which will be set during creating **new** object |
 | `:getter` | if getter should be created (default - `true`) |
 | `:setter` | if setter should be created (default - `true`) |
 | `:virtual` | mark field as virtual - will not be stored and retrieved from db |
-| `:numeric_converter` | **postgres only**: contains method to convert `PG::Numeric` to a used `type` |
+| `:converter` | class be used to serialize/deserialize value |
+
+To define field converter create a class which implements next methods:
+
+- `.from_db(DB::ResultSet, Bool)` - converts field reading it from db result set (second argument describes if field is nillable);
+- `.to_db(SomeType)` - converts field to the db format;
+- `.from_hash(Hash(String, Jennifer::DBAny), String)` - converts field from the given hash (second argument is a field name).
+
+There are 2 predefined converters:
+
+- `Jennifer::Model::JSONConverter` - default converter for `JSON::Any`;
+- `Jennifer::Model::NumericToFloat64Converter` - converts Postgres `PG::Numeric` to `Float64`.
 
 To make some field nillable tou can use any of the next options:
 
@@ -121,7 +132,7 @@ To make some field nillable tou can use any of the next options:
 - use `?` in type declaration (e.g. `some_field: String?` or `some_filed: {type: String?}`)
 - use union with `Nil` in the type declaration (e.g. `some_field: String | Nil` or `some_filed: {type: String | Nil}`)
 
-If you don't want to define all the table fields - pass `false` as second argument.
+If you don't want to define all the table fields - pass `false` as second argument (this will disable default strict mapping mode).
 
 `%mapping` defines next methods:
 
@@ -218,7 +229,7 @@ Existing mapping types:
 
 ### Numeric fields
 
-Crystal type of a numeric (decimal) field depends on chosen adapter: `Float64` for mysql and `PG::Numeric` for postgre. Sometimes usage of `PG::Numeric` with postgre may be annoying. To convert it to another type at the object building stage you can pass `numeric_converter` option with method to be used to convert `PG::Numeric` to the defined field `type`.
+Crystal type of a numeric (decimal) field depends on chosen adapter: `Float64` for mysql and `PG::Numeric` for Postgres. Sometimes usage of `PG::Numeric` with Postgres may be annoying. To convert it to another type at the object building stage you can pass `numeric_converter` option with method to be used to convert `PG::Numeric` to the defined field `type`.
 
 ```crystal
 class Product < Jennifer::Model::Base

--- a/docs/view.md
+++ b/docs/view.md
@@ -53,7 +53,7 @@ Also all defined mapping properties are accessible via `COLUMNS_METADA` constant
 
 ## Materialized
 
-> Materialized view is partially supported only by postgre adapter. MySQL doesn't provide support of materiazed view at all. This could be simulated only by using common table.
+> Materialized view is partially supported only by Postgres adapter. MySQL doesn't provide support of materialized view at all. This could be simulated only by using common table.
 
 Common migration for adding materialized view looks like this:
 

--- a/spec/model/mapping_spec.cr
+++ b/spec/model/mapping_spec.cr
@@ -224,7 +224,7 @@ describe Jennifer::Model::Mapping do
       end
     end
 
-    it "define default constructor if all fields are nilable or have default values" do
+    it "define default constructor if all fields are nillable or have default values" do
       Passport::WITH_DEFAULT_CONSTRUCTOR.should be_true
     end
 
@@ -305,7 +305,7 @@ describe Jennifer::Model::Mapping do
     context "data types" do
       describe "mapping types" do
         describe "Primary32" do
-          it "makes field nilable" do
+          it "makes field nillable" do
             Contact.primary_field_type.should eq(Int32?)
           end
         end
@@ -360,15 +360,15 @@ describe Jennifer::Model::Mapping do
         end
       end
 
-      context "nilable field" do
+      context "nillable field" do
         context "passed with ?" do
-          it "properly sets field as nilable" do
+          it "properly sets field as nillable" do
             typeof(ContactWithNillableName.new.name).should eq(String?)
           end
         end
 
         context "passed as union" do
-          it "properly sets field class as nilable" do
+          it "properly sets field class as nillable" do
             typeof(Factory.build_contact.created_at).should eq(Time?)
           end
         end

--- a/spec/model/sti_mapping_spec.cr
+++ b/spec/model/sti_mapping_spec.cr
@@ -34,18 +34,18 @@ describe Jennifer::Model::STIMapping do
         end
 
         context "using :null option" do
-          it "parses type as nilable" do
+          it "parses type as nillable" do
             typeof(Factory.build_twitter_profile.email).should eq(String?)
           end
         end
       end
     end
 
-    pending "defines default constructor if all fields are nilable or have default values and superclass has default constructor" do
+    pending "defines default constructor if all fields are nillable or have default values and superclass has default constructor" do
       TwitterProfile::WITH_DEFAULT_CONSTRUCTOR.should be_true
     end
 
-    it "doesn't define default constructor if all fields are nilable or have default values" do
+    it "doesn't define default constructor if all fields are nillable or have default values" do
       TwitterProfile::WITH_DEFAULT_CONSTRUCTOR.should be_false
     end
   end

--- a/spec/models.cr
+++ b/spec/models.cr
@@ -433,7 +433,7 @@ class ContactWithFloatMapping < Jennifer::Model::Base
   {% if env("DB") == "postgres" || env("DB") == nil %}
     mapping({
       id: Primary32,
-      ballance: { type: Float64?, numeric_converter: :to_f64}
+      ballance: { type: Float64?, converter: Jennifer::Model::NumericToFloat64Converter }
     }, false)
   {% else %}
     mapping({id: Primary32}, false)

--- a/src/jennifer/adapter/postgres.cr
+++ b/src/jennifer/adapter/postgres.cr
@@ -217,6 +217,7 @@ module Jennifer
   end
 end
 
+require "./postgres/converters"
 require "./postgres/criteria"
 require "./postgres/numeric"
 require "./postgres/migration/table_builder/base"

--- a/src/jennifer/adapter/postgres/converters.cr
+++ b/src/jennifer/adapter/postgres/converters.cr
@@ -1,0 +1,27 @@
+module Jennifer
+  module Model
+    class NumericToFloat64Converter
+      def self.from_db(pull, nillable)
+        if nillable
+          pull.read(PG::Numeric?).try(&.to_f64)
+        else
+          pull.read(PG::Numeric).to_f64
+        end
+      end
+
+      def self.to_db(value : Float?)
+        value
+      end
+
+      def self.from_hash(hash : Hash, column)
+        value = hash[column]
+        case value
+        when PG::Numeric
+          value.to_f64
+        else
+          value
+        end
+      end
+    end
+  end
+end

--- a/src/jennifer/model/base.cr
+++ b/src/jennifer/model/base.cr
@@ -4,6 +4,7 @@ require "./sti_mapping"
 require "./validation"
 require "./callback"
 require "./parameter_converter"
+require "./converters"
 
 module Jennifer
   module Model

--- a/src/jennifer/model/converters.cr
+++ b/src/jennifer/model/converters.cr
@@ -1,0 +1,28 @@
+module Jennifer
+  module Model
+    class JSONConverter
+      def self.from_db(pull, nillable)
+        puts pull.class
+        nillable ? pull.read(JSON::Any?) : pull.read(JSON::Any)
+      end
+
+      def self.to_db(value : JSON::Any)
+        value.to_json
+      end
+
+      def self.to_db(value : Nil)
+        value
+      end
+
+      def self.from_hash(hash : Hash, column)
+        value = hash[column]
+        case value
+        when String
+          JSON.parse(value)
+        else
+          value
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# What does this PR do?

- replaces mapping option `numeric_converter` with `converter` which allows specifying any kind of converter
- adds numeric-to-float64 and json converters
- small mapping optimizations

# Any background context you want to provide?

This allows defining custom converters for any kind of field.

# Release notes

**Model**

- replaces mapping option `numeric_converter` with new `converter`
- adds `NumericToFloat64Converter` and `JSONConverter`
- now `#to_h` and `#to_str_h` use field getter methods

