### PR TITLE
Polymorphic relations

### DIFF
--- a/.travis.setup.sh
+++ b/.travis.setup.sh
@@ -12,4 +12,4 @@ if [ "$DB" == 'mysql' ] || [ "$PAIR" == '1' ]; then
 fi
 
 ./examples/setup.sh
-crystal ./examples/run.cr -- db:setup
+make sam db:setup

--- a/examples/migrations/20180909200027509_create_note.cr
+++ b/examples/migrations/20180909200027509_create_note.cr
@@ -1,0 +1,16 @@
+class CreateNote < Jennifer::Migration::Base
+  def up
+    create_table :notes do |t|
+      t.string :text
+
+      t.integer :notable_id
+      t.string :notable_type
+
+      t.timestamps
+    end
+  end
+
+  def down
+    drop_table :notes
+  end
+end

--- a/spec/factories.cr
+++ b/spec/factories.cr
@@ -125,7 +125,7 @@ class TwitterProfileFactory < ProfileFactory
   attr :type, TwitterProfile.to_s
 end
 
-class MaleContactFactory < Factory::Base
+class MaleContactFactory < Factory::Jennifer::Base
   postgres_only do
     argument_type (Array(Int32) | Int32 | PG::Numeric | String? | Time)
   end
@@ -134,4 +134,22 @@ class MaleContactFactory < Factory::Base
   attr :age, 21
   attr :gender, "male"
   attr :created_at, ->{ Time.utc_now }
+end
+
+class NoteFactory < Factory::Jennifer::Base
+  argument_type Jennifer::DBAny
+
+  attr :text, "Some text"
+  attr :notable_id, nil
+  attr :notable_type, nil
+
+  trait :with_user do
+    attr :notable_id, -> { Factory.create_user([:with_valid_password]).id }, Int32
+    attr :notable_type, "User"
+  end
+
+  trait :with_contact do
+    attr :notable_id, -> { Factory.create_contact.id }, Int32
+    attr :notable_type, "Contact"
+  end
 end

--- a/spec/migration/table_builder_spec.cr
+++ b/spec/migration/table_builder_spec.cr
@@ -1,0 +1,6 @@
+require "../spec_helper"
+
+describe Jennifer::Migration::TableBuilder do
+  pending "add" do
+  end
+end

--- a/spec/model/base_spec.cr
+++ b/spec/model/base_spec.cr
@@ -731,17 +731,17 @@ describe Jennifer::Model::Base do
   end
 
   describe "#inspect" do
-    it {
+    it do
       address = Factory.build_address
       address.inspect.should eq("#<Address:0x#{address.object_id.to_s(16)} id: nil, main: false, street: \"#{address.street}\","\
         " contact_id: nil, details: nil, created_at: nil, updated_at: nil>")
-    }
+    end
 
-    it {
+    it do
       profile = Factory.build_facebook_profile
-      profile.inspect.should eq("#<FacebookProfile:0x#{profile.object_id.to_s(16)} uid: \"1234\", "\
-        "virtual_child_field: nil, id: nil, login: \"some_login\", contact_id: nil, type: \"FacebookProfile\", "\
-        "virtual_parent_field: nil>")
-    }
+      profile.inspect.should eq("#<FacebookProfile:0x#{profile.object_id.to_s(16)} id: nil, login: \"some_login\", "\
+        "contact_id: nil, type: \"FacebookProfile\", virtual_parent_field: nil, uid: \"1234\", "\
+        "virtual_child_field: nil>")
+    end
   end
 end

--- a/spec/model/relation_definition_spec.cr
+++ b/spec/model/relation_definition_spec.cr
@@ -679,7 +679,7 @@ module Jennifer::Model
           q = c.countries_query
           select_query(q)
             .should match(/JOIN contacts_countries ON contacts_countries\.country_id = countries\.id AND contacts_countries\.contact_id = %s/)
-          q.select_args.should eq(db_array(c.id))
+          q.sql_args.should eq(db_array(c.id))
         end
 
         context "relation is a sti subclass" do
@@ -690,7 +690,7 @@ module Jennifer::Model
               .should match(/JOIN contacts_profiles ON contacts_profiles\.profile_id = profiles\.id AND contacts_profiles\.contact_id = %s/)
             select_query(q)
               .should match(/profiles\.type = %s/)
-            q.select_args.includes?("FacebookProfile").should be_true
+            q.sql_args.includes?("FacebookProfile").should be_true
           end
 
           it "works as well in inverse direction" do
@@ -698,7 +698,7 @@ module Jennifer::Model
             q = c.facebook_contacts_query
             select_query(q)
               .should match(/JOIN contacts_profiles ON contacts_profiles\.contact_id = contacts\.id AND contacts_profiles\.profile_id = %s/)
-            q.select_args.should eq(db_array(c.id))
+            q.sql_args.should eq(db_array(c.id))
           end
         end
       end

--- a/spec/model/relation_definition_spec.cr
+++ b/spec/model/relation_definition_spec.cr
@@ -1,543 +1,710 @@
 require "../spec_helper"
 
-describe Jennifer::Model::RelationDefinition do
-  describe "%nullify_dependency" do
-    it "adds before_destroy callback" do
-      ContactWithDependencies::CALLBACKS[:destroy][:before].includes?("__nullify_callback_facebook_profiles").should be_true
-    end
+module Jennifer::Model
+  class NoteWithDestroyDependency < Base
+    include Note::Mapping
 
-    it "doesn't invoke callbacks on associated model" do
-      c = Factory.create_contact
-      Factory.create_facebook_profile(contact_id: c.id)
-      c = ContactWithDependencies.all.last!
-      c.facebook_profiles.size.should eq(1)
-      c.destroy
-      f = FacebookProfile.all.last!
-      f.contact_id.nil?.should be_true
-    end
+    self.table_name "notes"
+
+    polymorphic_belongs_to :notable, Union(User | FacebookProfile), dependent: :destroy
+    actual_table_field_count
   end
 
-  describe "%delete_dependency" do
-    it "adds before_destroy callback" do
-      ContactWithDependencies::CALLBACKS[:destroy][:before].includes?("__delete_callback_addresses").should be_true
-    end
+  class NoteWithExceptionDependency < Base
+    include Note::Mapping
 
-    it "doesn't invoke callbacks on associated model" do
-      c = Factory.create_contact
-      Factory.create_address(contact_id: c.id)
-      count = Address.destroy_counter
-      c = ContactWithDependencies.all.last!
-      c.addresses.size.should eq(1)
-      c.destroy
-      Address.all.exists?.should be_false
-      Address.destroy_counter.should eq(count)
-    end
+    self.table_name "notes"
+
+    polymorphic_belongs_to :notable, Union(User | FacebookProfile), dependent: :restrict_with_exception
+    actual_table_field_count
   end
 
-  describe "%destroy_dependency" do
-    it "adds before_destroy callback" do
-      ContactWithDependencies::CALLBACKS[:destroy][:before].includes?("__destroy_callback_passports").should be_true
+  describe RelationDefinition do
+    describe "%nullify_dependency" do
+      it "adds before_destroy callback" do
+        ContactWithDependencies::CALLBACKS[:destroy][:before].includes?("__nullify_callback_facebook_profiles").should be_true
+      end
+
+      it "doesn't invoke callbacks on associated model" do
+        c = Factory.create_contact
+        Factory.create_facebook_profile(contact_id: c.id)
+        c = ContactWithDependencies.all.last!
+        c.facebook_profiles.size.should eq(1)
+        c.destroy
+        f = FacebookProfile.all.last!
+        f.contact_id.nil?.should be_true
+      end
     end
 
-    it "invokes callbacks on associated model" do
-      c = Factory.create_contact
-      Factory.create_passport(contact_id: c.id)
-      count = Passport.destroy_counter
-      c = ContactWithDependencies.all.last!
-      c.passports.size.should eq(1)
-      c.destroy
-      Passport.all.exists?.should be_false
-      Passport.destroy_counter.should eq(count + 1)
-    end
-  end
+    describe "%delete_dependency" do
+      it "adds before_destroy callback" do
+        ContactWithDependencies::CALLBACKS[:destroy][:before].includes?("__delete_callback_addresses").should be_true
+      end
 
-  describe "%restrict_with_exception_dependency" do
-    it "adds before_destroy callback" do
-      ContactWithDependencies::CALLBACKS[:destroy][:before].includes?("__restrict_with_exception_callback_twitter_profiles").should be_true
+      it "doesn't invoke callbacks on associated model" do
+        c = Factory.create_contact
+        Factory.create_address(contact_id: c.id)
+        count = Address.destroy_counter
+        c = ContactWithDependencies.all.last!
+        c.addresses.size.should eq(1)
+        c.destroy
+        Address.all.exists?.should be_false
+        Address.destroy_counter.should eq(count)
+      end
     end
 
-    it "raises exception if any associated record exists" do
-      c = Factory.create_contact
-      Factory.create_twitter_profile(contact_id: c.id)
-      c = ContactWithDependencies.all.last!
-      c.twitter_profiles.size.should eq(1)
-      expect_raises(::Jennifer::RecordExists) do
+    describe "%destroy_dependency" do
+      it "adds before_destroy callback" do
+        ContactWithDependencies::CALLBACKS[:destroy][:before].includes?("__destroy_callback_passports").should be_true
+      end
+
+      it "invokes callbacks on associated model" do
+        c = Factory.create_contact
+        Factory.create_passport(contact_id: c.id)
+        count = Passport.destroy_counter
+        c = ContactWithDependencies.all.last!
+        c.passports.size.should eq(1)
+        c.destroy
+        Passport.all.exists?.should be_false
+        Passport.destroy_counter.should eq(count + 1)
+      end
+
+      describe "polymorphic relation" do
+        it "adds before_destroy callback" do
+          NoteWithDestroyDependency::CALLBACKS[:destroy][:before].includes?("__destroy_callback_notable").should be_true
+        end
+
+        it "invokes callbacks on associated model" do
+          n = NoteWithDestroyDependency.find!(Factory.create_note.id)
+          n.add_notable(Factory.create_facebook_profile)
+          count = FacebookProfile.destroy_counter
+          n.destroy
+          FacebookProfile.all.exists?.should be_false
+          FacebookProfile.destroy_counter.should eq(count + 1)
+        end
+      end
+    end
+
+    describe "%restrict_with_exception_dependency" do
+      it "adds before_destroy callback" do
+        ContactWithDependencies::CALLBACKS[:destroy][:before].includes?("__restrict_with_exception_callback_twitter_profiles").should be_true
+      end
+
+      it "raises exception if any associated record exists" do
+        c = Factory.create_contact
+        Factory.create_twitter_profile(contact_id: c.id)
+        c = ContactWithDependencies.all.last!
+        c.twitter_profiles.size.should eq(1)
+        expect_raises(::Jennifer::RecordExists) do
+          c.destroy
+        end
+        TwitterProfile.all.count.should eq(1)
+      end
+
+       it "passes if no associated object exists" do
+        c = Factory.create_contact
         c.destroy
       end
-      TwitterProfile.all.count.should eq(1)
-    end
-  end
 
-  describe "%has_many" do
-    it "adds relation name to RELATIONS constant" do
-      Contact::RELATIONS.size.should eq(7)
-      Contact::RELATIONS.has_key?("addresses").should be_true
+      describe "polymorphic relation" do
+        it "adds before_destroy callback" do
+          NoteWithExceptionDependency::CALLBACKS[:destroy][:before].includes?("__restrict_with_exception_callback_notable").should be_true
+        end
+
+        it "raises exception if any associated record exists" do
+          n = NoteWithExceptionDependency.find!(Factory.create_note.id)
+          n.add_notable(Factory.create_facebook_profile)
+          expect_raises(::Jennifer::RecordExists) do
+            n.destroy
+          end
+          FacebookProfile.all.count.should eq(1)
+        end
+
+        it "passes if no associated object exists" do
+          n = NoteWithExceptionDependency.find!(Factory.create_note.id)
+          n.destroy
+        end
+      end
     end
 
-    context "query" do
-      it "sets correct query part" do
-        Contact.relation("addresses").condition_clause.as_sql.should eq("addresses.contact_id = contacts.id")
+    describe "%has_many" do
+      it "adds relation name to RELATIONS constant" do
+        Contact::RELATIONS.size.should eq(7)
+        Contact::RELATIONS.has_key?("addresses").should be_true
       end
 
-      context "when declaration has additional block" do
+      context "query" do
         it "sets correct query part" do
-          Contact.relation("main_address").condition_clause.as_sql.should match(/addresses\.contact_id = contacts\.id AND addresses\.main/)
+          Contact.relation("addresses").condition_clause.as_sql.should eq("addresses.contact_id = contacts.id")
+        end
+
+        context "when declaration has additional block" do
+          it "sets correct query part" do
+            Contact.relation("main_address").condition_clause.as_sql.should match(/addresses\.contact_id = contacts\.id AND addresses\.main/)
+          end
         end
       end
-    end
 
-    describe "#/relation_name/_query" do
-      it "returns query object" do
-        c = Factory.create_contact
-        q = c.addresses_query
-        q.as_sql.should match(/addresses.contact_id = %s/)
-        q.sql_args.should eq(db_array(c.id))
-      end
+      describe "#/relation_name/_query" do
+        it "returns query object" do
+          c = Factory.create_contact
+          q = c.addresses_query
+          q.as_sql.should match(/addresses.contact_id = %s/)
+          q.sql_args.should eq(db_array(c.id))
+        end
 
-      context "relation is a sti subclass" do
-        it "returns proper objects" do
-          c = Factory.build_contact
-          q = c.facebook_profiles_query
-          q.as_sql.should match(/profiles\.type = %s/)
-          q.sql_args.includes?("FacebookProfile").should be_true
+        context "relation is a sti subclass" do
+          it "returns proper objects" do
+            c = Factory.build_contact
+            q = c.facebook_profiles_query
+            q.as_sql.should match(/profiles\.type = %s/)
+            q.sql_args.includes?("FacebookProfile").should be_true
+          end
         end
       end
-    end
 
-    describe "#/relation_name/" do
-      it "loads relation objects from db" do
-        c = Factory.create_contact
-        Factory.create_address(contact_id: c.id)
-        c.addresses.size.should eq(1)
+      describe "#/relation_name/" do
+        it "loads relation objects from db" do
+          c = Factory.create_contact
+          Factory.create_address(contact_id: c.id)
+          c.addresses.size.should eq(1)
+        end
+
+        it "will not hit db again if previous call returns empty array" do
+          c = Factory.create_contact
+          count = query_count
+          c.addresses.empty?.should be_true
+          query_count.should eq(count + 1)
+          c.addresses
+          query_count.should eq(count + 1)
+        end
+
+        context "with defined inverse_of" do
+          it "sets owner during building collection" do
+            c = Factory.create_contact
+            a = Factory.create_address(contact_id: c.id)
+            count = query_count
+            c.addresses[0].contact
+            query_count.should eq(count + 1)
+          end
+
+          it "sets owner during building collection 2" do
+            c = Factory.create_contact
+            a = Factory.create_facebook_profile(contact_id: c.id)
+            count = query_count
+            c.facebook_profiles[0].contact
+            query_count.should eq(count + 1)
+          end
+        end
+
+        context "new record" do
+          it "doesn't hit the db" do
+            c = Factory.build_contact
+            count = query_count
+            c.addresses
+            query_count.should eq(count)
+          end
+        end
       end
 
-      it "will not hit db again if previous call returns empty array" do
-        c = Factory.create_contact
-        count = query_count
-        c.addresses.empty?.should be_true
-        query_count.should eq(count + 1)
-        c.addresses
-        query_count.should eq(count + 1)
+      describe "#add_/relation_name/" do
+        it "creates new objects depending on given hash" do
+          c = Factory.create_contact
+          c.add_addresses({:main => true, :street => "some street", :details => nil})
+          c.addresses.size.should eq(1)
+          c.addresses[0].street.should eq("some street")
+          c.addresses[0].contact_id.should eq(c.id)
+          c.addresses[0].new_record?.should be_false
+        end
+
+        it "creates new objects depending on given object" do
+          c = Factory.create_contact
+          a = Factory.build_address(street: "some street")
+          c.add_addresses(a)
+          c.addresses.size.should eq(1)
+          c.addresses[0].street.should eq("some street")
+          c.addresses[0].contact_id.should eq(c.id)
+          c.addresses[0].new_record?.should be_false
+        end
+
+        it "stop loading relation from db" do
+          c = Factory.create_contact
+          a = Factory.build_address(street: "some street")
+          Factory.create_address(contact_id: c.id)
+          c.add_addresses(a)
+          count = query_count
+          c.addresses.size.should eq(1)
+          query_count.should eq(count)
+        end
       end
 
