### PR TITLE
Fix custom port not used in postgres adapter

### DIFF
--- a/src/jennifer/adapter/postgres/command_interface.cr
+++ b/src/jennifer/adapter/postgres/command_interface.cr
@@ -45,7 +45,7 @@ module Jennifer
 
       private def default_env_variables
         env = {"PGPASSWORD" => config.password} of String => Command::Option
-        env = env.merge({"PGPORT" => config.port.to_s}) unless config.port == -1
+        env["PGPORT"] = config.port.to_s unless config.port == -1
         env
       end
     end

--- a/src/jennifer/adapter/postgres/command_interface.cr
+++ b/src/jennifer/adapter/postgres/command_interface.cr
@@ -44,7 +44,9 @@ module Jennifer
       end
 
       private def default_env_variables
-        {"PGPASSWORD" => config.password} of String => Command::Option
+        env = {"PGPASSWORD" => config.password} of String => Command::Option
+        env = env.merge({"PGPORT" => config.port.to_s}) unless config.port == -1
+        env
       end
     end
   end


### PR DESCRIPTION
When using a custom port, the `config.port` is populated with the new port,
but the port is not used in the Jennifer::Postgres::CommandInterface methods.

this is fixed by updating #default_env_variables with the environment variable PGPORT:
```ruby
 env.merge({"PGPORT" => config.port.to_s}) unless config.port == -1
```

# What does this PR do?
Fix custom port not used in Postgres adapter.

# Any background context you want to provide?
I had an issue while creating the DB, it was using the default port even though I set up the custom port using `conf.port` and `#from_uri` both.

# Release notes

**Adapter**
- Fix custom port not used when accessing the Postgres database.

