### PR TITLE
Return true when save persisted unchanged model

### DIFF
--- a/spec/model/base_spec.cr
+++ b/spec/model/base_spec.cr
@@ -255,7 +255,7 @@ describe Jennifer::Model::Base do
       end
 
       it "returns false if record wasn't saved" do
-        Factory.create_contact.save.should be_false
+        Factory.create_address.save.should be_true
       end
 
       it "calls after_save_callback" do

--- a/src/jennifer/model/base.cr
+++ b/src/jennifer/model/base.cr
@@ -201,10 +201,6 @@ module Jennifer
         update_columns({name => value})
       end
 
-      private def __check_if_changed
-        raise Jennifer::Skip.new unless changed? || new_record?
-      end
-
       def save!(skip_validation : Bool = false)
         raise Jennifer::RecordInvalid.new(errors.to_a) unless save(skip_validation)
         true
@@ -262,6 +258,7 @@ module Jennifer
 
       private def update_record : Bool
         return false unless __before_update_callback
+        return true unless changed?
         res = self.class.adapter.update(self)
         __after_update_callback
         res.rows_affected == 1
@@ -346,7 +343,6 @@ module Jennifer
         ::Jennifer::Model::RelationDefinition.inherited_hook
 
         after_save :__refresh_changes
-        before_save :__check_if_changed
 
         def self.superclass
           {{@type.superclass}}


### PR DESCRIPTION
# What does this PR do?

Allow saving model instance with no changed fields.

```crystal
User.create.save # => true instead of false
```

# Release notes

**Model**

- `#save` and `#update` will return `true` when is called on an object with no changed fields (all before callbacks are invoked) 