-      context "with defined inverse_of" do
-        it "sets owner during building collection" do
+      describe "#remove_/relation_name/" do
+        it "removes foreign key and removes it from array" do
+          c = Factory.create_contact
+          a = Factory.build_address(street: "some street")
+          c.add_addresses(a)
+          c.addresses[0].new_record?.should be_false
+          c.remove_addresses(a)
+          c.addresses.size.should eq(0)
+          a = Address.find!(a.id)
+          a.contact_id.should be_nil
+        end
+      end
+
+      describe "#/relation_name/_reload" do
+        it "reloads objects" do
           c = Factory.create_contact
           a = Factory.create_address(contact_id: c.id)
-          count = query_count
-          c.addresses[0].contact
-          query_count.should eq(count + 1)
-        end
-
-        it "sets owner during building collection 2" do
-          c = Factory.create_contact
-          a = Factory.create_facebook_profile(contact_id: c.id)
-          count = query_count
-          c.facebook_profiles[0].contact
-          query_count.should eq(count + 1)
-        end
-      end
-
-      context "new record" do
-        it "doesn't hit the db" do
-          c = Factory.build_contact
-          count = query_count
           c.addresses
-          query_count.should eq(count)
+          a.street = "some strange street"
+          a.save
+          c.addresses_reload
+          c.addresses[0].street.should eq("some strange street")
         end
       end
     end
 
-    describe "#add_/relation_name/" do
-      it "creates new objects depending on given hash" do
-        c = Factory.create_contact
-        c.add_addresses({:main => true, :street => "some street", :details => nil})
-        c.addresses.size.should eq(1)
-        c.addresses[0].street.should eq("some street")
-        c.addresses[0].contact_id.should eq(c.id)
-        c.addresses[0].new_record?.should be_false
+    describe "%belongs_to" do
+      it "adds relation name to RELATIONS constant" do
+        Address::RELATIONS.size.should eq(1)
+        Address::RELATIONS.has_key?("contact").should be_true
       end
 
-      it "creates new objects depending on given object" do
-        c = Factory.create_contact
-        a = Factory.build_address(street: "some street")
-        c.add_addresses(a)
-        c.addresses.size.should eq(1)
-        c.addresses[0].street.should eq("some street")
-        c.addresses[0].contact_id.should eq(c.id)
-        c.addresses[0].new_record?.should be_false
-      end
-
-      it "stop loading relation from db" do
-        c = Factory.create_contact
-        a = Factory.build_address(street: "some street")
-        Factory.create_address(contact_id: c.id)
-        c.add_addresses(a)
-        count = query_count
-        c.addresses.size.should eq(1)
-        query_count.should eq(count)
-      end
-    end
-
-    describe "#remove_/relation_name/" do
-      it "removes foreign key and removes it from array" do
-        c = Factory.create_contact
-        a = Factory.build_address(street: "some street")
-        c.add_addresses(a)
-        c.addresses[0].new_record?.should be_false
-        c.remove_addresses(a)
-        c.addresses.size.should eq(0)
-        a = Address.find!(a.id)
-        a.contact_id.should be_nil
-      end
-    end
-
-    describe "#/relation_name/_reload" do
-      it "reloads objects" do
-        c = Factory.create_contact
-        a = Factory.create_address(contact_id: c.id)
-        c.addresses
-        a.street = "some strange street"
-        a.save
-        c.addresses_reload
-        c.addresses[0].street.should eq("some strange street")
-      end
-    end
-  end
-
-  describe "%belongs_to" do
-    it "adds relation name to RELATIONS constant" do
-      Address::RELATIONS.size.should eq(1)
-      Address::RELATIONS.has_key?("contact").should be_true
-    end
-
-    context "query" do
-      it "sets correct query part" do
-        Address.relation("contact").condition_clause.as_sql.should eq("contacts.id = addresses.contact_id")
-      end
-
-      context "when declaration has additional block" do
+      context "query" do
         it "sets correct query part" do
-          query = JohnPassport.relation("contact").condition_clause
-          query.as_sql.should match(/contacts\.id = passports\.contact_id AND contacts\.name = %s/)
-          query.sql_args.should eq(db_array("John"))
+          Address.relation("contact").condition_clause.as_sql.should eq("contacts.id = addresses.contact_id")
+        end
+
+        context "when declaration has additional block" do
+          it "sets correct query part" do
+            query = JohnPassport.relation("contact").condition_clause
+            query.as_sql.should match(/contacts\.id = passports\.contact_id AND contacts\.name = %s/)
+            query.sql_args.should eq(db_array("John"))
+          end
         end
       end
-    end
 
-    describe "#/relation_name/_query" do
-      it "returns query object" do
-        c = Factory.create_contact
-        a = Factory.create_address(contact_id: c.id)
-        q = a.contact_query
-        q.as_sql.should match(/contacts.id = %s/)
-        q.sql_args.should eq(db_array(c.id))
-      end
-    end
-
-    describe "#/relation_name/" do
-      it "loads relation objects from db" do
-        c = Factory.create_contact
-        a = Factory.create_address(contact_id: c.id)
-        a.contact.should be_a(Contact)
-      end
-
-      it "will not hit db again if previous call returns empty array" do
-        a = Factory.create_address
-        count = query_count
-        a.contact.nil?.should be_true
-        query_count.should eq(count + 1)
-        a.contact
-        query_count.should eq(count + 1)
-      end
-
-      context "new record" do
-        it "doesn't hit the db" do
-          c = Factory.build_contact
-          count = query_count
-          c.addresses
-          query_count.should eq(count)
-        end
-      end
-    end
-
-    describe "#add_/relation_name/" do
-      it "builds new objects depending on given hash" do
-        a = Factory.create_address
-        a.add_contact({:name => "some name", :age => 16})
-        a.contact!.name.should eq("some name")
-      end
-    end
-
-    describe "#/relation_name/_reload" do
-      it "reloads objects" do
-        c = Factory.create_contact
-        a = Factory.create_address(contact_id: c.id)
-        a.contact
-        c.name = "some new name"
-        c.save
-        a.contact_reload
-        a.contact_reload.not_nil!.name.should eq("some new name")
-      end
-    end
-
-    describe "#remove_/relation_name/" do
-      it "removes foreign key and removes it from array" do
-        c = Factory.create_contact
-        a = Factory.create_address(contact_id: c.id)
-        a.contact
-        a.remove_contact
-        a.contact.should be_nil
-        Address.find!(a.id).contact_id.should be_nil
-      end
-    end
-  end
-
-  describe "%has_one" do
-    it "adds relation name to RELATIONS constant" do
-      Contact::RELATIONS.has_key?("addresses").should be_true
-    end
-
-    context "query" do
-      it "sets correct query part" do
-        Contact.relation("passport").condition_clause.as_sql.should eq("passports.contact_id = contacts.id")
-      end
-
-      context "when declaration has additional block" do
-        it "sets correct query part" do
-          sql_reg = /addresses\.contact_id = contacts\.id AND addresses\.main/
-          Contact.relation("main_address").condition_clause.as_sql.should match(sql_reg)
-        end
-      end
-    end
-
-    describe "#/relation_name/_query" do
-      it "returns query object" do
-        c = Factory.create_contact
-        q = c.main_address_query
-        q.as_sql.should match(/addresses.contact_id = %s AND addresses.main/)
-        q.sql_args.should eq(db_array(c.id))
-      end
-    end
-
-    describe "#/relation_name/" do
-      it "loads relation objects from db" do
-        c = Factory.create_contact
-        Factory.create_address(contact_id: c.id, main: true)
-        c.main_address.nil?.should be_false
-      end
-
-      it "will not hit db again if previous call returns empty array" do
-        c = Factory.create_contact
-        count = query_count
-        c.main_address.nil?.should be_true
-        query_count.should eq(count + 1)
-        c.main_address
-        query_count.should eq(count + 1)
-      end
-
-      context "with defined inverse_of" do
-        it "sets owner during building collection" do
+      describe "#/relation_name/_query" do
+        it "returns query object" do
           c = Factory.create_contact
-          a = Factory.create_address(contact_id: c.id, main: true)
-          count = query_count
-          c.main_address!.contact
-          query_count.should eq(count + 1)
-        end
-
-        it "sets owner during building collection 2" do
-          c = Factory.create_contact
-          a = Factory.create_passport(contact_id: c.id)
-          count = query_count
-          c.passport!.contact
-          query_count.should eq(count + 1)
-        end
-      end
-
-      context "new record" do
-        it "doesn't hit the db" do
-          c = Factory.build_contact
-          count = query_count
-          c.addresses
-          query_count.should eq(count)
-        end
-      end
-    end
-
-    describe "#add_/relation_name/" do
-      it "builds new objects depending on given hash" do
-        c = Factory.build_contact
-        c.add_main_address({:main => true, :street => "some street", :contact_id => 1, :details => nil})
-        c.main_address.nil?.should be_false
-      end
-    end
-
-    describe "#/relation_name/_reload" do
-      it "reloads objects" do
-        c = Factory.create_contact
-        a = Factory.create_address(contact_id: c.id, main: true)
-        c.main_address
-        a.street = "some strange street"
-        a.save
-        c.main_address_reload
-        c.main_address!.street.should eq("some strange street")
-      end
-    end
-
-    describe "#remove_/relation_name/" do
-      it "removes foreign key and removes it from array" do
-        c = Factory.create_contact
-        p = Factory.create_passport(contact_id: c.id)
-        c.passport
-        c.remove_passport
-        c.passport.should be_nil
-        Passport.find!(p.enn).contact_id.should be_nil
-      end
-    end
-  end
-
-  describe "%has_and_belongs_many" do
-    context "query" do
-      it "sets correct query part" do
-        query = ContactWithDependencies.relation("u_countries")
-        query.condition_clause.as_sql.should eq("countries.contact_id = contacts.id AND countries.name LIKE %s")
-        query.condition_clause.sql_args.should eq(db_array("U%"))
-      end
-    end
-
-    describe "#/relation_name/_query" do
-      it "returns query object" do
-        c = Factory.create_contact
-        q = c.countries_query
-        select_query(q)
-          .should match(/JOIN contacts_countries ON contacts_countries\.country_id = countries\.id AND contacts_countries\.contact_id = %s/)
-        q.sql_args.should eq(db_array(c.id))
-      end
-
-      context "relation is a sti subclass" do
-        it "returns proper objects" do
-          c = Factory.create_contact
-          q = c.facebook_many_profiles_query
-          select_query(q)
-            .should match(/JOIN contacts_profiles ON contacts_profiles\.profile_id = profiles\.id AND contacts_profiles\.contact_id = %s/)
-          select_query(q)
-            .should match(/profiles\.type = %s/)
-          q.sql_args.includes?("FacebookProfile").should be_true
-        end
-
-        it "works as well in inverse direction" do
-          c = Factory.create_facebook_profile
-          q = c.facebook_contacts_query
-          select_query(q)
-            .should match(/JOIN contacts_profiles ON contacts_profiles\.contact_id = contacts\.id AND contacts_profiles\.profile_id = %s/)
+          a = Factory.create_address(contact_id: c.id)
+          q = a.contact_query
+          q.as_sql.should match(/contacts.id = %s/)
           q.sql_args.should eq(db_array(c.id))
         end
       end
-    end
 
-    describe "#/relation_name/" do
-      it "loads relation objects from db" do
-        c = Factory.create_contact
+      describe "#/relation_name/" do
+        it "loads relation objects from db" do
+          c = Factory.create_contact
+          a = Factory.create_address(contact_id: c.id)
+          a.contact.should be_a(Contact)
+        end
 
-        c.add_countries({:name => "k1"})
-        c.countries.size.should eq(1)
-        Country.all.first!.name.should eq("k1")
-      end
-
-      it "will not hit db again if previous call returns empty array" do
-        c = Factory.create_contact
-        count = query_count
-        c.countries.empty?.should be_true
-        query_count.should eq(count + 1)
-        c.countries
-        query_count.should eq(count + 1)
-      end
-
-      context "new record" do
-        it "doesn't hit the db" do
-          c = Factory.build_contact
+        it "will not hit db again if previous call returns empty array" do
+          a = Factory.create_address
           count = query_count
-          c.addresses
-          query_count.should eq(count)
+          a.contact.nil?.should be_true
+          query_count.should eq(count + 1)
+          a.contact
+          query_count.should eq(count + 1)
+        end
+
+        context "new record" do
+          it "doesn't hit the db" do
+            c = Factory.build_contact
+            count = query_count
+            c.addresses
+            query_count.should eq(count)
+          end
+        end
+      end
+
+      describe "#add_/relation_name/" do
+        it "builds new objects depending on given hash" do
+          a = Factory.create_address
+          a.add_contact({:name => "some name", :age => 16})
+          a.contact!.name.should eq("some name")
+        end
+      end
+
+      describe "#/relation_name/_reload" do
+        it "reloads objects" do
+          c = Factory.create_contact
+          a = Factory.create_address(contact_id: c.id)
+          a.contact
+          c.name = "some new name"
+          c.save
+          a.contact_reload
+          a.contact_reload.not_nil!.name.should eq("some new name")
+        end
+      end
+
+      describe "#remove_/relation_name/" do
+        it "removes foreign key and removes it from array" do
+          c = Factory.create_contact
+          a = Factory.create_address(contact_id: c.id)
+          a.contact
+          a.remove_contact
+          a.contact.should be_nil
+          Address.find!(a.id).contact_id.should be_nil
+        end
+      end
+
+      describe "polymorphic" do
+        it "adds relation name to RELATIONS constant" do
+          Note::RELATIONS.size.should eq(1)
+          Note::RELATIONS.has_key?("notable").should be_true
+        end
+
+        describe "#/relation_name/_query" do
+          it "returns query object" do
+            n = Factory.create_note([:with_user])
+            q = n.notable_query
+            q.as_sql.should match(/users.id = %s/)
+            q.sql_args.should eq(db_array(n.notable!.id))
+          end
+        end
+
+        describe "#/relation_name/" do
+          it "loads relation objects from db" do
+            u = Factory.create_user([:with_valid_password])
+            note = Note.create!(text: "some text", notable_id: u.id, notable_type: "User")
+            note.notable.should be_a(User)
+            note.notable.as(User).id.should eq(u.id)
+          end
+
+          it "doesn't hit db when foreign key or polymorphic type is empty" do
+            note = Factory.create_note
+            count = query_count
+            note.notable.nil?.should be_true
+            query_count.should eq(count)
+          end
+
+          it "will not hit db again if previous call returns empty array" do
+            note = Factory.create_note
+            note.notable_type = "User"
+            note.notable_id = 1
+            count = query_count
+            note.notable.nil?.should be_true
+            query_count.should eq(count + 1)
+            note.notable
+            query_count.should eq(count + 1)
+          end
+
+          context "new record" do
+            it "doesn't hit the db" do
+              n = Factory.build_note
+              count = query_count
+              n.notable
+              query_count.should eq(count)
+            end
+          end
+
+          describe "with class suffix" do
+            it "returns casted instance" do
+              Factory.create_note([:with_contact]).notable_contact.should be_a(Contact)
+              Factory.create_note([:with_user]).notable_user.should be_a(User)
+            end
+          end
+        end
+
+        describe "#add_/relation_name/" do
+          context "with given hash" do
+            it "builds new object" do
+              note = Factory.create_note
+              note.add_notable({ "name" => "Jack", "age" => 16, "notable_type" => "Contact"})
+              note.notable.should be_a(Contact)
+              note.notable_contact.name.should eq("Jack")
+              note.notable_id.should_not be_nil
+              note.notable_type.should eq("Contact")
+            end
+          end
+
+          context "with given object" do
+            it "builds new object" do
+              note = Factory.create_note
+              c = Factory.create_contact
+              note.add_notable(c)
+              note.notable.should be_a(Contact)
+              note.notable_contact.name.should eq(c.name)
+              note.notable_id.should eq(c.id)
+              note.notable_type.should eq("Contact")
+            end
+          end
+        end
+
+        describe "#/relation_name/_reload" do
+          it "reloads objects" do
+            c = Factory.create_contact
+            n = Factory.create_note(notable_id: c.id, notable_type: "Contact")
+            n.notable
+            c.name = "some new name"
+            c.save
+            n.notable_reload.as(Contact).name.should eq("some new name")
+          end
+        end
+
+        describe "#remove_/relation_name/" do
+          it "removes foreign key and removes it from array" do
+            n = Factory.create_note([:with_contact])
+            n.notable
+            n.remove_notable
+            n.notable.should be_nil
+            n.reload
+            n.notable_id.should be_nil
+            n.notable_type.should be_nil
+          end
         end
       end
     end
 
-    describe "#add_/relation_name/" do
-      it "builds new objects depending on given hash" do
-        c = Factory.create_contact
-        c.add_countries({:name => "k1"})
-        c.countries.size.should eq(1)
-        Country.all.count.should eq(1)
-        ::Jennifer::Query.new("contacts_countries").where do
-          (_contact_id == c.id) & (_country_id == c.countries[0].id)
-        end.exists?.should be_true
-        c.countries[0].name.should eq("k1")
+    describe "%has_one" do
+      it "adds relation name to RELATIONS constant" do
+        Contact::RELATIONS.has_key?("addresses").should be_true
       end
