### PR TITLE
Populate native exception from the driver during quering

### DIFF
--- a/.travis.spec.sh
+++ b/.travis.spec.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 if [ "$INTEGRATION" == '1' ]; then
-  crystal spec spec/**/*_test.cr
+  # crystal spec spec/**/*_test.cr
+  crystal spec spec/integration/sam_test.cr & crystal spec spec/integration/concurrency_test.cr
 else
   crystal spec
 fi

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,7 +61,7 @@ db_uri = "mysql://root@somehost/some_database?max_pool_size=111&initial_pool_siz
 Jennifer::Config.from_uri(db)
 ```
 
-## Supported configuation parameters
+## Supported configuration parameters
 
 | Config | Default value |
 | --- | --- |
@@ -75,7 +75,7 @@ Jennifer::Config.from_uri(db)
 | `password` | - |
 | `db` | - |
 | `adapter` | - |
-| `max_pool_size` | 5 |
+| `max_pool_size` | 1 |
 | `initial_pool_size` | 1 |
 | `max_idle_pool_size` | 1 |
 | `retry_attempts` | 1 |
@@ -87,6 +87,8 @@ Jennifer::Config.from_uri(db)
 | `docker_container` | `""` |
 | `docker_source_location` | `""` |
 | `command_shell_sudo` | `false` |
+
+> It is highly recommended to set `max_idle_pool_size = max_pool_size = initial_pool_size` to prevent blowing up count of DB connections. For any details take a look at `crystal-db` [issue](https://github.com/crystal-lang/crystal-db/issues/77).
 
 To avoid port usage set it to `-1`. For doing same with the password - assign to it blank value (`""`). Empty string also turns off `structure_folder` config.
 

--- a/shard.yml
+++ b/shard.yml
@@ -17,7 +17,7 @@ development_dependencies:
     version: "~> 0.15.0"
   factory:
     github: imdrasil/factory
-    version: "~> 0.1.3"
+    version: "~> 0.1.4"
 dependencies:
   sam:
     github: imdrasil/sam.cr

--- a/spec/adapter/base_spec.cr
+++ b/spec/adapter/base_spec.cr
@@ -229,7 +229,7 @@ describe Jennifer::Adapter::Base do
         config.db = "db"
 
         db_connection_string = "#{config.adapter}://user:password@host/db?" \
-                               "max_pool_size=5&initial_pool_size=1&max_idle_pool_size=1&retry_attempts=1&checkout_timeout=5.0&retry_delay=1.0"
+                               "max_pool_size=1&initial_pool_size=1&max_idle_pool_size=1&retry_attempts=1&checkout_timeout=5.0&retry_delay=1.0"
         adapter.class.connection_string(:db).should eq(db_connection_string)
       end
 
@@ -241,7 +241,7 @@ describe Jennifer::Adapter::Base do
           config.db = "db"
           config.port = 3000
           db_connection_string = "#{config.adapter}://user:password@host:3000/db?" \
-                                 "max_pool_size=5&initial_pool_size=1&max_idle_pool_size=1&retry_attempts=1&checkout_timeout=5.0&retry_delay=1.0"
+                                 "max_pool_size=1&initial_pool_size=1&max_idle_pool_size=1&retry_attempts=1&checkout_timeout=5.0&retry_delay=1.0"
           adapter.class.connection_string(:db).should eq(db_connection_string)
         end
       end
@@ -255,7 +255,7 @@ describe Jennifer::Adapter::Base do
         config.db = "db"
 
         connection_string = "#{config.adapter}://user:password@host?" \
-                            "max_pool_size=5&initial_pool_size=1&max_idle_pool_size=1&retry_attempts=1&checkout_timeout=5.0&retry_delay=1.0"
+                            "max_pool_size=1&initial_pool_size=1&max_idle_pool_size=1&retry_attempts=1&checkout_timeout=5.0&retry_delay=1.0"
         adapter.class.connection_string.should eq(connection_string)
       end
     end
@@ -265,7 +265,7 @@ describe Jennifer::Adapter::Base do
         config.port = 3333
         config.password = ""
         connection_string = "#{config.adapter}://#{config.user}@#{config.host}:3333?" \
-                            "max_pool_size=5&initial_pool_size=1&max_idle_pool_size=1&retry_attempts=1&checkout_timeout=5.0&retry_delay=1.0"
+                            "max_pool_size=1&initial_pool_size=1&max_idle_pool_size=1&retry_attempts=1&checkout_timeout=5.0&retry_delay=1.0"
         adapter.class.connection_string.should eq(connection_string)
       end
     end

--- a/spec/integration/concurrency_test.cr
+++ b/spec/integration/concurrency_test.cr
@@ -1,0 +1,114 @@
+require "./shared_helpers"
+require "./spec_helper"
+
+POOL_SIZE = 3
+
+exit 0 if Spec.adapter != "mysql"
+
+Jennifer::Config.configure do |conf|
+  conf.logger.level = Logger::INFO
+  conf.host = "localhost"
+  conf.adapter = Spec.adapter
+  conf.migration_files_path = "./examples/migrations"
+  conf.db = "jennifer_test"
+  conf.max_pool_size = POOL_SIZE
+  conf.initial_pool_size = POOL_SIZE
+  conf.max_idle_pool_size = POOL_SIZE
+  conf.checkout_timeout = 1.0
+
+  case Spec.adapter
+  when "mysql"
+    conf.user = ENV["DB_USER"]? || "root"
+    conf.password = ""
+  when "postgres"
+    conf.user = ENV["DB_USER"]? || "developer"
+    conf.password = ENV["DB_PASSWORD"]? || "1qazxsw2"
+  else
+    raise "Unknown adapter #{Spec.adapter}"
+  end
+end
+
+Spec.before_each do
+  (Jennifer::Model::Base.models - [Jennifer::Migration::Version]).each { |model| model.all.delete }
+end
+
+describe "Concurrent execution" do
+  adapter = Jennifer::Adapter.adapter
+  tread_count = POOL_SIZE + 1
+
+  describe "Jennifer::Adapter::Base" do
+    sleep_command =
+      case Spec.adapter
+      when "mysql"
+        "SELECT SLEEP(2)"
+      when "postgres"
+        "SELECT pg_sleep(2)"
+      else
+        raise "Unknown adapter #{Spec.adapter}"
+      end
+
+    describe "#exec" do
+      it "raises native db exception" do
+        ch = Channel(String).new
+        tread_count.times do
+          spawn do
+            begin
+              adapter.exec(sleep_command)
+              ch.send("")
+            rescue e : Exception
+              ch.send(e.class.to_s)
+            end
+          end
+        end
+
+        responses = (0...tread_count).map { ch.receive }
+        responses.includes?("DB::PoolTimeout").should be_true
+      end
+    end
+
+    describe "#query" do
+      it "raises native db exception" do
+        ch = Channel(String).new
+        tread_count.times do
+          spawn do
+            begin
+              adapter.query(sleep_command) do |rs|
+                rs.each do
+                  rs.columns.size.times do
+                    rs.read
+                  end
+                end
+              end
+
+              ch.send("")
+            rescue e : Exception
+              ch.send(e.class.to_s)
+            end
+          end
+        end
+
+        responses = (0...tread_count).map { ch.receive }
+        responses.includes?("DB::PoolTimeout").should be_true
+      end
+    end
+
+    describe "#scalar" do
+      it "raises native db exception" do
+        ch = Channel(String).new
+        tread_count.times do
+          spawn do
+            begin
+              adapter.scalar(sleep_command)
+              ch.send("")
+            rescue e : Exception
+              ch.send(e.class.to_s)
+            end
+          end
+        end
+
+        responses = (0...tread_count).map { ch.receive }
+        responses.includes?("DB::PoolTimeout").should be_true
+      end
+    end
+  end
+end

--- a/spec/model/base_spec.cr
+++ b/spec/model/base_spec.cr
@@ -80,7 +80,7 @@ describe Jennifer::Model::Base do
   end
 
   describe "#new_record?" do
-    it "returns true if mrimary field nil" do
+    it "returns true if primary field nil" do
       Factory.build_contact.new_record?.should be_true
     end
 
@@ -328,7 +328,7 @@ describe Jennifer::Model::Base do
         ::Jennifer::Adapter.adapter.sql_generator.select(Contact.all.ordered).should match(/ORDER BY contacts\.name ASC/)
       end
 
-      context "without arguemnt" do
+      context "without argument" do
         it "is accessible from query object" do
           Contact.all.main.as_sql.should match(/contacts\.age >/)
         end
@@ -363,7 +363,7 @@ describe Jennifer::Model::Base do
         ::Jennifer::Adapter.adapter.sql_generator.select(Contact.johny).should match(/name =/)
       end
 
-      context "without arguemnt" do
+      context "without argument" do
         it "is accessible from query object" do
           Contact.johny.as_sql.should match(/contacts\.name =/)
         end
@@ -407,7 +407,7 @@ describe Jennifer::Model::Base do
       Contact.all.exists?.should be_false
     end
 
-    it "doen't invoke destroy callbacks" do
+    it "doesn't invoke destroy callbacks" do
       address = Factory.create_address
       count = Address.destroy_counter
       address.delete
@@ -500,7 +500,7 @@ describe Jennifer::Model::Base do
       Contact.all.count.should eq(1)
     end
 
-    it "doen't invoke destroy callbacks" do
+    it "doesn't invoke destroy callbacks" do
       address = Factory.create_address
       count = Address.destroy_counter
       Address.delete([address.id])

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -35,7 +35,7 @@ def clean_db
   postgres_only do
     Jennifer::Adapter.adapter.as(Jennifer::Postgres::Adapter).refresh_materialized_view(FemaleContact.table_name)
   end
-  Jennifer::Model::Base.models.select { |t| t.has_table? }.each(&.all.delete)
+  (Jennifer::Model::Base.models - [Jennifer::Migration::Version]).select { |t| t.has_table? }.each(&.all.delete)
 end
 
 # Ends current transaction, yields to the block, clear and starts next one

--- a/src/jennifer/adapter/base.cr
+++ b/src/jennifer/adapter/base.cr
@@ -24,9 +24,7 @@ module Jennifer
 
       extend AbstractClassMethods
 
-      @db : DB::Database
-
-      getter db
+      getter db : DB::Database
 
       def initialize
         @db = DB.open(Base.connection_string(:db))
@@ -50,6 +48,8 @@ module Jennifer
       rescue e : BaseException
         BadQuery.prepend_information(e, _query, args)
         raise e
+      rescue e : DB::Error
+        raise e
       rescue e : Exception
         raise BadQuery.new(e.message, _query, args)
       end
@@ -61,6 +61,8 @@ module Jennifer
         res
       rescue e : BaseException
         BadQuery.prepend_information(e, _query, args)
+        raise e
+      rescue e : DB::Error
         raise e
       rescue e : Exception
         raise BadQuery.new(e.message, _query, args)
@@ -74,6 +76,8 @@ module Jennifer
         res
       rescue e : BaseException
         BadQuery.prepend_information(e, _query, args)
+        raise e
+      rescue e : DB::Error
         raise e
       rescue e : Exception
         raise BadQuery.new(e.message, _query, args)

--- a/src/jennifer/adapter/base_sql_generator.cr
+++ b/src/jennifer/adapter/base_sql_generator.cr
@@ -43,7 +43,7 @@ module Jennifer
         "TRUNCATE #{table}"
       end
 
-      # TODO: unify method generting - #parse_query should be called here or by caller
+      # TODO: unify method generating - #parse_query should be called here or by caller
       def self.delete(query)
         parse_query(
           String.build do |s|

--- a/src/jennifer/adapter/transactions.cr
+++ b/src/jennifer/adapter/transactions.cr
@@ -28,8 +28,11 @@ module Jennifer
           yield @locks[fiber_id].transaction
         else
           conn = @db.checkout
-          res = yield conn
-          conn.release
+          begin
+            res = yield conn
+          ensure
+            conn.release
+          end
           res || false
         end
       end

--- a/src/jennifer/adapter/transactions.cr
+++ b/src/jennifer/adapter/transactions.cr
@@ -30,7 +30,7 @@ module Jennifer
           conn = @db.checkout
           res = yield conn
           conn.release
-          res ? res : false
+          res || false
         end
       end
 

--- a/src/jennifer/config.cr
+++ b/src/jennifer/config.cr
@@ -64,9 +64,16 @@ module Jennifer
       @local_time_zone_name = Time::Location.local.name
       @local_time_zone = Time::Location.local
 
+      # NOTE: Uncomment common default values after resolving https://github.com/crystal-lang/crystal-db/issues/77
+
+      # @initial_pool_size = 1
+      # @max_pool_size = 5
+      # @max_idle_pool_size = 1
+
       @initial_pool_size = 1
-      @max_pool_size = 5
+      @max_pool_size = 1
       @max_idle_pool_size = 1
+
       @retry_attempts = 1
 
       @checkout_timeout = 5.0
@@ -153,6 +160,11 @@ module Jennifer
     def validate_config
       raise Jennifer::InvalidConfig.new("No adapter configured") if adapter.empty?
       raise Jennifer::InvalidConfig.new("No database configured") if db.empty?
+      if max_idle_pool_size != max_pool_size || max_pool_size != initial_pool_size
+        logger.warn("It is highly recommended to set max_idle_pool_size = max_pool_size = initial_pool_size to "\
+                    "prevent blowing up count of DB connections. For any details take a look at "\
+                    "https://github.com/crystal-lang/crystal-db/issues/77")
+      end
     end
 
     def self.from_uri(uri)

--- a/src/jennifer/model/converters.cr
+++ b/src/jennifer/model/converters.cr
@@ -2,7 +2,6 @@ module Jennifer
   module Model
     class JSONConverter
       def self.from_db(pull, nillable)
-        puts pull.class
         nillable ? pull.read(JSON::Any?) : pull.read(JSON::Any)
       end
 


### PR DESCRIPTION
# What does this PR do?

Fix #156 and connection leak issue - when an exception is raised during transaction connection will not be released.

- add separa 

# Any background context you want to provide?

ATM `crystal-db` has some issue with idle connections in the connection pool so setting `max_idle_pool_size = max_pool_size = initial_pool_size` is the only way to ensure that application will use specified amount of connection.

# Release notes

**Model**

- remove `puts` from `JSONConverter#from_db`

**Adapter**

- propagate native `DB::Error` instead of wrapping it into `BadQuery`
- manually release a connection when an exception occurs under the transaction

**Config**

- set default `max_pool_size` to 1 and warn about dunger of setting different `max_pool_size`, `max_idle_pool_size` and `initial_pool_size`