-    end
 
-    describe "#remove_/relation_name/" do
-      it "removes join table record from db and array" do
-        c = Factory.create_contact
-        country = Factory.create_country
-        c.add_countries(country)
-        c.countries.size.should eq(1)
-        c.remove_countries(country)
-        c.countries.size.should eq(0)
-        ::Jennifer::Query.new("contacts_countries").where do
-          (_contact_id == c.id) & (_country_id == country.id)
-        end.exists?.should be_false
-      end
-    end
-
-    describe "#/relation_name/_reload" do
-      it "reloads objects" do
-        c = Factory.create_contact
-        c.add_countries({:name => "k1"})
-        country = Country.all.first!
-        country.name = "k2"
-        country.save
-        c.countries_reload
-        c.countries[0].name.should eq("k2")
-      end
-    end
-
-    describe "#__/relation_name/_clean" do
-      it "removes join table record" do
-        c = Factory.create_contact
-        country = Factory.create_country
-        c.add_countries(country)
-        q = Jennifer::Query.new("contacts_countries").where do
-          (_contact_id == c.id) & (_country_id == country.id)
+      context "query" do
+        it "sets correct query part" do
+          Contact.relation("passport").condition_clause.as_sql.should eq("passports.contact_id = contacts.id")
         end
-        q.exists?.should be_true
-        country.__contacts_clean
-        q.exists?.should be_false
+
+        context "when declaration has additional block" do
+          it "sets correct query part" do
+            sql_reg = /addresses\.contact_id = contacts\.id AND addresses\.main/
+            Contact.relation("main_address").condition_clause.as_sql.should match(sql_reg)
+          end
+        end
+      end
+
+      describe "#/relation_name/_query" do
+        it "returns query object" do
+          c = Factory.create_contact
+          q = c.main_address_query
+          q.as_sql.should match(/addresses.contact_id = %s AND addresses.main/)
+          q.sql_args.should eq(db_array(c.id))
+        end
+      end
+
+      describe "#/relation_name/" do
+        it "loads relation objects from db" do
+          c = Factory.create_contact
+          Factory.create_address(contact_id: c.id, main: true)
+          c.main_address.nil?.should be_false
+        end
+
+        it "will not hit db again if previous call returns empty array" do
+          c = Factory.create_contact
+          count = query_count
+          c.main_address.nil?.should be_true
+          query_count.should eq(count + 1)
+          c.main_address
+          query_count.should eq(count + 1)
+        end
+
+        context "with defined inverse_of" do
+          it "sets owner during building collection" do
+            c = Factory.create_contact
+            a = Factory.create_address(contact_id: c.id, main: true)
+            count = query_count
+            c.main_address!.contact
+            query_count.should eq(count + 1)
+          end
+
+          it "sets owner during building collection 2" do
+            c = Factory.create_contact
+            a = Factory.create_passport(contact_id: c.id)
+            count = query_count
+            c.passport!.contact
+            query_count.should eq(count + 1)
+          end
+        end
+
+        context "new record" do
+          it "doesn't hit the db" do
+            c = Factory.build_contact
+            count = query_count
+            c.addresses
+            query_count.should eq(count)
+          end
+        end
+      end
+
+      describe "#add_/relation_name/" do
+        it "builds new objects depending on given hash" do
+          c = Factory.build_contact
+          c.add_main_address({:main => true, :street => "some street", :contact_id => 1, :details => nil})
+          c.main_address.nil?.should be_false
+        end
+      end
+
+      describe "#/relation_name/_reload" do
+        it "reloads objects" do
+          c = Factory.create_contact
+          a = Factory.create_address(contact_id: c.id, main: true)
+          c.main_address
+          a.street = "some strange street"
+          a.save
+          c.main_address_reload
+          c.main_address!.street.should eq("some strange street")
+        end
+      end
+
+      describe "#remove_/relation_name/" do
+        it "removes foreign key and removes it from array" do
+          c = Factory.create_contact
+          p = Factory.create_passport(contact_id: c.id)
+          c.passport
+          c.remove_passport
+          c.passport.should be_nil
+          Passport.find!(p.enn).contact_id.should be_nil
+        end
       end
     end
-  end
 
-  describe "#relation_retrieved" do
-    describe "sti" do
+    describe "%has_and_belongs_many" do
+      context "query" do
+        it "sets correct query part" do
+          query = ContactWithDependencies.relation("u_countries")
+          query.condition_clause.as_sql.should eq("countries.contact_id = contacts.id AND countries.name LIKE %s")
+          query.condition_clause.sql_args.should eq(db_array("U%"))
+        end
+      end
+
+      describe "#/relation_name/_query" do
+        it "returns query object" do
+          c = Factory.create_contact
+          q = c.countries_query
+          select_query(q)
+            .should match(/JOIN contacts_countries ON contacts_countries\.country_id = countries\.id AND contacts_countries\.contact_id = %s/)
+          q.select_args.should eq(db_array(c.id))
+        end
+
+        context "relation is a sti subclass" do
+          it "returns proper objects" do
+            c = Factory.create_contact
+            q = c.facebook_many_profiles_query
+            select_query(q)
+              .should match(/JOIN contacts_profiles ON contacts_profiles\.profile_id = profiles\.id AND contacts_profiles\.contact_id = %s/)
+            select_query(q)
+              .should match(/profiles\.type = %s/)
+            q.select_args.includes?("FacebookProfile").should be_true
+          end
+
+          it "works as well in inverse direction" do
+            c = Factory.create_facebook_profile
+            q = c.facebook_contacts_query
+            select_query(q)
+              .should match(/JOIN contacts_profiles ON contacts_profiles\.contact_id = contacts\.id AND contacts_profiles\.profile_id = %s/)
+            q.select_args.should eq(db_array(c.id))
+          end
+        end
+      end
+
+      describe "#/relation_name/" do
+        it "loads relation objects from db" do
+          c = Factory.create_contact
+
+          c.add_countries({:name => "k1"})
+          c.countries.size.should eq(1)
+          Country.all.first!.name.should eq("k1")
+        end
+
+        it "will not hit db again if previous call returns empty array" do
+          c = Factory.create_contact
+          count = query_count
+          c.countries.empty?.should be_true
+          query_count.should eq(count + 1)
+          c.countries
+          query_count.should eq(count + 1)
+        end
+
+        context "new record" do
+          it "doesn't hit the db" do
+            c = Factory.build_contact
+            count = query_count
+            c.addresses
+            query_count.should eq(count)
+          end
+        end
+      end
+
+      describe "#add_/relation_name/" do
+        it "builds new objects depending on given hash" do
+          c = Factory.create_contact
+          c.add_countries({:name => "k1"})
+          c.countries.size.should eq(1)
+          Country.all.count.should eq(1)
+          ::Jennifer::Query.new("contacts_countries").where do
+            (_contact_id == c.id) & (_country_id == c.countries[0].id)
+          end.exists?.should be_true
+          c.countries[0].name.should eq("k1")
+        end
+      end
+
+      describe "#remove_/relation_name/" do
+        it "removes join table record from db and array" do
+          c = Factory.create_contact
+          country = Factory.create_country
+          c.add_countries(country)
+          c.countries.size.should eq(1)
+          c.remove_countries(country)
+          c.countries.size.should eq(0)
+          ::Jennifer::Query.new("contacts_countries").where do
+            (_contact_id == c.id) & (_country_id == country.id)
+          end.exists?.should be_false
+        end
+      end
+
+      describe "#/relation_name/_reload" do
+        it "reloads objects" do
+          c = Factory.create_contact
+          c.add_countries({:name => "k1"})
+          country = Country.all.first!
+          country.name = "k2"
+          country.save
+          c.countries_reload
+          c.countries[0].name.should eq("k2")
+        end
+      end
+
+      describe "#__/relation_name/_clean" do
+        it "removes join table record" do
+          c = Factory.create_contact
+          country = Factory.create_country
+          c.add_countries(country)
+          q = Jennifer::Query.new("contacts_countries").where do
+            (_contact_id == c.id) & (_country_id == country.id)
+          end
+          q.exists?.should be_true
+          country.__contacts_clean
+          q.exists?.should be_false
+        end
+      end
+    end
+
+    describe "#relation_retrieved" do
+      describe "sti" do
+        context "with unknown relation" do
+          it { expect_raises(Jennifer::UnknownRelation) { Factory.create_facebook_profile.relation_retrieved("unknown") } }
+        end
+
+        context "with own relation" do
+          it { Factory.create_facebook_profile.relation_retrieved("facebook_contacts") }
+        end
+
+        context "with parent relation" do
+          it { Factory.create_facebook_profile.relation_retrieved("contact") }
+        end
+      end
+
       context "with unknown relation" do
-        it { expect_raises(Jennifer::UnknownRelation) { Factory.create_facebook_profile.relation_retrieved("unknown") } }
+        it { expect_raises(Jennifer::UnknownRelation) { Factory.create_contact.relation_retrieved("unknown") } }
       end
 
       context "with own relation" do
-        it { Factory.create_facebook_profile.relation_retrieved("facebook_contacts") }
+        it { Factory.create_contact.relation_retrieved("passport") }
       end
-
-      context "with parent relation" do
-        it { Factory.create_facebook_profile.relation_retrieved("contact") }
-      end
-    end
-
-    context "with unknown relation" do
-      it { expect_raises(Jennifer::UnknownRelation) { Factory.create_contact.relation_retrieved("unknown") } }
-    end
-
-    context "with own relation" do
-      it { Factory.create_contact.relation_retrieved("passport") }
     end
   end
 end

--- a/spec/models.cr
+++ b/spec/models.cr
@@ -71,32 +71,38 @@ end
 class Contact < ApplicationRecord
   with_timestamps
 
-  {% if env("DB") == "postgres" || env("DB") == nil %}
-    mapping(
-      id:          Primary32,
-      name:        String,
-      ballance:    PG::Numeric?,
-      age:         {type: Int32, default: 10},
-      gender:      {type: String?, default: "male"},
-      description: String?,
-      created_at:  Time?,
-      updated_at:  Time?,
-      user_id:     Int32?,
-      tags:        Array(Int32)?
-    )
-  {% else %}
-    mapping(
-      id:          Primary32,
-      name:        String,
-      ballance:    Float64?,
-      age:         {type: Int32, default: 10},
-      gender:      {type: String?, default: "male"},
-      description: String?,
-      created_at:  Time?,
-      updated_at:  Time?,
-      user_id:     Int32?
-    )
-  {% end %}
+  module Mapping
+    macro included
+      {% if env("DB") == "postgres" || env("DB") == nil %}
+        mapping(
+          id:          Primary32,
+          name:        String,
+          ballance:    PG::Numeric?,
+          age:         {type: Int32, default: 10},
+          gender:      {type: String?, default: "male"},
+          description: String?,
+          created_at:  Time?,
+          updated_at:  Time?,
+          user_id:     Int32?,
+          tags:        Array(Int32)?
+        )
+      {% else %}
+        mapping(
+          id:          Primary32,
+          name:        String,
+          ballance:    Float64?,
+          age:         {type: Int32, default: 10},
+          gender:      {type: String?, default: "male"},
+          description: String?,
+          created_at:  Time?,
+          updated_at:  Time?,
+          user_id:     Int32?
+        )
+      {% end %}
+    end
+  end
+
+  include Mapping
 
   has_many :addresses, Address, inverse_of: :contact
   has_many :facebook_profiles, FacebookProfile, inverse_of: :contact

--- a/spec/models.cr
+++ b/spec/models.cr
@@ -189,11 +189,22 @@ class Profile < ApplicationRecord
     virtual_parent_field: {type: String?, virtual: true}
   )
 
+  @@destroy_counter = 0
+
   getter commit_callback_called = false
 
   belongs_to :contact, Contact
 
+  after_destroy :increment_destroy_counter
   after_commit :set_commit, on: :create
+
+  def self.destroy_counter
+    @@destroy_counter
+  end
+
+  def increment_destroy_counter
+    @@destroy_counter += 1
+  end
 
   def set_commit
     @commit_callback_called = true
@@ -274,6 +285,27 @@ class City < ApplicationRecord
   )
 
   belongs_to :country, Country
+end
+
+class Note < ApplicationRecord
+  module Mapping
+    macro included
+      mapping(
+        id: Primary32,
+        text: String?,
+        notable_id: Int32?,
+        notable_type: String?,
+        created_at: Time?,
+        updated_at: Time?
+      )
+
+      with_timestamps
+    end
+  end
+
+  include Mapping
+
+  polymorphic_belongs_to :notable, Union(User | Contact)
 end
 
 class OneFieldModel < Jennifer::Model::Base

--- a/spec/models.cr
+++ b/spec/models.cr
@@ -305,7 +305,7 @@ class Note < ApplicationRecord
 
   include Mapping
 
-  polymorphic_belongs_to :notable, Union(User | Contact)
+  belongs_to :notable, Union(User | Contact), { where { _name.like("%on") } }, polymorphic: true
 end
 
 class OneFieldModel < Jennifer::Model::Base
@@ -488,4 +488,63 @@ class CountryWithDefault < Jennifer::Model::Base
     virtual: { type: Bool, default: true, virtual: true },
     name: String?
   )
+end
+
+class NoteWithCallback < ApplicationRecord
+  include Note::Mapping
+
+  self.table_name "notes"
+
+  belongs_to :notable, Union(User | FacebookProfileWithDestroyNotable), polymorphic: true
+
+  after_destroy :increment_destroy_counter
+
+  @@destroy_counter = 0
+
+  def self.destroy_counter
+    @@destroy_counter
+  end
+
+  def increment_destroy_counter
+    @@destroy_counter += 1
+  end
+end
+
+class FacebookProfileWithDestroyNotable < Jennifer::Model::Base
+  module Mapping
+    macro included
+      mapping({
+        id: Primary32,
+        login: String,
+        contact_id: Int32?,
+        type: String,
+        uid: String?
+    }, false)
+    end
+  end
+  include Mapping
+
+  table_name "profiles"
+
+  has_many :notes, NoteWithCallback, inverse_of: :notable, polymorphic: true, dependent: :destroy
+
+  after_destroy :increment_destroy_counter
+
+  @@destroy_counter = 0
+
+  def self.destroy_counter
+    @@destroy_counter
+  end
+
+  def increment_destroy_counter
+    @@destroy_counter += 1
+  end
+end
+
+class ProfileWithOneNote < Jennifer::Model::Base
+  include FacebookProfileWithDestroyNotable::Mapping
+
+  table_name "profiles"
+
+  has_one :note, NoteWithCallback, inverse_of: :notable, polymorphic: true, dependent: :nullify
 end

--- a/spec/query_builder/criteria_spec.cr
+++ b/spec/query_builder/criteria_spec.cr
@@ -2,10 +2,11 @@ require "../spec_helper"
 
 describe Jennifer::QueryBuilder::Criteria do
   described_class = Jennifer::QueryBuilder::Criteria
+
   # all sql checks are in operator_spec.cr
   {% for op in [:==, :<, :>, :<=, :>=, :!=] %}
     describe "#{{{op.stringify}}}" do
-      it "retruns condition" do
+      it "returns condition" do
         c = Factory.build_criteria
         cond = (c {{op.id}} "a")
         cond.should be_a Jennifer::QueryBuilder::Condition
@@ -31,7 +32,7 @@ describe Jennifer::QueryBuilder::Criteria do
   {% end %}
 
   describe "#=~" do
-    it "retruns condition" do
+    it "returns condition" do
       c = Factory.build_criteria
       cond = (c =~ "a")
       cond.should be_a Jennifer::QueryBuilder::Condition

--- a/spec/relation/base_spec.cr
+++ b/spec/relation/base_spec.cr
@@ -70,7 +70,7 @@ describe Jennifer::Relation::Base do
         profile.all.join(note, type: :left, relation: "notable") do
           example_relation.condition_clause.not_nil!
         end
-      example_relation.join_condition(profile.all, :left).to_sql.should eq(expected_query.to_sql)
+      example_relation.join_condition(profile.all, :left).as_sql.should eq(expected_query.as_sql)
     end
   end
 

--- a/spec/relation/base_spec.cr
+++ b/spec/relation/base_spec.cr
@@ -1,0 +1,120 @@
+require "../spec_helper"
+
+describe Jennifer::Relation::Base do
+  example_class = Jennifer::Relation::Base(NoteWithCallback, FacebookProfileWithDestroyNotable)
+  relation_name = "notable"
+  note = NoteWithCallback
+  profile = FacebookProfileWithDestroyNotable
+  query = NoteWithCallback.all
+  example_relation = example_class.new(relation_name, :notable_id, nil, query)
+
+  describe "#foreign_field" do
+    context "without specified foreign field" do
+      it do
+        example_relation.foreign_field.should eq("notable_id")
+      end
+    end
+
+    context "with specified foreign field" do
+      it do
+        example_class.new(relation_name, "specific_type", nil, query).foreign_field.should eq("specific_type")
+      end
+    end
+  end
+
+  describe "#primary_field" do
+    context "without specified primary field" do
+      it do
+        example_relation.primary_field.should eq("id")
+      end
+    end
+
+    context "with specified primary field" do
+      it do
+        example_class.new(relation_name, nil, "specific_type", query).primary_field.should eq("specific_type")
+      end
+    end
+  end
+
+  describe "#condition_clause" do
+    context "without custom query" do
+      it do
+        condition = example_relation.condition_clause
+        condition.should eq(note.c(:notable_id, relation_name) == profile.c(:id))
+      end
+
+      describe "for specific id" do
+        it do
+          condition = example_relation.condition_clause(1)
+          condition.should eq(note.c(:notable_id, relation_name) == 1)
+        end
+      end
+
+      describe "for specific ids" do
+        it do
+          condition = example_relation.condition_clause([1, 2, 3])
+          condition.should eq(note.c(:notable_id, relation_name).in([1, 2, 3]))
+        end
+      end
+    end
+
+    context "with custom query" do
+      pending "add" do
+      end
+    end
+  end
+
+  describe "#join_condition" do
+    it do
+      expected_query =
+        profile.all.join(note, type: :left, relation: "notable") do
+          example_relation.condition_clause.not_nil!
+        end
+      example_relation.join_condition(profile.all, :left).to_sql.should eq(expected_query.to_sql)
+    end
+  end
+
+  describe "#query" do
+    it do
+      example_relation.query(1).tree.should eq(example_relation.condition_clause(1))
+    end
+  end
+
+  describe "#insert" do
+    context "with hash" do
+      it do
+        p = profile.find!(Factory.create_facebook_profile.id)
+        n = example_relation.insert(p, { "text" => "text"} of String => Jennifer::DBAny)
+        n.notable_id.should eq(p.id)
+      end
+
+      it do
+        p = profile.find!(Factory.create_facebook_profile.id)
+        n = example_relation.insert(p, { :text => "text"} of Symbol => Jennifer::DBAny)
+        n.notable_id.should eq(p.id)
+      end
+    end
+
+    context "with object" do
+      it do
+        p = profile.find!(Factory.create_facebook_profile.id)
+        n = note.build(text: "some text")
+        n = example_relation.insert(p, n)
+        n.notable_id.should eq(p.id)
+      end
+    end
+  end
+
+  describe "#remove" do
+    context "with given object" do
+      it do
+        p = profile.find!(Factory.create_facebook_profile.id)
+        n = note.create!(text: "some text", notable_id: p.id)
+
+        example_relation.remove(p, n)
+        n.reload
+        n.notable_id.should be_nil
+      end
+    end
+  end
+end

--- a/spec/relation/has_one_spec.cr
+++ b/spec/relation/has_one_spec.cr
@@ -1,0 +1,5 @@
+require "../spec_helper"
+
+describe Jennifer::Relation::HasOne do
+  pending "add"
+end

--- a/spec/relation/polymorphic_belongs_to_spec.cr
+++ b/spec/relation/polymorphic_belongs_to_spec.cr
@@ -1,0 +1,235 @@
+require "../spec_helper"
+
+describe Jennifer::Relation::IPolymorphicBelongsTo do
+  example_class = NoteWithCallback::NotableRelation
+  relation_name = "notable"
+  note = NoteWithCallback
+  profile = FacebookProfileWithDestroyNotable
+  example_relation = example_class.new(relation_name, nil, nil, nil)
+
+  describe "#foreign_type" do
+    context "without specified foreign type" do
+      it do
+        example_class.new(relation_name, nil, nil, nil).foreign_type.should eq("notable_type")
+      end
+    end
+
+    context "with specified foreign type" do
+      it do
+        example_class.new(relation_name, nil, nil, "specific_type").foreign_type.should eq("specific_type")
+      end
+    end
+  end
+
+  describe "#foreign_field" do
+    context "without specified foreign field" do
+      it do
+        example_class.new(relation_name, nil, nil, nil).foreign_field.should eq("notable_id")
+      end
+    end
+
+    context "with specified foreign field" do
+      it do
+        example_class.new(relation_name, "specific_type", nil, nil).foreign_field.should eq("specific_type")
+      end
+    end
+  end
+
+  describe "#primary_field" do
+    context "without specified primary field" do
+      it do
+        example_class.new(relation_name, nil, nil, nil).primary_field.should eq("id")
+      end
+    end
+
+    context "with specified primary field" do
+      it do
+        example_class.new(relation_name, nil, "specific_type", nil).primary_field.should eq("specific_type")
+      end
+    end
+  end
+
+  describe "#condition_clause" do
+    context "without custom query" do
+      describe "for specific id" do
+        it do
+          condition = example_relation.condition_clause(1, profile.to_s)
+          condition.should eq(profile.c(:id, relation_name) == 1)
+        end
+      end
+    end
+  end
+
+  describe "#query" do
+    context "with nil polymorphic type" do
+      it do
+        example_relation.query(1, nil).do_nothing?.should be_true
+      end
+    end
+
+    context "with valid polymorphic type" do
+      it do
+        p = Factory.create_facebook_profile
+        example_relation.query(p.id, profile.to_s).count.should eq(1)
+      end
+    end
+
+    context "with custom query" do
+      it do
+        condition = Note::NotableRelation.new(relation_name, nil, nil, nil).query(1, "User").tree
+        condition.should eq((User.c(:id, relation_name) == 1) & (User.c(:name).like("%on")))
+      end
+    end
+  end
+
+  describe "#build" do
+    context "with valid polymorphic type" do
+      it do
+        p = example_relation.build({ "login" => "login", "type" => "type" } of String => Jennifer::DBAny, profile.to_s)
+        p.is_a?(FacebookProfileWithDestroyNotable).should be_true
+        u = example_relation.build({} of String => Jennifer::DBAny, "User")
+        u.is_a?(User).should be_true
+      end
+    end
+
+    context "with invalid polymorphic type" do
+      it do
+        expect_raises(Jennifer::BaseException) do
+          example_relation.build({} of String => Jennifer::DBAny, "Contact")
+        end
+      end
+    end
+  end
+
+  describe "#create!" do
+    context "with valid polymorphic type" do
+      it do
+        p = example_relation.create!({ "login" => "login", "type" => "type" } of String => Jennifer::DBAny, profile.to_s)
+        p.is_a?(FacebookProfileWithDestroyNotable).should be_true
+        p.persisted?.should be_true
+
+        u = example_relation.build(Factory.build_user.to_str_h, "User")
+        u.is_a?(User).should be_true
+        u.persisted?.should be_true
+      end
+    end
+
+    context "with invalid polymorphic type" do
+      it do
+        expect_raises(Jennifer::BaseException) do
+          example_relation.create!({} of String => Jennifer::DBAny, "Contact")
+        end
+      end
+    end
+
+    context "with invalid model options" do
+      it do
+        expect_raises(Jennifer::RecordInvalid) do
+          example_relation.create!({} of String => Jennifer::DBAny, "User")
+        end
+      end
+    end
+  end
+
+  describe "#load" do
+    context "with valid polymorphic type" do
+      context "with blank foreign field" do
+        it do
+          example_relation.load(nil, "User").should be_nil
+        end
+      end
+
+      it do
+        u = Factory.create_user([:with_valid_password])
+        example_relation.load(u.id, "User").as(User).id.should eq(u.id)
+      end
+    end
+
+    context "with invalid polymorphic type" do
+      it do
+        expect_raises(Jennifer::BaseException) do
+          example_relation.load(1, "Contact")
+        end
+      end
+    end
+  end
+
+  describe "#destroy" do
+    context "with valid polymorphic type" do
+      context "with blank foreign field" do
+        it do
+          n = note.build(text: "test")
+          example_relation.destroy(n).should be_nil
+        end
+      end
+
+      it do
+        p = Factory.create_facebook_profile
+        n = note.build(text: "test", notable_type: profile.to_s, notable_id: p.id)
+
+        count = profile.destroy_counter
+        example_relation.destroy(n)
+        profile.find(p.id).should be_nil
+        profile.destroy_counter.should eq(count + 1)
+      end
+    end
+
+    context "with invalid polymorphic type" do
+      it do
+        n = note.build(text: "test", notable_type: "Contact", notable_id: 1)
+        expect_raises(Jennifer::BaseException) do
+          example_relation.destroy(n)
+        end
+      end
+    end
+  end
+
+  describe "#insert" do
+    context "with hash" do
+      it do
+        n = note.find!(Factory.create_note.id)
+        opts = {
+          "login" => "login",
+          "type" => "type",
+          "notable_type" => "FacebookProfileWithDestroyNotable"
+        } of String => Jennifer::DBAny
+        example_relation.insert(n, opts).as(FacebookProfileWithDestroyNotable)
+        p = n.notable.as(FacebookProfileWithDestroyNotable)
+        n.notable_id.should eq(p.id)
+        n.notable_type.should eq(profile.to_s)
+      end
+    end
+
+    context "with object" do
+      it do
+        n = note.find!(Factory.create_note.id)
+        p = profile.create!(login: "login", type: "type")
+        example_relation.insert(n, p)
+        n.notable_id.should eq(p.id)
+        n.notable_type.should eq(profile.to_s)
+      end
+
+      it "raises exception if object is already assigned" do
+        p1 = profile.find!(Factory.create_facebook_profile.id)
+        p2 = profile.find!(Factory.create_facebook_profile.id)
+        n = note.build(text: "some text")
+        n = p2.add_notes(n)[0]
+        expect_raises(Jennifer::BaseException) do
+          example_relation.insert(n, p1)
+        end
+      end
+    end
+  end
+
+  describe "#remove" do
+    it do
+      p = profile.find!(Factory.create_facebook_profile.id)
+      n = p.add_notes(note.build(text: "some text"))[0]
+
+      example_relation.remove(n)
+      n.reload
+      n.notable_type.should be_nil
+      n.notable_id.should be_nil
+    end
+  end
+end

--- a/spec/relation/polymorphic_belongs_to_spec.cr
+++ b/spec/relation/polymorphic_belongs_to_spec.cr
@@ -1,10 +1,24 @@
 require "../spec_helper"
 
+module Spec
+  class Note < ApplicationRecord
+    include ::Note::Mapping
+
+    belongs_to :notable, Union(::User | ::Spec::Contact), polymorphic: true
+  end
+
+  class Contact < ApplicationRecord
+    include ::Contact::Mapping
+
+    has_one :note, Note, inverse_of: :notable, polymorphic: true, dependent: :nullify
+  end
+end
+
 describe Jennifer::Relation::IPolymorphicBelongsTo do
   example_class = NoteWithCallback::NotableRelation
   relation_name = "notable"
-  note = NoteWithCallback
-  profile = FacebookProfileWithDestroyNotable
+  note_class = NoteWithCallback
+  profile_class = FacebookProfileWithDestroyNotable
   example_relation = example_class.new(relation_name, nil, nil, nil)
 
   describe "#foreign_type" do
@@ -53,8 +67,8 @@ describe Jennifer::Relation::IPolymorphicBelongsTo do
     context "without custom query" do
       describe "for specific id" do
         it do
-          condition = example_relation.condition_clause(1, profile.to_s)
-          condition.should eq(profile.c(:id, relation_name) == 1)
+          condition = example_relation.condition_clause(1, profile_class.to_s)
+          condition.should eq(profile_class.c(:id, relation_name) == 1)
         end
       end
     end
@@ -70,7 +84,7 @@ describe Jennifer::Relation::IPolymorphicBelongsTo do
     context "with valid polymorphic type" do
       it do
         p = Factory.create_facebook_profile
-        example_relation.query(p.id, profile.to_s).count.should eq(1)
+        example_relation.query(p.id, profile_class.to_s).count.should eq(1)
       end
     end
 
@@ -85,10 +99,8 @@ describe Jennifer::Relation::IPolymorphicBelongsTo do
   describe "#build" do
     context "with valid polymorphic type" do
       it do
-        p = example_relation.build({ "login" => "login", "type" => "type" } of String => Jennifer::DBAny, profile.to_s)
+        p = example_relation.build({ "login" => "login", "type" => "type" } of String => Jennifer::DBAny, profile_class.to_s)
         p.is_a?(FacebookProfileWithDestroyNotable).should be_true
-        u = example_relation.build({} of String => Jennifer::DBAny, "User")
-        u.is_a?(User).should be_true
       end
     end
 
@@ -99,18 +111,29 @@ describe Jennifer::Relation::IPolymorphicBelongsTo do
         end
       end
     end
+
+    describe "alternative class" do
+      it do
+        u = example_relation.build({} of String => Jennifer::DBAny, "User")
+        u.is_a?(User).should be_true
+      end
+    end
   end
 
   describe "#create!" do
     context "with valid polymorphic type" do
       it do
-        p = example_relation.create!({ "login" => "login", "type" => "type" } of String => Jennifer::DBAny, profile.to_s)
+        p = example_relation.create!({ "login" => "login", "type" => "type" } of String => Jennifer::DBAny, profile_class.to_s)
         p.is_a?(FacebookProfileWithDestroyNotable).should be_true
         p.persisted?.should be_true
+      end
 
-        u = example_relation.build(Factory.build_user.to_str_h, "User")
-        u.is_a?(User).should be_true
-        u.persisted?.should be_true
+      describe "alternative class" do
+        it do
+          u = example_relation.build(Factory.build_user.to_str_h, "User")
+          u.is_a?(User).should be_true
+          u.persisted?.should be_true
+        end
       end
     end
 
@@ -158,25 +181,25 @@ describe Jennifer::Relation::IPolymorphicBelongsTo do
     context "with valid polymorphic type" do
       context "with blank foreign field" do
         it do
-          n = note.build(text: "test")
+          n = note_class.build(text: "test")
           example_relation.destroy(n).should be_nil
         end
       end
 
       it do
         p = Factory.create_facebook_profile
-        n = note.build(text: "test", notable_type: profile.to_s, notable_id: p.id)
+        n = note_class.build(text: "test", notable_type: profile_class.to_s, notable_id: p.id)
 
-        count = profile.destroy_counter
+        count = profile_class.destroy_counter
         example_relation.destroy(n)
-        profile.find(p.id).should be_nil
-        profile.destroy_counter.should eq(count + 1)
+        profile_class.find(p.id).should be_nil
+        profile_class.destroy_counter.should eq(count + 1)
       end
     end
 
     context "with invalid polymorphic type" do
       it do
-        n = note.build(text: "test", notable_type: "Contact", notable_id: 1)
+        n = note_class.build(text: "test", notable_type: "Contact", notable_id: 1)
         expect_raises(Jennifer::BaseException) do
           example_relation.destroy(n)
         end
@@ -187,7 +210,7 @@ describe Jennifer::Relation::IPolymorphicBelongsTo do
   describe "#insert" do
     context "with hash" do
       it do
-        n = note.find!(Factory.create_note.id)
+        n = note_class.find!(Factory.create_note.id)
         opts = {
           "login" => "login",
           "type" => "type",
@@ -196,26 +219,53 @@ describe Jennifer::Relation::IPolymorphicBelongsTo do
         example_relation.insert(n, opts).as(FacebookProfileWithDestroyNotable)
         p = n.notable.as(FacebookProfileWithDestroyNotable)
         n.notable_id.should eq(p.id)
-        n.notable_type.should eq(profile.to_s)
+        n.notable_type.should eq(profile_class.to_s)
+      end
+
+      describe "alternative class" do
+        it do
+          n = Spec::Note.find!(Factory.create_note.id)
+          opts = {
+            "name" => "name",
+            "age" => 42,
+            "gender" => "male",
+            "notable_type" => "Spec::Contact"
+          } of String => Jennifer::DBAny
+          Spec::Note.notable_relation.insert(n, opts)
+          p = n.notable.as(Spec::Contact)
+          n.notable_id.should eq(p.id)
+          n.notable_type.should eq("Spec::Contact")
+        end
       end
     end
 
     context "with object" do
       it do
-        n = note.find!(Factory.create_note.id)
-        p = profile.create!(login: "login", type: "type")
+        n = note_class.find!(Factory.create_note.id)
+        p = profile_class.create!(login: "login", type: "type")
         example_relation.insert(n, p)
         n.notable_id.should eq(p.id)
-        n.notable_type.should eq(profile.to_s)
+        n.notable_type.should eq(profile_class.to_s)
       end
 
       it "raises exception if object is already assigned" do
-        p1 = profile.find!(Factory.create_facebook_profile.id)
-        p2 = profile.find!(Factory.create_facebook_profile.id)
-        n = note.build(text: "some text")
+        p1 = profile_class.find!(Factory.create_facebook_profile.id)
+        p2 = profile_class.find!(Factory.create_facebook_profile.id)
+        n = note_class.build(text: "some text")
         n = p2.add_notes(n)[0]
         expect_raises(Jennifer::BaseException) do
           example_relation.insert(n, p1)
+        end
+      end
+
+      describe "alternative class" do
+        it do
+          n = Spec::Note.find!(Factory.create_note.id)
+          p = Spec::Contact.find!(Factory.create_contact.id)
+          Spec::Note.notable_relation.insert(n, p)
+
+          n.notable_id.should eq(p.id)
+          n.notable_type.should eq(p.class.to_s)
         end
       end
     end
@@ -223,13 +273,24 @@ describe Jennifer::Relation::IPolymorphicBelongsTo do
 
   describe "#remove" do
     it do
-      p = profile.find!(Factory.create_facebook_profile.id)
-      n = p.add_notes(note.build(text: "some text"))[0]
+      p = profile_class.find!(Factory.create_facebook_profile.id)
+      n = p.add_notes(note_class.build(text: "some text"))[0]
 
       example_relation.remove(n)
       n.reload
       n.notable_type.should be_nil
       n.notable_id.should be_nil
+    end
+
+    describe "alternative class" do
+      it do
+        n = Spec::Note.create!({text: "some_text", notable_id: 1, notable_type: "User"})
+
+        example_relation.remove(n)
+        n.reload
+        n.notable_type.should be_nil
+        n.notable_id.should be_nil
+      end
     end
   end
 end

--- a/spec/relation/polymorphic_has_many_spec.cr
+++ b/spec/relation/polymorphic_has_many_spec.cr
@@ -1,0 +1,83 @@
+require "../spec_helper"
+
+describe Jennifer::Relation::PolymorphicHasMany do
+  example_class = Jennifer::Relation::PolymorphicHasMany(NoteWithCallback, FacebookProfileWithDestroyNotable)
+  relation_name = "notes"
+  note = NoteWithCallback
+  profile = FacebookProfileWithDestroyNotable
+
+  describe "#foreign_type" do
+    context "without specified foreign type" do
+      it do
+        example_class.new(relation_name, nil, nil, NoteWithCallback.all, nil, :notable).foreign_type.should eq("notable_type")
+      end
+    end
+
+    context "with specified foreign type" do
+      it do
+        example_class.new(relation_name, nil, nil, NoteWithCallback.all, "specific_type", :notable).foreign_type.should eq("specific_type")
+      end
+    end
+  end
+
+  describe "#condition_clause" do
+    context "without custom query" do
+      it do
+        condition = example_class.new(relation_name, nil, nil, NoteWithCallback.all, nil, :notable).condition_clause
+        condition.should eq((note.c(:notable_id, relation_name) == profile.c(:id)) & (note.c(:notable_type, relation_name) == "FacebookProfileWithDestroyNotable"))
+      end
+
+      describe "for specific id" do
+        it do
+          condition = example_class.new(relation_name, nil, nil, NoteWithCallback.all, nil, :notable).condition_clause(1)
+          condition.should eq((note.c(:notable_id, relation_name) == 1) & (note.c(:notable_type, relation_name) == "FacebookProfileWithDestroyNotable"))
+        end
+      end
+
+      describe "for specific ids" do
+        it do
+          condition = example_class.new(relation_name, nil, nil, NoteWithCallback.all, nil, :notable).condition_clause([1, 2, 3])
+          condition.should eq((note.c(:notable_id, relation_name).in([1, 2, 3])) & (note.c(:notable_type, relation_name) == "FacebookProfileWithDestroyNotable"))
+        end
+      end
+    end
+
+    context "with custom query" do
+      pending "add" do
+      end
+    end
+  end
+
+  describe "#insert" do
+    context "with hash" do
+      it do
+        p = FacebookProfileWithDestroyNotable.find!(Factory.create_facebook_profile.id)
+        n = example_class.new(relation_name, nil, nil, NoteWithCallback.all, nil, :notable).insert(p, { "text" => "text"} of String => Jennifer::DBAny)
+        n.notable_id.should eq(p.id)
+        n.notable_type.should eq(profile.to_s)
+      end
+    end
+
+    context "with object" do
+      it do
+        p = profile.find!(Factory.create_facebook_profile.id)
+        n = note.build(text: "some text")
+        n = example_class.new(relation_name, nil, nil, NoteWithCallback.all, nil, :notable).insert(p, n)
+        n.notable_id.should eq(p.id)
+        n.notable_type.should eq(profile.to_s)
+      end
+    end
+  end
+
+  describe "#remove" do
+    it do
+      p = profile.find!(Factory.create_facebook_profile.id)
+      n = p.add_notes(note.build(text: "some text"))[0]
+
+      example_class.new(relation_name, nil, nil, NoteWithCallback.all, nil, :notable).remove(p, n)
+      n.reload
+      n.notable_type.should be_nil
+      n.notable_id.should be_nil
+    end
+  end
+end

--- a/spec/relation/polymorphic_has_one_spec.cr
+++ b/spec/relation/polymorphic_has_one_spec.cr
@@ -1,0 +1,109 @@
+require "../spec_helper"
+
+describe Jennifer::Relation::PolymorphicHasOne do
+  example_class = Jennifer::Relation::PolymorphicHasOne(NoteWithCallback, ProfileWithOneNote)
+  relation_name = "note"
+  note = NoteWithCallback
+  profile = ProfileWithOneNote
+  query = NoteWithCallback.all
+  example_relation = example_class.new(relation_name, nil, nil, query, nil, :notable)
+
+  describe "#foreign_type" do
+    context "without specified foreign type" do
+      it do
+        example_class.new(relation_name, nil, nil, NoteWithCallback.all, nil, :notable).foreign_type.should eq("notable_type")
+      end
+    end
+
+    context "with specified foreign type" do
+      it do
+        example_class.new(relation_name, nil, nil, NoteWithCallback.all, "specific_type", :notable).foreign_type.should eq("specific_type")
+      end
+    end
+  end
+
+  describe "#condition_clause" do
+    context "without custom query" do
+      it do
+        condition = example_relation.condition_clause
+        condition.should eq((note.c(:notable_id, relation_name) == profile.c(:id)) & (note.c(:notable_type, relation_name) == "ProfileWithOneNote"))
+      end
+
+      describe "for specific id" do
+        it do
+          condition = example_relation.condition_clause(1)
+          condition.should eq((note.c(:notable_id, relation_name) == 1) & (note.c(:notable_type, relation_name) == "ProfileWithOneNote"))
+        end
+      end
+
+      describe "for specific ids" do
+        it do
+          condition = example_relation.condition_clause([1, 2, 3])
+          condition.should eq((note.c(:notable_id, relation_name).in([1, 2, 3])) & (note.c(:notable_type, relation_name) == "ProfileWithOneNote"))
+        end
+      end
+    end
+
+    context "with custom query" do
+      pending "add" do
+      end
+    end
+  end
+
+  describe "#insert" do
+    context "with hash" do
+      it do
+        p = profile.find!(Factory.create_facebook_profile.id)
+        n = example_relation.insert(p, { "text" => "text"} of String => Jennifer::DBAny)
+        n.notable_id.should eq(p.id)
+        n.notable_type.should eq(profile.to_s)
+      end
+    end
+
+    context "with object" do
+      it do
+        p = profile.find!(Factory.create_facebook_profile.id)
+        n = note.build(text: "some text")
+        n = example_relation.insert(p, n)
+        n.notable_id.should eq(p.id)
+        n.notable_type.should eq(profile.to_s)
+      end
+
+      it "raises exception if related object is already assigned" do
+        p1 = profile.find!(Factory.create_facebook_profile.id)
+        p2 = profile.find!(Factory.create_facebook_profile.id)
+        n = note.build(text: "some text")
+        n = p2.add_note(n)
+        expect_raises(Jennifer::BaseException) do
+          example_relation.insert(p1, n)
+        end
+      end
+    end
+  end
+
+  describe "#remove" do
+    context "with given object" do
+      it do
+        p = profile.find!(Factory.create_facebook_profile.id)
+        n = p.add_note(note.build(text: "some text"))
+
+        example_relation.remove(p, n)
+        n.reload
+        n.notable_type.should be_nil
+        n.notable_id.should be_nil
+      end
+    end
+
+    context "without related object" do
+      it do
+        p = profile.find!(Factory.create_facebook_profile.id)
+        n = p.add_note(note.build(text: "some text"))
+
+        example_relation.remove(p)
+        n.reload
+        n.notable_type.should be_nil
+        n.notable_id.should be_nil
+      end
+    end
+  end
+end

--- a/src/jennifer/migration/table_builder/change_table.cr
+++ b/src/jennifer/migration/table_builder/change_table.cr
@@ -69,12 +69,13 @@ module Jennifer
           self
         end
 
+        # TODO: add more documentation.
+
         # Adds index.
         #
         # ```
         # t.add_index("index_name", [:field1, :field2], length: { :field1 => 2, :field2 => 3 }, orders: { :field1 => :asc }})
         # ```
-        # TODO: add more documentation.
         def add_index(name : String, fields : Array(Symbol), type : Symbol? = nil, lengths : Hash(Symbol, Int32) = {} of Symbol => Int32, orders : Hash(Symbol, Symbol) = {} of Symbol => Symbol)
           @commands << CreateIndex.new(@adapter, @name, name, fields, type, lengths, orders)
           self
@@ -90,6 +91,7 @@ module Jennifer
           )
         end
 
+        # Drops index by given *name*.
         def drop_index(name)
           @commands << DropIndex.new(@adapter, @name, name.to_s)
           self
@@ -106,6 +108,7 @@ module Jennifer
           self
         end
 
+        # Drops foreign key of *to_table*.
         def drop_foreign_key(to_table, name = nil)
           @commands << DropForeignKey.new(@adapter, @name, to_table.to_s, name)
           self

--- a/src/jennifer/migration/table_builder/create_table.cr
+++ b/src/jennifer/migration/table_builder/create_table.cr
@@ -43,10 +43,17 @@ module Jennifer
         # Adds a reference.
         #
         # Defines foreign key field based on given relation name (*name*). By default it is integer and null value is allowed.
-        def reference(name, to_table = Inflector.pluralize(name), primary_key = nil, key_name = nil)
+        #
+        # If *polymorphic* is `true` - additional string field `"#{name}_type"` is created and foreign key is not added.
+        def reference(name, to_table = Inflector.pluralize(name), primary_key = nil, key_name = nil, polymorphic : Bool = false)
           column = Inflector.foreign_key(name)
           integer(column, { :type => :integer, :null => true })
-          foreign_key(to_table, column, primary_key, key_name)
+          if polymorphic
+            string("#{name}_type", { :null => true })
+          else
+            foreign_key(to_table, column, primary_key, key_name)
+          end
+          self
         end
 
         # Defines `created_at` and `updated_at` timestamp fields.

--- a/src/jennifer/model/base.cr
+++ b/src/jennifer/model/base.cr
@@ -35,6 +35,8 @@ module Jennifer
       end
 
       # Represent actual amount of model's table column amount (is grepped from db).
+      # If somewhy you define model with custom table name after the place where adapter is used the first time -
+      # manually invoke this method anywhere after table name definition.
       def self.actual_table_field_count
         @@actual_table_field_count ||= adapter.table_column_count(table_name)
       end
@@ -158,9 +160,10 @@ module Jennifer
       # Returns list of available model classes.
       def self.models
         {% begin %}
-          {% if !@type.all_subclasses.empty? %}
+          {% models = @type.all_subclasses.select { |m| !m.abstract? } %}
+          {% if !models.empty? %}
             [
-              {% for model in @type.all_subclasses %}
+              {% for model in models %}
                 {{model.id}},
               {% end %}
             ]

--- a/src/jennifer/model/base.cr
+++ b/src/jennifer/model/base.cr
@@ -90,6 +90,12 @@ module Jennifer
         @destroyed
       end
 
+      # Returns `true` if the record is persisted, i.e. it’s not a new record and
+      # it was not destroyed, otherwise returns `false`.
+      def persisted?
+        !(new_record? || destroyed?)
+      end
+
       def self.create(values : Hash | NamedTuple)
         o = build(values)
         o.save
@@ -157,7 +163,7 @@ module Jennifer
       # Returns named tuple of all model fields to insert.
       abstract def arguments_to_insert
 
-      # Returns list of available model classes.
+      # Returns array of all non-abstract subclasses of *Jennifer::Model::Base*.
       def self.models
         {% begin %}
           {% models = @type.all_subclasses.select { |m| !m.abstract? } %}

--- a/src/jennifer/model/mapping.cr
+++ b/src/jennifer/model/mapping.cr
@@ -149,6 +149,18 @@ module Jennifer
 
         __field_declaration({{properties}}, {{primary_auto_incrementable}})
 
+        private def inspect_attributes(io) : Nil
+          io << ' '
+          {% for var, i in properties.keys %}
+            {% if i > 0 %}
+              io << ", "
+            {% end %}
+            io << "{{var.id}}: "
+            @{{var.id}}.inspect(io)
+          {% end %}
+          nil
+        end
+
         # :nodoc:
         def self.primary_auto_incrementable?
           {{primary_auto_incrementable}}
@@ -386,12 +398,12 @@ module Jennifer
                     @{{key.id}} = local
                     @{{key.id}}_changed = true
                   else
-                    raise ::Jennifer::BaseException.new("Wrong type for #{name} : #{value.class}")
+                    raise ::Jennifer::BaseException.new("Wrong type for #{self.class}##{name} : #{value.class}")
                   end
               {% end %}
             {% end %}
             else
-              raise ::Jennifer::BaseException.new("Unknown model attribute - #{name}")
+              raise ::Jennifer::BaseException.new("Unknown model attribute - #{self.class}##{name}")
             end
           end
 

--- a/src/jennifer/model/relation_definition.cr
+++ b/src/jennifer/model/relation_definition.cr
@@ -38,8 +38,9 @@ module Jennifer
         before_destroy :__delete_callback_{{name.id}}
       end
 
-      # :nodoc:
       # TODO: add validation for cyclic destroy dependency
+
+      # :nodoc:
       macro destroy_dependency(name, relation_type, polymorphic)
         # :nodoc:
         def __destroy_callback_{{name.id}}
@@ -63,6 +64,8 @@ module Jennifer
         before_destroy :__restrict_with_exception_callback_{{name.id}}
       end
 
+      # TODO: add "restrict_with_error" strategy
+
       # :nodoc:
       macro declare_dependent(name, type, relation_type, polymorphic = false)
         {% type = type.id.stringify %}
@@ -84,6 +87,33 @@ module Jennifer
       end
 
       # Specifies a one-to-many association.
+      #
+      # Options:
+      #
+      # - *name* - relation name
+      # - *klass* - specify the class name of the association
+      # - *request* - extra request scope to retrieve a specific set of records when access the associated collection
+      # - *foreign* - specify the foreign key used for the association
+      # - *foreign_type* - specify the column used to store  the associated object's type,
+      # if this is a polymorphic relation
+      # - *primary* - specify the name of the column to use as the primary key for the relation
+      # - *dependent* - specify the destroy strategy of the associated objects when their owner is destroyed;
+      # available options are: `destroy`, `delete`, `nullify`, `restrict_with_exception`
+      # - *inverse_of* - specifies the name of the `belongs_to` relation on the associated object that is the inverse of this relation;
+      # required for polymorphic relation
+      # - *polymorphic* - specifies that this relation is a polymorphic
+      #
+      # The following methods for retrieval and query of a single associated object will be added:
+      #
+      # `association` is a placeholder for the symbol passed as the name argument.
+      #
+      # - `.association_relation` - returns `association` relation
+      # - `#association` - returns array of related objects
+      # - `#append_association(rel)` - builds related object from hash (or use given instance) and adds to relation
+      # - `#add_association(rel)` - insert given object to db and relation; doesn't support `inverse_of` option
+      # - `#remove_association(rel)` - removes given object from relation array
+      # - `#association_query` - returns `association` relation query for the object
+      # - `#association_reload` - reloads related objects from the DB.
       macro has_many(name, klass, request = nil, foreign = nil, foreign_type = nil, primary = nil, dependent = :nullify, inverse_of = nil, polymorphic = false)
         {{"{% RELATION_NAMES << #{name.id.stringify} %}".id}}
         ::Jennifer::Model::RelationDefinition.declare_dependent({{name}}, {{dependent}}, :has_many, {{polymorphic}})
@@ -102,7 +132,6 @@ module Jennifer
         @{{name.id}} = [] of {{klass}}
         @__{{name.id}}_retrieved = false
 
-        # :nodoc:
         private def set_{{name.id}}_relation(collection : Array)
           @__{{name.id}}_retrieved = true
           @{{name.id}} = collection
@@ -115,18 +144,18 @@ module Jennifer
           {% if inverse_of %} object.append_{{inverse_of.id}}(self) {% end %}
         end
 
-        # Returns {{name.id}} relation metaobject
+        # :nodoc:
         def self.{{name.id}}_relation
           RELATIONS["{{name.id}}"].as({{relation_class}})
         end
 
-        # Returns {{name.id}} relation query for the object
+        # :nodoc:
         def {{name.id}}_query
           primary_value = {{ primary ? primary.id : "primary".id }}
           {{@type}}.{{name.id}}_relation.query(primary_value).as(::Jennifer::QueryBuilder::ModelQuery({{klass}}))
         end
 
-        # Returns array of related objects
+        # :nodoc:
         def {{name.id}}
           if !@__{{name.id}}_retrieved && @{{name.id}}.empty? && !new_record?
             set_{{name.id}}_relation({{name.id}}_query.to_a.as(Array({{klass}})))
@@ -134,25 +163,27 @@ module Jennifer
           @{{name.id}}
         end
 
-        # Builds related object from hash and adds to relation
+        # :nodoc:
         def append_{{name.id}}(rel : Hash)
           obj = {{klass}}.build(rel, false)
           set_{{name.id}}_relation(obj)
           obj
         end
 
+        # :nodoc:
         def append_{{name.id}}(rel : {{klass}})
           set_{{name.id}}_relation(rel)
           rel
         end
 
+        # :nodoc:
         def append_{{name.id}}(rel : Jennifer::Model::Resource)
           obj = rel.as({{klass}})
           set_{{name.id}}_relation(obj)
           obj
         end
 
-        # Removes given object from relation array
+        # :nodoc:
         def remove_{{name.id}}(rel : {{klass}})
           index = @{{name.id}}.index { |e| e.primary == rel.primary }
           if index
@@ -162,25 +193,51 @@ module Jennifer
           rel
         end
 
-        # Insert given object to db and relation; doesn't support `inverse_of` option
+        # :nodoc:
         def add_{{name.id}}(rel : Hash)
           @{{name.id}} << {{@type}}.{{name.id}}_relation.insert(self, rel).as({{klass}})
         end
 
+        # :nodoc:
         def add_{{name.id}}(rel : {{klass}})
           @{{name.id}} << {{@type}}.{{name.id}}_relation.insert(self, rel)
         end
 
+        # :nodoc:
         def {{name.id}}_reload
           @{{name.id}} = {{name.id}}_query.to_a.as(Array({{klass}}))
         end
       end
 
-      # Specifies a many-to-many relationship with another class. This associates two classes via an intermediate join table.
-      # Unless the join table is explicitly specified as an option, it is guessed using the lexical order of the class names.
+      # Specifies a many-to-many relationship with another class.
+      #
+      # This associates two classes via an intermediate join table. Unless the join table is explicitly specified as an option,
+      # it is guessed using the lexical order of the class names.
       # So a join between Developer and Project will give the default join table name of "developers_projects" because "D" precedes "P" alphabetically.
       # Note that this precedence is calculated using the < operator for String. This means that if the strings are of different lengths, and
       # the strings are equal when compared up to the shortest length, then the longer string is considered of higher lexical precedence than the shorter one.
+      #
+      # Options:
+      #
+      # - *name* - relation name
+      # - *klass* - specify the class name of the association
+      # - *request* - extra request scope to retrieve a specific set of records when access the associated collection
+      # - *foreign* - specify the foreign key used for the association
+      # - *primary* - specify the name of the column to use as the primary key for the relation
+      # - *join_table* - specifies the name of the join table if the default based on lexical order isn't what you want
+      # - *association_foreign* - specifies the foreign key used for the association on the receiving side of the association
+      #
+      # The following methods for retrieval and query of a single associated object will be added:
+      #
+      # `association` is a placeholder for the symbol passed as the name argument.
+      #
+      # - `.association_relation`
+      # - `#association`
+      # - `#append_association(rel)`
+      # - `#add_association(rel)`
+      # - `#remove_association(rel)`
+      # - `#association_query`
+      # - `#association_reload`
       macro has_and_belongs_to_many(name, klass, request = nil, foreign = nil, primary = nil, join_table = nil, association_foreign = nil)
         {{"{% RELATION_NAMES << #{name.id.stringify} %}".id}}
         RELATIONS["{{name.id}}"] =
@@ -211,10 +268,12 @@ module Jennifer
           @{{name.id}} << object
         end
 
+        # :nodoc:
         def self.{{name.id}}_relation
           RELATIONS["{{name.id}}"].as(::Jennifer::Relation::ManyToMany({{klass}}, {{@type}}))
         end
 
+        # :nodoc:
         def {{name.id}}_query
           primary_field = {% if primary %} {{primary.id}} {% else %} primary {% end %}
           RELATIONS["{{name.id}}"].query(primary_field).as(::Jennifer::QueryBuilder::ModelQuery({{klass}}))
@@ -227,22 +286,26 @@ module Jennifer
           @{{name.id}}
         end
 
+        # :nodoc:
         def append_{{name.id}}(rel : Hash)
           obj = {{klass}}.build(rel, false)
           set_{{name.id}}_relation(obj)
           obj
         end
 
+        # :nodoc:
         def append_{{name.id}}(rel : {{klass}})
           set_{{name.id}}_relation(rel)
           rel
         end
 
+        # :nodoc:
         def append_{{name.id}}(rel : Jennifer::Model::Resource)
           set_{{name.id}}_relation(rel.as({{klass}}))
           rel
         end
 
+        # :nodoc:
         def remove_{{name.id}}(rel : {{klass}})
           index = @{{name.id}}.index { |e| e.primary == rel.primary }
           if index
@@ -252,44 +315,33 @@ module Jennifer
           rel
         end
 
+        # :nodoc:
         def add_{{name.id}}(rel : Hash)
           @{{name.id}} << {{@type}}.{{name.id}}_relation.insert(self, rel)
         end
 
+        # :nodoc:
         def add_{{name.id}}(rel : {{klass}})
           @{{name.id}} << {{@type}}.{{name.id}}_relation.insert(self, rel)
         end
 
+        # :nodoc:
         def {{name.id}}_reload
           @{{name.id}} = {{name.id}}_query.to_a.as(Array({{klass}}))
         end
       end
 
-      # Specifies a one-to-one polymorphic association with another class. This macro should only be used if this class contains the foreign key.
-      # If the other class contains the foreign key, then you should use has_one instead.
-      macro polymorphic_belongs_to(name, klass, foreign = nil, foreign_type = nil, primary = nil,  dependent = :none)
-        {{"{% RELATION_NAMES << #{name.id.stringify} %}".id}}
+      private macro polymorphic_belongs_to(name, klass, request, foreign, foreign_type, primary, dependent)
         {% relation_class = "#{name.id.camelcase}Relation".id %}
-        ::Jennifer::Model::RelationDefinition.declare_dependent({{name}}, {{dependent}}, :belongs_to, true)
 
-        ::Jennifer::Relation::IPolymorphicBelongsTo.define_relation_class({{name}}, {{@type}}, {{klass}}, {{klass.type_vars[0].types}})
+        ::Jennifer::Relation::IPolymorphicBelongsTo.define_relation_class({{name}}, {{@type}}, {{klass}}, {{klass.type_vars[0].types}}, {{request}})
 
         RELATIONS["{{name.id}}"] =
-          {{relation_class}}.new("{{name.id}}", {{foreign}}, {{foreign_type}}, {{primary}})
+          {{relation_class}}.new("{{name.id}}", {{foreign}}, {{primary}}, {{foreign_type}})
 
-        @{{name.id}} : {{klass}}?
-        @__{{name.id}}_retrieved = false
-
+        # :nodoc:
         def self.{{name.id}}_relation
           RELATIONS["{{name.id}}"].as({{relation_class}})
-        end
-
-        def {{name.id}}
-          if !@__{{name.id}}_retrieved && @{{name.id}}.nil? && !new_record?
-            @__{{name.id}}_retrieved = true
-            @{{name.id}} = {{name.id}}_reload
-          end
-          @{{name.id}}
         end
 
         {% for type in klass.type_vars[0].types %}
@@ -298,15 +350,13 @@ module Jennifer
             {{name.id}}.as({{type}})
           end
 
+          # :nodoc:
           def {{name.id}}_{{related_name}}?
             {{name.id}}.is_a?({{type}})
           end
         {% end %}
 
-        def {{name.id}}!
-          {{name.id}}.not_nil!
-        end
-
+        # :nodoc:
         def {{name.id}}_query
           foreign_field = {{ (foreign ? foreign : "#{name.id}_id").id }}
           polymorphic_type = {{ (foreign_type ? foreign_type : "#{name.id}_type").id }}
@@ -314,6 +364,7 @@ module Jennifer
           self.class.{{name.id}}_relation.query(foreign_field, polymorphic_type)
         end
 
+        # :nodoc:
         def {{name.id}}_reload
           foreign_field = {{ (foreign ? foreign : "#{name.id}_id").id }}
           polymorphic_type = {{ (foreign_type ? foreign_type : "#{name.id}_type").id }}
@@ -321,50 +372,53 @@ module Jennifer
           @{{name.id}} = self.class.{{name.id}}_relation.load(foreign_field, polymorphic_type)
         end
 
+        # :nodoc:
         def append_{{name.id}}(rel : Hash)
           raise ::Jennifer::BaseException.new("Polymorphic relation can't be loaded dynamically.")
         end
-
-        def append_{{name.id}}(rel : {{klass}})
-          @__{{name.id}}_retrieved = true
-          @{{name.id}} = rel
-        end
-
-        def append_{{name.id}}(rel : Jennifer::Model::Resource)
-          @__{{name.id}}_retrieved = true
-          @{{name.id}} = rel.as({{klass}})
-        end
-
-        def remove_{{name.id}}
-          {{@type}}.{{name.id}}_relation.remove(self)
-          @{{name.id}} = nil
-        end
-
-        def add_{{name.id}}(rel : Hash)
-          @{{name.id}} = {{@type}}.{{name.id}}_relation.insert(self, rel)
-        end
-
-        def add_{{name.id}}(rel : {{klass}})
-          @{{name.id}} = {{@type}}.{{name.id}}_relation.insert(self, rel)
-        end
       end
 
-      # Specifies a one-to-one association with another class. This macro should only be used if this class contains the foreign key.
+      # Specifies a one-to-one association with another class.
+      #
+      # This macro should only be used if this class contains the foreign key.
       # If the other class contains the foreign key, then you should use has_one instead.
-      macro belongs_to(name, klass, request = nil, foreign = nil, primary = nil, dependent = :none)
+      #
+      # Options:
+      #
+      # - *name* - relation name
+      # - *klass* - specify the class name of the association; in case of polymorphic relation use `Union(Class1 | Class2)` syntax
+      # - *request* - extra request scope to retrieve a specific set of records when access the associated collection
+      # - *foreign* - specify the foreign key used for the association
+      # - *primary* - specify the name of the column to use as the primary key for the relation
+      # - *dependent* - specify the destroy strategy of the associated objects when their owner is destroyed;
+      # available options are: `destroy`, `delete`, `nullify` (exception is polymorphic relation), `restrict_with_exception`
+      # - *polymorphic* - specifies that this relation is a polymorphic
+      # - *foreign_type* - specify the column used to store  the associated object's type,
+      # if this is a polymorphic relation
+      #
+      # Methods will be added for retrieval and query for a single associated object, for which this object holds an id:
+      #
+      # `association` is a placeholder for the symbol passed as the `name` argument.
+      #
+      # - `.association_relation`
+      # - `#association`
+      # - `#association!`
+      # - `#append_association(rel)`
+      # - `#add_association(rel)`
+      # - `#remove_association`
+      # - `#association_query`
+      # - `#association_reload`
+      #
+      # Polymorphic relation also generates next methods
+      #
+      # - `#association_class_name` - returns casted related object to `ClassName`
+      # - `#association_class_name?` - returns whether related object is a `ClassName`
+      macro belongs_to(name, klass, request = nil, foreign = nil, primary = nil, dependent = :none, polymorphic = false, foreign_type = nil)
         {{"{% RELATION_NAMES << #{name.id.stringify} %}".id}}
-        {% relation_class = "::Jennifer::Relation::BelongsTo(#{klass}, #{@type})".id %}
-        ::Jennifer::Model::RelationDefinition.declare_dependent({{name}}, {{dependent}}, :belongs_to)
-
-        RELATIONS["{{name.id}}"] =
-            {{relation_class}}.new("{{name.id}}", {{foreign}}, {{primary}}, {{klass}}.all{% if request %}.exec {{request}} {% end %})
+        ::Jennifer::Model::RelationDefinition.declare_dependent({{name}}, {{dependent}}, :belongs_to, {{polymorphic}})
 
         @{{name.id}} : {{klass}}?
         @__{{name.id}}_retrieved = false
-
-        def self.{{name.id}}_relation
-          RELATIONS["{{name.id}}"].as({{relation_class}})
-        end
 
         def {{name.id}}
           if !@__{{name.id}}_retrieved && @{{name.id}}.nil? && !new_record?
@@ -374,51 +428,104 @@ module Jennifer
           @{{name.id}}
         end
 
+        # :nodoc:
         def {{name.id}}!
           {{name.id}}.not_nil!
         end
 
-        def {{name.id}}_query
-          foreign_field = {{ (foreign ? foreign : "attribute(#{klass}.foreign_key_name)").id }}
-          self.class.{{name.id}}_relation.query(foreign_field).as(::Jennifer::QueryBuilder::ModelQuery({{klass}}))
-        end
-
-        def {{name.id}}_reload
-          @{{name.id}} = {{name.id}}_query.first.as({{klass}}?)
-        end
-
-        def append_{{name.id}}(rel : Hash)
-          @__{{name.id}}_retrieved = true
-          @{{name.id}} = {{klass}}.build(rel, false)
-        end
-
+        # :nodoc:
         def append_{{name.id}}(rel : {{klass}})
           @__{{name.id}}_retrieved = true
           @{{name.id}} = rel
         end
 
+        # :nodoc:
         def append_{{name.id}}(rel : Jennifer::Model::Resource)
           @__{{name.id}}_retrieved = true
           @{{name.id}} = rel.as({{klass}})
         end
 
+        # :nodoc:
+        def add_{{name.id}}(rel : Hash)
+          @{{name.id}} = {{@type}}.{{name.id}}_relation.insert(self, rel)
+        end
+
+        # :nodoc:
+        def add_{{name.id}}(rel : {{klass}})
+          @{{name.id}} = {{@type}}.{{name.id}}_relation.insert(self, rel)
+        end
+
+        # :nodoc:
         def remove_{{name.id}}
           {{@type}}.{{name.id}}_relation.remove(self)
           @{{name.id}} = nil
         end
 
-        def add_{{name.id}}(rel : Hash)
-          @{{name.id}} = {{@type}}.{{name.id}}_relation.insert(self, rel)
-        end
+        {% if polymorphic %}
+          polymorphic_belongs_to({{name}}, {{klass}}, {{request}}, {{foreign}}, {{foreign_type}}, {{primary}},  {{dependent}})
+        {% else %}
+          {% relation_class = "::Jennifer::Relation::BelongsTo(#{klass}, #{@type})".id %}
 
-        def add_{{name.id}}(rel : {{klass}})
-          @{{name.id}} = {{@type}}.{{name.id}}_relation.insert(self, rel)
-        end
+          RELATIONS["{{name.id}}"] =
+              {{relation_class}}.new("{{name.id}}", {{foreign}}, {{primary}}, {{klass}}.all{% if request %}.exec {{request}} {% end %})
+
+          # :nodoc:
+          def self.{{name.id}}_relation
+            RELATIONS["{{name.id}}"].as({{relation_class}})
+          end
+
+          # :nodoc:
+          def {{name.id}}_query
+            foreign_field = {{ (foreign ? foreign : "attribute(#{klass}.foreign_key_name)").id }}
+            self.class.{{name.id}}_relation.query(foreign_field).as(::Jennifer::QueryBuilder::ModelQuery({{klass}}))
+          end
+
+          # :nodoc:
+          def {{name.id}}_reload
+            @{{name.id}} = {{name.id}}_query.first.as({{klass}}?)
+          end
+
+          # :nodoc:
+          def append_{{name.id}}(rel : Hash)
+            @__{{name.id}}_retrieved = true
+            @{{name.id}} = {{klass}}.build(rel, false)
+          end
+        {% end %}
       end
 
-      # Specifies a one-to-one association with another class. This macro should only be used if the other class contains the foreign key.
+      # Specifies a one-to-one association with another class.
+      #
+      # This macro should only be used if the other class contains the foreign key.
       # If the current class contains the foreign key, then you should use belongs_to instead.
-      macro has_one(name, klass, request = nil, foreign = nil, foreign_type = nil, primary = nil, join_foreign = nil, dependent = :nullify, inverse_of = nil, polymorphic = false)
+      #
+      # Options:
+      #
+      # - *name* - relation name
+      # - *klass* - specify the class name of the association
+      # - *request* - extra request scope to retrieve a specific set of records when access the associated collection
+      # - *foreign* - specify the foreign key used for the association
+      # - *foreign_type* - specify the column used to store  the associated object's type,
+      # if this is a polymorphic relation
+      # - *primary* - specify the name of the column to use as the primary key for the relation
+      # - *dependent* - specify the destroy strategy of the associated objects when their owner is destroyed;
+      # available options are: `destroy`, `delete`, `nullify`, `restrict_with_exception`
+      # - *inverse_of* - specifies the name of the `belongs_to` relation on the associated object that is the inverse of this relation;
+      # required for polymorphic relation
+      # - *polymorphic* - specifies that this relation is a polymorphic
+      #
+      # The following methods for retrieval and query of a single associated object will be added:
+      #
+      # `association` is a placeholder for the symbol passed as the name argument.
+      #
+      # - `.association_relation`
+      # - `#association`
+      # - `#association!`
+      # - `#append_association(rel)`
+      # - `#add_association(rel)`
+      # - `#remove_association`
+      # - `#association_query`
+      # - `#association_reload`
+      macro has_one(name, klass, request = nil, foreign = nil, foreign_type = nil, primary = nil, dependent = :nullify, inverse_of = nil, polymorphic = false)
         {{"{% RELATION_NAMES << #{name.id.stringify} %}".id}}
         ::Jennifer::Model::RelationDefinition.declare_dependent({{name}}, {{dependent}}, :has_one)
 
@@ -445,6 +552,7 @@ module Jennifer
           {% end %}
         end
 
+        # :nodoc:
         def self.{{name.id}}_relation
           RELATIONS["{{name.id}}"].as({{relation_class}})
         end
@@ -456,45 +564,53 @@ module Jennifer
           @{{name.id}}
         end
 
+        # :nodoc:
         def {{name.id}}!
           {{name.id}}.not_nil!
         end
 
+        # :nodoc:
         def {{name.id}}_query
           primary_field = {{ (primary ? primary : "primary").id }}
           self.class.{{name.id}}_relation.query(primary_field).as(::Jennifer::QueryBuilder::ModelQuery({{klass}}))
         end
 
+        # :nodoc:
         def {{name.id}}_reload
           @__{{name.id}}_retrieved = true
           @{{name.id}} = {{name.id}}_query.first.as({{klass}}?)
         end
 
-        # ... ; doesn't support `inverse_of` option
+        # :nodoc:
         def append_{{name.id}}(rel : Hash)
           @__{{name.id}}_retrieved = true
           @{{name.id}} = {{klass}}.build(rel, false)
         end
 
+        # :nodoc:
         def append_{{name.id}}(rel : {{klass}})
           @__{{name.id}}_retrieved = true
           @{{name.id}} = rel
         end
 
+        # :nodoc:
         def append_{{name.id}}(rel : Jennifer::Model::Resource)
           @__{{name.id}}_retrieved = true
           @{{name.id}} = rel.as({{klass}})
         end
 
+        # :nodoc:
         def remove_{{name.id}}
           {{@type}}.{{name.id}}_relation.remove(self)
           @{{name.id}} = nil
         end
 
+        # :nodoc:
         def add_{{name.id}}(rel : Hash)
           @{{name.id}} = {{@type}}.{{name.id}}_relation.insert(self, rel)
         end
 
+        # :nodoc:
         def add_{{name.id}}(rel : {{klass}})
           @{{name.id}} = {{@type}}.{{name.id}}_relation.insert(self, rel)
         end

--- a/src/jennifer/model/relation_definition.cr
+++ b/src/jennifer/model/relation_definition.cr
@@ -93,6 +93,7 @@ module Jennifer
       # - *name* - relation name
       # - *klass* - specify the class name of the association
       # - *request* - extra request scope to retrieve a specific set of records when access the associated collection
+      # (ATM only `WHERE` conditions are respected)
       # - *foreign* - specify the foreign key used for the association
       # - *foreign_type* - specify the column used to store  the associated object's type,
       # if this is a polymorphic relation
@@ -222,6 +223,7 @@ module Jennifer
       # - *name* - relation name
       # - *klass* - specify the class name of the association
       # - *request* - extra request scope to retrieve a specific set of records when access the associated collection
+      # (ATM only `WHERE` conditions are respected)
       # - *foreign* - specify the foreign key used for the association
       # - *primary* - specify the name of the column to use as the primary key for the relation
       # - *join_table* - specifies the name of the join table if the default based on lexical order isn't what you want
@@ -388,6 +390,7 @@ module Jennifer
       # - *name* - relation name
       # - *klass* - specify the class name of the association; in case of polymorphic relation use `Union(Class1 | Class2)` syntax
       # - *request* - extra request scope to retrieve a specific set of records when access the associated collection
+      # (ATM only `WHERE` conditions are respected)
       # - *foreign* - specify the foreign key used for the association
       # - *primary* - specify the name of the column to use as the primary key for the relation
       # - *dependent* - specify the destroy strategy of the associated objects when their owner is destroyed;
@@ -503,6 +506,7 @@ module Jennifer
       # - *name* - relation name
       # - *klass* - specify the class name of the association
       # - *request* - extra request scope to retrieve a specific set of records when access the associated collection
+      # (ATM only `WHERE` conditions are respected)
       # - *foreign* - specify the foreign key used for the association
       # - *foreign_type* - specify the column used to store  the associated object's type,
       # if this is a polymorphic relation

--- a/src/jennifer/model/resource.cr
+++ b/src/jennifer/model/resource.cr
@@ -45,7 +45,7 @@ module Jennifer
         {% begin %}
           io << "#<" << {{@type.name.id.stringify}} << ":0x"
           object_id.to_s(16, io)
-          {% if @type.constant("COLUMNS_METADATA") %}
+          {% if !@type.abstract? && @type.constant("COLUMNS_METADATA") %}
             io << ' '
             {% for var, i in @type.constant("COLUMNS_METADATA").keys %}
               {% if i > 0 %}

--- a/src/jennifer/model/resource.cr
+++ b/src/jennifer/model/resource.cr
@@ -42,22 +42,15 @@ module Jennifer
       @@expression_builder : QueryBuilder::ExpressionBuilder?
 
       def inspect(io) : Nil
-        {% begin %}
-          io << "#<" << {{@type.name.id.stringify}} << ":0x"
-          object_id.to_s(16, io)
-          {% if !@type.abstract? && @type.constant("COLUMNS_METADATA") %}
-            io << ' '
-            {% for var, i in @type.constant("COLUMNS_METADATA").keys %}
-              {% if i > 0 %}
-                io << ", "
-              {% end %}
-              io << "{{var.id}}: "
-              @{{var.id}}.inspect(io)
-            {% end %}
-          {% end %}
-          io << '>'
-          nil
-        {% end %}
+        io << "#<" << {{@type.name.id.stringify}} << ":0x"
+        object_id.to_s(16, io)
+        inspect_attributes(io)
+        io << '>'
+        nil
+      end
+
+      private def inspect_attributes(io) : Nil
+        nil
       end
 
       def self.build(values : Hash(Symbol, ::Jennifer::DBAny) | NamedTuple)
@@ -117,12 +110,12 @@ module Jennifer
         result
       end
 
-      def self.c(name : String)
-        context.c(name)
+      def self.c(name : String | Symbol)
+        context.c(name.to_s)
       end
 
       def self.c(name : String | Symbol, relation)
-        ::Jennifer::QueryBuilder::Criteria.new(name, table_name, relation)
+        ::Jennifer::QueryBuilder::Criteria.new(name.to_s, table_name, relation)
       end
 
       def self.star

--- a/src/jennifer/model/sti_mapping.cr
+++ b/src/jennifer/model/sti_mapping.cr
@@ -44,6 +44,16 @@ module Jennifer
 
         __field_declaration({{properties}}, false)
 
+        private def inspect_attributes(io) : Nil
+          super
+          {% for var, i in properties.keys %}
+            io << ", "
+            io << "{{var.id}}: "
+            @{{var.id}}.inspect(io)
+          {% end %}
+          nil
+        end
+
         private def _sti_extract_attributes(values : Hash(String, ::Jennifer::DBAny))
           {% for key, value in properties %}
             %var{key.id} = {{value[:default]}}

--- a/src/jennifer/query_builder/executables.cr
+++ b/src/jennifer/query_builder/executables.cr
@@ -66,11 +66,13 @@ module Jennifer
       #
       # No callbacks or validation will be executed.
       def delete
+        return if @do_nothing
         adapter.delete(self)
       end
 
       # Returns whether any record satisfying given conditions exists.
       def exists?
+        return false if @do_nothing
         adapter.exists?(self)
       end
 

--- a/src/jennifer/query_builder/logic_operator.cr
+++ b/src/jennifer/query_builder/logic_operator.cr
@@ -1,6 +1,6 @@
 module Jennifer
   module QueryBuilder
-    abstract class LogicOperator
+    abstract class LogicOperator < SQLNode
       module Operators
         def &(other : Criteria)
           And.new(self, other.to_condition)

--- a/src/jennifer/query_builder/logic_operator.cr
+++ b/src/jennifer/query_builder/logic_operator.cr
@@ -1,6 +1,6 @@
 module Jennifer
   module QueryBuilder
-    abstract class LogicOperator < SQLNode
+    abstract class LogicOperator
       module Operators
         def &(other : Criteria)
           And.new(self, other.to_condition)

--- a/src/jennifer/query_builder/query.cr
+++ b/src/jennifer/query_builder/query.cr
@@ -54,6 +54,10 @@ module Jennifer
         initialize
       end
 
+      def do_nothing?
+        @do_nothing
+      end
+
       def self.null
         new.none
       end

--- a/src/jennifer/query_builder/query.cr
+++ b/src/jennifer/query_builder/query.cr
@@ -327,7 +327,7 @@ module Jennifer
       end
 
       def to_s
-        to_sql
+        as_sql
       end
 
       # Joins given *other* condition statement to the main condition tree.

--- a/src/jennifer/query_builder/query.cr
+++ b/src/jennifer/query_builder/query.cr
@@ -54,6 +54,10 @@ module Jennifer
         initialize
       end
 
+      def self.null
+        new.none
+      end
+
       protected def initialize_copy_without(other, except : Array(String))
         {% for segment in %w(having limit offset raw_select from lock distinct) %}
           @{{segment.id}} = other.@{{segment.id}}.clone unless except.includes?({{segment}})

--- a/src/jennifer/relation/base.cr
+++ b/src/jennifer/relation/base.cr
@@ -1,7 +1,9 @@
 module Jennifer
   module Relation
+    # Relation interface.
     abstract class IRelation
       abstract def name
+      # TODO: remove this method - it isn't used anywhere
       abstract def table_name
       abstract def model_class
       abstract def join_query
@@ -14,6 +16,8 @@ module Jennifer
       abstract def preload_relation(collection, out_collection, pk_repo)
     end
 
+    # Base generic relation class.
+    #
     # *T* - related model
     # *Q* - parent model
     class Base(T, Q) < IRelation
@@ -42,12 +46,12 @@ module Jennifer
       end
 
       def condition_clause(id)
-        tree = T.c(foreign_field) == id
+        tree = T.c(foreign_field, @name) == id
         @join_query ? tree & @join_query.not_nil!.clone : tree
       end
 
       def condition_clause(ids : Array)
-        tree = T.c(foreign_field).in(ids)
+        tree = T.c(foreign_field, @name).in(ids)
         @join_query ? tree & @join_query.not_nil!.clone : tree
       end
 
@@ -88,7 +92,7 @@ module Jennifer
         T.table_name
       end
 
-      # Foreign key on ~T~ model side
+      # Foreign key on *T* model side
       def foreign_field
         @foreign ||= Q.foreign_key_name
       end

--- a/src/jennifer/relation/base.cr
+++ b/src/jennifer/relation/base.cr
@@ -37,9 +37,7 @@ module Jennifer
       end
 
       def condition_clause
-        _foreign = foreign_field
-        _primary = primary_field
-        tree = T.c(_foreign, @name) == Q.c(_primary)
+        tree = T.c(foreign_field, @name) == Q.c(primary_field)
         @join_query ? tree & @join_query.not_nil!.clone : tree
       end
 

--- a/src/jennifer/relation/base.cr
+++ b/src/jennifer/relation/base.cr
@@ -10,7 +10,8 @@ module Jennifer
       abstract def condition_clause
       abstract def condition_clause(a)
       abstract def join_condition(a, b)
-      abstract def query(a)
+      # Returns query for given primary field values
+      abstract def query(primary_value)
       abstract def insert(a, b)
       # Preloads relation into *collection* from *out_collection* depending on keys from *pk_repo*.
       abstract def preload_relation(collection, out_collection, pk_repo)
@@ -62,7 +63,6 @@ module Jennifer
         end
       end
 
-      # Returns query for given primary field values
       def query(primary_value)
         condition = condition_clause(primary_value)
         T.where { condition }

--- a/src/jennifer/relation/has_one.cr
+++ b/src/jennifer/relation/has_one.cr
@@ -14,7 +14,7 @@ module Jennifer
       def remove(obj : Q)
         this = self
         _pf = obj.attribute(primary_field)
-        T.all.where { T.c(this.foreign_field) == _pf }.update({foreign_field => nil})
+        T.all.where { T.c(this.foreign_field) == _pf }.update({ foreign_field => nil })
       end
     end
   end

--- a/src/jennifer/relation/polymorphc_belongs_to.cr
+++ b/src/jennifer/relation/polymorphc_belongs_to.cr
@@ -2,20 +2,20 @@ module Jennifer
   module Relation
     abstract class IPolymorphicBelongsTo < IRelation
       getter foreign : String, primary : String
-      getter name : String, type_field : String
+      getter name : String, foreign_type : String
 
-      def initialize(@name, foreign : String | Symbol?, foreign_type : String | Symbol?, primary : String | Symbol?)
-        @type_field = foreign_type ? foreign_type.to_s : "#{name}_type"
+      def initialize(@name, foreign : String | Symbol?, primary : String | Symbol?, foreign_type : String | Symbol?)
+        @foreign_type = foreign_type ? foreign_type.to_s : "#{name}_type"
         @foreign = foreign ? foreign.to_s : "#{name}_id"
         @primary = primary ? primary.to_s : "id"
       end
 
-      abstract def related_model(arg)
-      abstract def table_name(type)
+      private abstract def related_model(arg)
+      private abstract def table_name(type)
 
       def condition_clause(id, polymorphic_type : String?)
         model = related_model(polymorphic_type)
-        _tree = model.c(primary_field) == id
+        _tree = model.c(primary_field, @name) == id
         _tree
       end
 
@@ -36,17 +36,18 @@ module Jennifer
         @primary
       end
 
-      macro define_relation_class(name, klass, related_class, types)
+      macro define_relation_class(name, klass, related_class, types, request)
+        # :nodoc:
         class {{name.id.camelcase}}Relation < ::Jennifer::Relation::IPolymorphicBelongsTo
           def initialize(*opts)
             super
           end
 
-          def related_model(obj : {{klass}})
-            related_model(obj.attribute(type_field))
+          private def related_model(obj : {{klass}})
+            related_model(obj.attribute(foreign_type).as(String))
           end
 
-          def related_model(type : String)
+          private def related_model(type : String)
             case type
             {% for type in types %}
             when {{type.stringify}}
@@ -57,7 +58,7 @@ module Jennifer
             end
           end
 
-          def table_name(type : String)
+          private def table_name(type : String)
             case type
             {% for type in types %}
             when {{type.stringify}}
@@ -67,6 +68,13 @@ module Jennifer
               raise ::Jennifer::BaseException.new("Unknown polymorphic type #{type}")
             end
           end
+
+          {% if request %}
+            def query(id, polymorphic_type : String)
+              condition = condition_clause(id, polymorphic_type)
+              Query[table_name(polymorphic_type)].where { condition }.exec {{request}}
+            end
+          {% end %}
 
           def build(opts : Hash, polymorphic_type)
             case polymorphic_type
@@ -103,9 +111,10 @@ module Jennifer
             end
           end
 
+          # Destroys related to *obj* object. Is called on `dependent: :destroy`.
           def destroy(obj : {{klass}})
             foreign_field = obj.attribute(foreign)
-            polymorphic_type = obj.attribute(type_field).as(String?)
+            polymorphic_type = obj.attribute(foreign_type).as(String?)
             return if foreign_field.nil? || polymorphic_type.nil?
 
             condition = condition_clause(foreign_field, polymorphic_type)
@@ -120,21 +129,22 @@ module Jennifer
           end
 
           def insert(obj : {{klass}}, rel : Hash(String, Jennifer::DBAny))
-            foreign_type = rel[type_field].as(String)
-            main_obj = create!(rel, foreign_type)
-            obj.update_columns({ foreign_field => main_obj.attribute(primary_field), type_field => foreign_type })
+            raise ::Jennifer::BaseException.new("Given hash has no #{foreign_type} field.") unless rel.has_key?(foreign_type)
+            type_field = rel[foreign_type].as(String)
+            main_obj = create!(rel, type_field)
+            obj.update_columns({ foreign_field => main_obj.attribute(primary_field), foreign_type => type_field })
             main_obj
           end
 
           def insert(obj : {{klass}}, rel : {{related_class}})
             raise ::Jennifer::BaseException.new("Object already belongs to another object") unless obj.attribute(foreign_field).nil?
-            obj.update_columns({ foreign_field => rel.attribute(primary_field), type_field => rel.class.to_s })
+            obj.update_columns({ foreign_field => rel.attribute(primary_field), foreign_type => rel.class.to_s })
             rel.save! if rel.new_record?
             rel
           end
 
           def remove(obj : {{klass}})
-            obj.update_columns({ foreign_field => nil, type_field => nil })
+            obj.update_columns({ foreign_field => nil, foreign_type => nil })
           end
         end
       end

--- a/src/jennifer/relation/polymorphc_belongs_to.cr
+++ b/src/jennifer/relation/polymorphc_belongs_to.cr
@@ -1,0 +1,175 @@
+module Jennifer
+  module Relation
+    abstract class IPolymorphicBelongsTo < IRelation
+      getter foreign : String, primary : String
+      getter name : String, type_field : String
+
+      def initialize(@name, foreign : String | Symbol?, foreign_type : String | Symbol?, primary : String | Symbol?)
+        @type_field = foreign_type ? foreign_type.to_s : "#{name}_type"
+        @foreign = foreign ? foreign.to_s : "#{name}_id"
+        @primary = primary ? primary.to_s : "id"
+      end
+
+      abstract def related_model(arg)
+      abstract def table_name(type)
+
+      def condition_clause(id, polymorphic_type : String?)
+        model = related_model(polymorphic_type)
+        _tree = model.c(primary_field) == id
+        _tree
+      end
+
+      def query(id, polymorphic_type : Nil)
+        Query.null
+      end
+
+      def query(id, polymorphic_type : String)
+        condition = condition_clause(id, polymorphic_type)
+        Query[table_name(polymorphic_type)].where { condition }
+      end
+
+      def foreign_field
+        @foreign
+      end
+
+      def primary_field
+        @primary
+      end
+
+      macro define_relation_class(name, klass, related_class, types)
+        class {{name.id.camelcase}}Relation < ::Jennifer::Relation::IPolymorphicBelongsTo
+          def initialize(*opts)
+            super
+          end
+
+          def related_model(obj : {{klass}})
+            related_model(obj.attribute(type_field))
+          end
+
+          def related_model(type : String)
+            case type
+            {% for type in types %}
+            when {{type.stringify}}
+              {{type}}
+            {% end %}
+            else
+              raise ::Jennifer::BaseException.new("Unknown polymorphic type #{type}")
+            end
+          end
+
+          def table_name(type : String)
+            case type
+            {% for type in types %}
+            when {{type.stringify}}
+              {{type}}.table_name
+            {% end %}
+            else
+              raise ::Jennifer::BaseException.new("Unknown polymorphic type #{type}")
+            end
+          end
+
+          def build(opts : Hash, polymorphic_type)
+            case polymorphic_type
+            {% for type in types %}
+            when {{type.stringify}}
+              {{type}}.build(opts, false)
+            {% end %}
+            else
+              raise ::Jennifer::BaseException.new("Unknown polymorphic type #{polymorphic_type}")
+            end
+          end
+
+          def create!(opts : Hash, polymorphic_type)
+            case polymorphic_type
+            {% for type in types %}
+            when {{type.stringify}}
+              {{type}}.create!(opts)
+            {% end %}
+            else
+              raise ::Jennifer::BaseException.new("Unknown polymorphic type #{polymorphic_type}")
+            end
+          end
+
+          def load(foreign_field, polymorphic_type : String?)
+            return if foreign_field.nil? || polymorphic_type.nil?
+            condition = condition_clause(foreign_field, polymorphic_type)
+            case polymorphic_type
+            {% for type in types %}
+            when {{type.stringify}}
+              {{type}}.where { condition }.first
+            {% end %}
+            else
+              raise ::Jennifer::BaseException.new("Unknown polymorphic type #{polymorphic_type}")
+            end
+          end
+
+          def destroy(obj : {{klass}})
+            foreign_field = obj.attribute(foreign)
+            polymorphic_type = obj.attribute(type_field).as(String?)
+            return if foreign_field.nil? || polymorphic_type.nil?
+
+            condition = condition_clause(foreign_field, polymorphic_type)
+            case polymorphic_type
+            {% for type in types %}
+            when {{type.stringify}}
+              {{type}}.where { condition }.destroy
+            {% end %}
+            else
+              raise ::Jennifer::BaseException.new("Unknown polymorphic type #{polymorphic_type}")
+            end
+          end
+
+          def insert(obj : {{klass}}, rel : Hash(String, Jennifer::DBAny))
+            foreign_type = rel[type_field].as(String)
+            main_obj = create!(rel, foreign_type)
+            obj.update_columns({ foreign_field => main_obj.attribute(primary_field), type_field => foreign_type })
+            main_obj
+          end
+
+          def insert(obj : {{klass}}, rel : {{related_class}})
+            raise ::Jennifer::BaseException.new("Object already belongs to another object") unless obj.attribute(foreign_field).nil?
+            obj.update_columns({ foreign_field => rel.attribute(primary_field), type_field => rel.class.to_s })
+            rel.save! if rel.new_record?
+            rel
+          end
+
+          def remove(obj : {{klass}})
+            obj.update_columns({ foreign_field => nil, type_field => nil })
+          end
+        end
+      end
+
+      def table_name
+        raise AbstractMethod.new("table_name", self)
+      end
+
+      def model_class
+        raise AbstractMethod.new("model_class", self)
+      end
+
+      def join_query
+        raise AbstractMethod.new("join_query", self)
+      end
+
+      def query(a)
+        raise AbstractMethod.new("query", self)
+      end
+
+      def condition_clause
+        raise AbstractMethod.new("condition_clause", self)
+      end
+
+      def condition_clause(id)
+        raise AbstractMethod.new("condition_clause", self)
+      end
+
+      def join_condition(query, type)
+        raise ::Jennifer::BaseException.new("Polymorphic belongs_to relation can't be dynamically joined.")
+      end
+
+      def preload_relation(collection, out_collection : Array(::Jennifer::Model::Resource), pk_repo)
+        raise ::Jennifer::BaseException.new("Polymorphic belongs_to relation can't be preloaded.")
+      end
+    end
+  end
+end

--- a/src/jennifer/relation/polymorphic_has_many.cr
+++ b/src/jennifer/relation/polymorphic_has_many.cr
@@ -1,0 +1,52 @@
+module Jennifer
+  module Relation
+    class PolymorphicHasMany(T, Q) < Base(T, Q)
+      getter foreign_type : String
+
+      def initialize(name, foreign, primary, query, foreign_type : String | Symbol?, inverse_of : String | Symbol)
+        @foreign_type = foreign_type ? foreign_type.to_s : inverse_of.to_s + "_type"
+        foreign = foreign || "#{inverse_of}_id"
+        super(name, foreign, primary, query, nil)
+      end
+
+      def condition_clause
+        tree = (T.c(foreign_field, @name) == Q.c(primary_field)) & (T.c(foreign_type, @name) == polymorphic_type_value)
+        @join_query ? tree & @join_query.not_nil!.clone : tree
+      end
+
+      def condition_clause(id)
+        tree = (T.c(foreign_field) == id) & (T.c(foreign_type, @name) == polymorphic_type_value)
+        @join_query ? tree & @join_query.not_nil!.clone : tree
+      end
+
+      def condition_clause(ids : Array)
+        tree = (T.c(foreign_field).in(ids)) & (T.c(foreign_type, @name) == polymorphic_type_value)
+        @join_query ? tree & @join_query.not_nil!.clone : tree
+      end
+
+      def insert(obj : Q, rel : Hash(String, Jennifer::DBAny))
+        rel[foreign_field] = obj.attribute(primary_field)
+        rel[foreign_type] = polymorphic_type_value
+        T.create!(rel)
+      end
+
+      def insert(obj : Q, rel : T)
+        rel.set_attribute(foreign_field, obj.attribute(primary_field))
+        rel.set_attribute(foreign_type, polymorphic_type_value)
+        rel.save!
+        rel
+      end
+
+      def remove(obj : Q, rel : T)
+        if rel.attribute(foreign_field) == obj.attribute(primary_field) && rel.attribute(foreign_type) == polymorphic_type_value
+          rel.update_columns({ foreign_field => nil, foreign_type => nil })
+        end
+        rel
+      end
+
+      def polymorphic_type_value
+        @polymorphic_type_value ||= Q.to_s
+      end
+    end
+  end
+end

--- a/src/jennifer/relation/polymorphic_has_many.cr
+++ b/src/jennifer/relation/polymorphic_has_many.cr
@@ -15,12 +15,12 @@ module Jennifer
       end
 
       def condition_clause(id)
-        tree = (T.c(foreign_field) == id) & (T.c(foreign_type, @name) == polymorphic_type_value)
+        tree = (T.c(foreign_field, @name) == id) & (T.c(foreign_type, @name) == polymorphic_type_value)
         @join_query ? tree & @join_query.not_nil!.clone : tree
       end
 
       def condition_clause(ids : Array)
-        tree = (T.c(foreign_field).in(ids)) & (T.c(foreign_type, @name) == polymorphic_type_value)
+        tree = (T.c(foreign_field, @name).in(ids)) & (T.c(foreign_type, @name) == polymorphic_type_value)
         @join_query ? tree & @join_query.not_nil!.clone : tree
       end
 

--- a/src/jennifer/relation/polymorphic_has_one.cr
+++ b/src/jennifer/relation/polymorphic_has_one.cr
@@ -1,0 +1,60 @@
+module Jennifer
+  module Relation
+    class PolymorphicHasOne(T, Q) < Base(T, Q)
+      getter foreign_type : String
+
+      def initialize(name, foreign, primary, query, foreign_type : String | Symbol?, inverse_of : String | Symbol)
+        @foreign_type = foreign_type ? foreign_type.to_s : inverse_of.to_s + "_type"
+        foreign = foreign || "#{inverse_of}_id"
+        super(name, foreign, primary, query, nil)
+      end
+
+      def condition_clause
+        tree = (T.c(foreign_field, @name) == Q.c(primary_field)) & (T.c(foreign_type, @name) == polymorphic_type_value)
+        @join_query ? tree & @join_query.not_nil!.clone : tree
+      end
+
+      def condition_clause(id)
+        tree = (T.c(foreign_field) == id) & (T.c(foreign_type, @name) == polymorphic_type_value)
+        @join_query ? tree & @join_query.not_nil!.clone : tree
+      end
+
+      def condition_clause(ids : Array)
+        tree = (T.c(foreign_field).in(ids)) & (T.c(foreign_type, @name) == polymorphic_type_value)
+        @join_query ? tree & @join_query.not_nil!.clone : tree
+      end
+
+      def insert(obj : Q, rel : Hash(String, Jennifer::DBAny))
+        rel[foreign_field] = obj.attribute(primary_field)
+        rel[foreign_type] = polymorphic_type_value
+        T.create!(rel)
+      end
+
+      def insert(obj : Q, rel : T)
+        raise BaseException.new("Object already has one another object") unless obj.attribute(foreign_field).nil?
+        rel.set_attribute(foreign_field, obj.attribute(primary_field))
+        rel.set_attribute(foreign_type, polymorphic_type_value)
+        rel.save!
+        rel
+      end
+
+      def remove(obj : Q, rel : T)
+        if rel.attribute(foreign_field) == obj.attribute(primary_field) && rel.attribute(foreign_type) == polymorphic_type_value
+          rel.update_columns({ foreign_field => nil, foreign_type => nil })
+        end
+        rel
+      end
+
+      def polymorphic_type_value
+        @polymorphic_type_value ||= Q.to_s
+      end
+
+      # TODO: find way to update exactly one record, not all
+      def remove(obj : Q)
+        this = self
+        _pf = obj.attribute(primary_field)
+        T.all.where { T.c(this.foreign_field) == _pf }.update({foreign_field => nil})
+      end
+    end
+  end
+end

--- a/src/jennifer/relation/polymorphic_has_one.cr
+++ b/src/jennifer/relation/polymorphic_has_one.cr
@@ -15,23 +15,24 @@ module Jennifer
       end
 
       def condition_clause(id)
-        tree = (T.c(foreign_field) == id) & (T.c(foreign_type, @name) == polymorphic_type_value)
+        tree = (T.c(foreign_field, @name) == id) & (T.c(foreign_type, @name) == polymorphic_type_value)
         @join_query ? tree & @join_query.not_nil!.clone : tree
       end
 
       def condition_clause(ids : Array)
-        tree = (T.c(foreign_field).in(ids)) & (T.c(foreign_type, @name) == polymorphic_type_value)
+        tree = (T.c(foreign_field, @name).in(ids)) & (T.c(foreign_type, @name) == polymorphic_type_value)
         @join_query ? tree & @join_query.not_nil!.clone : tree
       end
 
       def insert(obj : Q, rel : Hash(String, Jennifer::DBAny))
         rel[foreign_field] = obj.attribute(primary_field)
         rel[foreign_type] = polymorphic_type_value
+        # TODO: check whether object already has created related object
         T.create!(rel)
       end
 
       def insert(obj : Q, rel : T)
-        raise BaseException.new("Object already has one another object") unless obj.attribute(foreign_field).nil?
+        raise BaseException.new("Object already has one another object") unless rel.attribute(foreign_field).nil?
         rel.set_attribute(foreign_field, obj.attribute(primary_field))
         rel.set_attribute(foreign_type, polymorphic_type_value)
         rel.save!
@@ -45,15 +46,15 @@ module Jennifer
         rel
       end
 
-      def polymorphic_type_value
-        @polymorphic_type_value ||= Q.to_s
-      end
-
-      # TODO: find way to update exactly one record, not all
+      # Removes related instance of class *T* from DB without it's id.
       def remove(obj : Q)
         this = self
         _pf = obj.attribute(primary_field)
-        T.all.where { T.c(this.foreign_field) == _pf }.update({foreign_field => nil})
+        T.all.where { T.c(this.foreign_field) == _pf }.limit(1).update({ foreign_field => nil, foreign_type => nil })
+      end
+
+      def polymorphic_type_value
+        @polymorphic_type_value ||= Q.to_s
       end
     end
   end

--- a/src/jennifer/view/experimental_mapping.cr
+++ b/src/jennifer/view/experimental_mapping.cr
@@ -54,6 +54,18 @@ module Jennifer
 
       # :nodoc:
       macro __instance_methods
+        private def inspect_attributes(io) : Nil
+          io << ' '
+          {% for var, i in COLUMNS_METADATA.keys %}
+            {% if i > 0 %}
+              io << ", "
+            {% end %}
+            io << "{{var.id}}: "
+            @{{var.id}}.inspect(io)
+          {% end %}
+          nil
+        end
+
         # Creates object from `DB::ResultSet`
         def initialize(%pull : DB::ResultSet)
           {{COLUMNS_METADATA.keys.map { |f| "@#{f.id}" }.join(", ").id}} = _extract_attributes(%pull)


### PR DESCRIPTION
# What does this PR do?

Add polymorphic relationships: `belongs_to`, `has_many` and `has_one` 

# Release notes

**QueryBuilder**

- now `LogicOperator` is inherited from `SQLNode`
- `#delete` and `exists?` of `Executables` do nothing when `#do_nothing?` is `true`
- add `Query#do_nothing?`
- add `Query.null` which returns `Query.new.none`

**Model**

- add `Base#persisted?`
- now attribute-specific rendering for `Resource#inspect` is generated by `.mapping`
- add polymorphic relation support for `has_one`, `has_many` and `belongs_to` relations
- add `:nodoc:` for almost all generated relation methods (except `#association`)
- add missing relation names for criterion in `Relation::Base` methods
- add `Relation::IPolymorphicBelongsTo`, `Relation::PolymorphicHasMany` and `Relation::PolymorphicHasOne`

**View**

- now attribute-specific rendering for `Resource#inspect` is generated by `.mapping`

**Migration**

* `TableBuilder::CreateTable#reference` now accepts `polymorphic` bool argument presenting whether additional type column should be added; for polymorphic reference foreign key isn't adding 
