### PR TITLE
Adjust documentation generating

### DIFF
--- a/spec/model/sti_mapping_spec.cr
+++ b/spec/model/sti_mapping_spec.cr
@@ -228,4 +228,26 @@ describe Jennifer::Model::STIMapping do
       p.reload.uid.should eq("2222")
     end
   end
+
+  describe "::build_params" do
+    it "correctly converts arguments hash with maybe Nil types" do
+      params = {
+        "login" => "login".as(String?),
+        "contact_id" => "1234"
+      }
+      hash = FacebookProfile.build_params(params)
+      hash["login"].should eq("login")
+      hash["contact_id"].should eq(1234)
+    end
+
+    it "correctly converts nil values" do
+      params = {
+        "login" => "login",
+        "contact_id" => nil
+      }
+      hash = FacebookProfile.build_params(params)
+      hash["login"].should eq("login")
+      hash["contact_id"].should be_nil
+    end
+  end
 end

--- a/spec/view/base_spec.cr
+++ b/spec/view/base_spec.cr
@@ -149,4 +149,35 @@ describe Jennifer::View::Base do
       Jennifer::View::Base.views.includes?(Jennifer::View::Materialized).should be_false
     end
   end
+
+  describe "::build" do
+    context "strict mapping" do
+      it "raises exception if not all fields are described" do
+        Factory.create_contact
+        executed = false
+        expect_raises(::Jennifer::BaseException) do
+          StrictMaleContactWithExtraField.all.each_result_set do |rs|
+            executed = true
+            begin
+              StrictMaleContactWithExtraField.build(rs)
+            ensure
+              rs.read_to_end
+            end
+          end
+        end
+        executed.should be_true
+      end
+    end
+
+    context "with hash" do
+      context "strict mapping" do
+        it "raises exception if some field can't be casted" do
+          error_message = "Column StrinctBrokenMaleContact.name can't be casted from Nil to it's type - String"
+          expect_raises(Jennifer::BaseException, error_message) do
+            StrinctBrokenMaleContact.build({} of String => Jennifer::DBAny)
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/view/experimental_mapping_spec.cr
+++ b/spec/view/experimental_mapping_spec.cr
@@ -12,61 +12,6 @@ describe Jennifer::View::ExperimentalMapping do
     end
   end
 
-  describe "#_extract_attributes" do
-    it "returns tuple with values" do
-      ballance = postgres_only do
-        PG::Numeric.new(1i16, 0i16, 0i16, 0i16, [1i16])
-      end
-      mysql_only do
-        10f64
-      end
-      executed = false
-      c1 = Factory.create_contact(ballance: ballance)
-      MaleContact.all.where { _id == c1.id }.each_result_set do |rs|
-        executed = true
-        res = c1._extract_attributes(rs)
-        res.is_a?(Tuple).should be_true
-        res[0].should eq(c1.id)
-        res[1].should eq("Deepthi")
-        res[2].should eq(ballance)
-        res[3].should eq(28)
-        res[4].should eq("male")
-        res[6].is_a?(Time).should be_true
-        res[7].is_a?(Time).should be_true
-      end
-      executed.should be_true
-    end
-
-    context "strict mapping" do
-      it "raises exception if not all fields are described" do
-        Factory.create_contact
-        executed = false
-        expect_raises(::Jennifer::BaseException) do
-          StrictMaleContactWithExtraField.all.each_result_set do |rs|
-            executed = true
-            begin
-              StrictMaleContactWithExtraField.build(rs)
-            ensure
-              rs.read_to_end
-            end
-          end
-        end
-        executed.should be_true
-      end
-    end
-
-    context "with hash" do
-      context "strict mapping" do
-        it "raises exception if some field can't be casted" do
-          error_message = "Column StrinctBrokenMaleContact.name can't be casted from Nil to it's type - String"
-          expect_raises(Jennifer::BaseException, error_message) do
-            StrinctBrokenMaleContact.build({} of String => Jennifer::DBAny)
-          end
-        end
-      end
-    end
-  end
-
   describe "%mapping" do
     describe "::columns_tuple" do
       it "returns named tuple with column metedata" do

--- a/src/jennifer.cr
+++ b/src/jennifer.cr
@@ -1,8 +1,6 @@
 require "inflector"
-
 require "ifrit/converter"
 require "ifrit/core"
-
 require "i18n"
 
 require "./jennifer/macros"
@@ -27,6 +25,7 @@ require "./jennifer/migration/*"
 
 module Jennifer
   {% if Jennifer.constant("AFTER_LOAD_SCRIPT") == nil %}
+    # :nodoc:
     AFTER_LOAD_SCRIPT = [] of String
   {% end %}
 

--- a/src/jennifer/adapter.cr
+++ b/src/jennifer/adapter.cr
@@ -38,7 +38,6 @@ module Jennifer
       adapter.query(_query, args) { |rs| yield rs }
     end
 
-    # :nodoc:
     # Allows to assign newly created adapter and call setupe methods with existing adapter
     private def self.adapter=(_adapter)
       @@adapter = _adapter

--- a/src/jennifer/adapter/postgres/migration/table_builder/change_enum.cr
+++ b/src/jennifer/adapter/postgres/migration/table_builder/change_enum.cr
@@ -41,7 +41,7 @@ module Jennifer
           end
 
           def add_values
-            typed_array_cast(@options[:add_values].as(Array), String).each do |field|
+            Ifrit.typed_array_cast(@options[:add_values].as(Array), String).each do |field|
               adapter.exec "ALTER TYPE #{@name} ADD VALUE '#{field}'"
             end
           end

--- a/src/jennifer/adapter/shared/types.cr
+++ b/src/jennifer/adapter/shared/types.cr
@@ -1,6 +1,7 @@
 # Stubs for all adapters. Is added here to allow making general DBAny alias for
 # all adapters.
 module PG
+  # :nodoc:
   struct Numeric
     def_clone
 
@@ -11,6 +12,7 @@ module PG
 
   module Geo
     {% for type in %w(Point Line Circle LineSegment Box Path Polygon) %}
+      # :nodoc:
       struct {{type.id}}
         def_clone
 
@@ -22,22 +24,27 @@ module PG
   end
 end
 
+# :nodoc:
 struct Time
   def_clone
 
+  # :nodoc:
   struct Span
     def_clone
   end
 end
 
+# :nodoc:
 class Time::Location
   def_clone
 
+  # :nodoc:
   struct Zone
     def_clone
   end
 end
 
+# :nodoc:
 struct JSON::Any
   def_clone
 end

--- a/src/jennifer/migration/base.cr
+++ b/src/jennifer/migration/base.cr
@@ -2,6 +2,7 @@ module Jennifer
   module Migration
     abstract class Base
       module AbstractClassMethods
+        # Returns migration version - timestamp part of a class file name.
         abstract def version
       end
 
@@ -22,6 +23,7 @@ module Jennifer
       end
 
       macro inherited
+        # :nodoc:
         def self.version
           matched_data = File.basename(__FILE__, ".cr").match(/\A(\d)+/)
           return matched_data[0] if matched_data

--- a/src/jennifer/migration/table_builder/base.cr
+++ b/src/jennifer/migration/table_builder/base.cr
@@ -7,8 +7,6 @@ module Jennifer
         alias AAllowedTypes = EAllowedTypes | Array(EAllowedTypes)
         alias DB_OPTIONS = Hash(Symbol, EAllowedTypes | Array(EAllowedTypes))
 
-        extend Ifrit
-
         delegate schema_processor, table_exists?, index_exists?, column_exists?, to: adapter
 
         getter adapter : Adapter::Base

--- a/src/jennifer/migration/table_builder/change_table.cr
+++ b/src/jennifer/migration/table_builder/change_table.cr
@@ -26,7 +26,7 @@ module Jennifer
 
         def change_column(old_name, new_name, type : Symbol? = nil, options = DB_OPTIONS.new)
           @changed_columns[old_name.to_s] =
-            sym_hash_cast(options, AAllowedTypes).merge(
+            Ifrit.sym_hash_cast(options, AAllowedTypes).merge(
             {
               :new_name => new_name,
               :type     => type,
@@ -36,7 +36,7 @@ module Jennifer
 
         def add_column(name, type : Symbol, options = DB_OPTIONS.new)
           @new_columns[name.to_s] =
-            sym_hash_cast(options, AAllowedTypes).merge({ :type => type } of Symbol => AAllowedTypes)
+            Ifrit.sym_hash_cast(options, AAllowedTypes).merge({ :type => type } of Symbol => AAllowedTypes)
           self
         end
 
@@ -45,8 +45,12 @@ module Jennifer
           self
         end
 
+        # Adds index.
+        #
+        # ```
         # add_index("index_name", [:field1, :field2], { :length => { :field1 => 2, :field2 => 3 }, :order => { :field1 => :asc }})
         # add_index("index_name", [:field1], { :length => { :field1 => 2, :field2 => 3 }, :order => { :field1 => :asc }})
+        # ```
         def add_index(name : String, fields : Array(Symbol), type : Symbol? = nil, lengths : Hash(Symbol, Int32) = {} of Symbol => Int32, orders : Hash(Symbol, Symbol) = {} of Symbol => Symbol)
           @commands << CreateIndex.new(@adapter, @name, name, fields, type, lengths, orders)
           self

--- a/src/jennifer/migration/table_builder/create_table.cr
+++ b/src/jennifer/migration/table_builder/create_table.cr
@@ -20,7 +20,7 @@ module Jennifer
         {% end %}
 
         def enum(name, values = [] of String, options = DB_OPTIONS.new)
-          hash = ({ :type => :enum, :values => typed_array_cast(values, EAllowedTypes) } of Symbol => AAllowedTypes).merge(options)
+          hash = ({ :type => :enum, :values => Ifrit.typed_array_cast(values, EAllowedTypes) } of Symbol => AAllowedTypes).merge(options)
           @fields[name.to_s] = hash
           self
         end

--- a/src/jennifer/model/callback.cr
+++ b/src/jennifer/model/callback.cr
@@ -1,148 +1,184 @@
 module Jennifer
   module Model
+    # Callbacks are hooks into the life cycle of a model object that allow you to trigger logic before
+    #  or after an alteration of the object state.
     module Callback
-      def __before_save_callback
+      protected def __before_save_callback
         true
       end
 
-      def __before_create_callback
+      protected def __before_create_callback
         true
       end
 
-      def __before_update_callback
+      protected def __before_update_callback
         true
       end
 
-      def __before_destroy_callback
+      protected def __before_destroy_callback
         true
       end
 
-      def __before_validation_callback
+      protected def __before_validation_callback
         true
       end
 
-      def __after_save_callback
+      protected def __after_save_callback
         true
       end
 
-      def __after_create_callback
+      protected def __after_create_callback
         true
       end
 
-      def __after_update_callback
+      protected def __after_update_callback
         true
       end
 
-      def __after_initialize_callback
+      protected def __after_initialize_callback
         true
       end
 
-      def __after_destroy_callback
+      protected def __after_destroy_callback
         true
       end
 
-      def __after_validation_callback
+      protected def __after_validation_callback
         true
       end
 
-      def __after_save_commit_callback
+      protected def __after_save_commit_callback
         true
       end
 
-      def __after_create_commit_callback
+      protected def __after_create_commit_callback
         true
       end
 
-      def __after_update_commit_callback
+      protected def __after_update_commit_callback
         true
       end
 
-      def __after_destroy_commit_callback
+      protected def __after_destroy_commit_callback
         true
       end
 
-      def __after_save_rollback_callback
+      protected def __after_save_rollback_callback
         true
       end
 
-      def __after_create_rollback_callback
+      protected def __after_create_rollback_callback
         true
       end
 
-      def __after_destroy_rollback_callback
+      protected def __after_destroy_rollback_callback
         true
       end
 
-      def __after_update_rollback_callback
+      protected def __after_update_rollback_callback
         true
       end
 
+      # Defines callbacks which are called before `Base.save` (regardless of whether it's a `create` or `update` save).
+      #
+      # Note that these callbacks are already wrapped in the transaction around save.
       macro before_save(*names)
         {% for name in names %}
           {% CALLBACKS[:save][:before] << name.id.stringify %}
         {% end %}
       end
 
+      # Defines callbacks which are called after `Base.save` (regardless of whether it's a `create` or `update` save).
+      #
+      # Note that these callbacks are still wrapped in the transaction around save.
       macro after_save(*names)
         {% for name in names %}
           {% CALLBACKS[:save][:after] << name.id.stringify %}
         {% end %}
       end
 
+      # Defines callbacks which are called before `Base.save` on new objects that haven’t been saved yet
+      # (no record exists).
+      #
+      # Note that these callbacks are already wrapped in the transaction around save.
       macro before_create(*names)
         {% for name in names %}
           {% CALLBACKS[:create][:before] << name.id.stringify %}
         {% end %}
       end
 
+      # Defines callbacks which are called after `Base.save` on new objects that haven’t been saved yet
+      # (no record exists).
+      #
+      # Note that these callbacks is still wrapped in the transaction around save.
       macro after_create(*names)
         {% for name in names %}
           {% CALLBACKS[:create][:after] << name.id.stringify %}
         {% end %}
       end
 
+      # Defines callbacks which are called before `Base.save` on existing objects that have a record.
+      #
+      # Note that these callbacks are already wrapped in the transaction around save.
       macro before_update(*names)
         {% for name in names %}
           {% CALLBACKS[:update][:before] << name.id.stringify %}
         {% end %}
       end
 
+      # Defines callbacks which are called after `Base.save` on existing objects that have a record.
+      #
+      # Note that these callbacks are still wrapped in the transaction around save.
       macro after_update(*names)
         {% for name in names %}
           {% CALLBACKS[:update][:after] << name.id.stringify %}
         {% end %}
       end
 
+      # Defines callbacks which are called after `Base.build` call.
       macro after_initialize(*names)
         {% for name in names %}
           {% CALLBACKS[:initialize][:after] << name.id.stringify %}
         {% end %}
       end
 
+      # Defines callbacks which are called before `Base.destroy`
       macro before_destroy(*names)
         {% for name in names %}
           {% CALLBACKS[:destroy][:before] << name.id.stringify %}
         {% end %}
       end
 
+      # Defines callbacks which are called after `Base.destroy`.
       macro after_destroy(*names)
         {% for name in names %}
           {% CALLBACKS[:destroy][:after] << name.id.stringify %}
         {% end %}
       end
 
+      # Defines callbacks which are called before `Base.validate!` (which is part of the `Base.save` call).
       macro before_validation(*names)
         {% for name in names %}
           {% CALLBACKS[:validation][:before] << name.id.stringify %}
         {% end %}
       end
 
+      # Defines callbacks which are called after `Base.validate!` (which is part of the `Base.save` call).
       macro after_validation(*names)
         {% for name in names %}
           {% CALLBACKS[:validation][:after] << name.id.stringify %}
         {% end %}
       end
 
+      # Defines callbacks which are called after a record has been created, updated, or destroyed.
+      #
+      # You can specify that the callback should only be fired by a certain action with the :on option:
+      # ```
+      # after_commit :var, on: :save
+      # after_commit :foo, on: :create
+      # after_commit :bar, on: :update
+      # after_commit :baz, on: :destroy
+      # ```
       macro after_commit(*names, on)
         {% unless [:create, :save, :destroy, :update].includes?(on) %}
           {% raise "#{on} is invalid action for %after_commit callback." %}
@@ -152,6 +188,9 @@ module Jennifer
         {% end %}
       end
 
+      # Defines callbacks which are called after a create, update, or destroy are rolled back.
+      #
+      # Please check the documentation of `after_commit` macro for options.
       macro after_rollback(*names, on)
         {% unless [:create, :save, :destroy, :update].includes?(on) %}
           {% raise "#{on} is invalid action for %after_rollback callback." %}
@@ -161,7 +200,9 @@ module Jennifer
         {% end %}
       end
 
+      # :nodoc:
       macro inherited_hook
+        # :nodoc:
         CALLBACKS = {
           save: {
             before: [] of String,
@@ -197,12 +238,13 @@ module Jennifer
         }
       end
 
+      # :nodoc:
       macro finished_hook
         {% verbatim do %}
           {% for type in [:before, :after] %}
             {% for action in [:save, :create, :destroy, :validation, :update] %}
               {% if !CALLBACKS[action][type].empty? %}
-                def __{{type.id}}_{{action.id}}_callback
+                protected def __{{type.id}}_{{action.id}}_callback
                   return false unless super
                   {{ CALLBACKS[action][type].join("\n").id }}
                   true
@@ -217,9 +259,10 @@ module Jennifer
             {% for type in ["commit", "rollback"] %}
               {% constant_name = "HAS_#{action.upcase.id}_#{type.upcase.id}_CALLBACK" %}
               {% if !CALLBACKS[action][type].empty? %}
+                # :nodoc:
                 {{ "#{constant_name.id} = true".id}}
 
-                def __after_{{action.id}}_{{type.id}}_callback
+                protected def __after_{{action.id}}_{{type.id}}_callback
                   return false unless super
                   {{ CALLBACKS[action][type].join("\n").id }}
                   true
@@ -227,13 +270,14 @@ module Jennifer
                   false
                 end
               {% else %}
+                # :nodoc:
                 {{ "#{constant_name.id} = false".id}}
               {% end %}
             {% end %}
           {% end %}
 
           {% if !CALLBACKS[:initialize][:after].empty? %}
-            def __after_initialize_callback
+            protected def __after_initialize_callback
               return false unless super
               {{ CALLBACKS[:initialize][:after].join("\n").id }}
               true

--- a/src/jennifer/model/relation_definition.cr
+++ b/src/jennifer/model/relation_definition.cr
@@ -16,6 +16,7 @@ module Jennifer
       abstract def get_relation(name : String)
 
       macro nullify_dependency(name, relation_type)
+        # :nodoc:
         def __nullify_callback_{{name.id}}
           rel = \{{@type}}.relation({{name.id.stringify}})
           {{name.id}}_query.update({rel.foreign_field => nil})
@@ -25,6 +26,7 @@ module Jennifer
       end
 
       macro delete_dependency(name, relation_type)
+        # :nodoc:
         def __delete_callback_{{name.id}}
           rel = \{{@type}}.relation({{name.id.stringify}})
           {{name.id}}_query.delete
@@ -34,6 +36,7 @@ module Jennifer
       end
 
       macro destroy_dependency(name, relation_type)
+        # :nodoc:
         def __destroy_callback_{{name.id}}
           rel = \{{@type}}.relation({{name.id.stringify}})
           {{name.id}}_query.destroy
@@ -43,6 +46,7 @@ module Jennifer
       end
 
       macro restrict_with_exception_dependency(name, relation_type)
+        # :nodoc:
         def __restrict_with_exception_callback_{{name.id}}
           rel = \{{@type}}.relation({{name.id.stringify}})
           raise ::Jennifer::RecordExists.new(self, {{name.id.stringify}}) if {{name.id}}_query.exists?
@@ -81,32 +85,30 @@ module Jennifer
         @{{name.id}} = [] of {{klass}}
         @__{{name.id}}_retrieved = false
 
-        # :nodoc:
         private def set_{{name.id}}_relation(object : Array)
           @__{{name.id}}_retrieved = true
           @{{name.id}} = object
           {% if inverse_of %} object.each(&.append_{{inverse_of.id}}(self)) {% end %}
         end
 
-        # :nodoc:
         private def set_{{name.id}}_relation(object)
           @__{{name.id}}_retrieved = true
           @{{name.id}} << object
           {% if inverse_of %} object.append_{{inverse_of.id}}(self) {% end %}
         end
 
-        # returns relation metaobject
+        # Returns {{name.id}} relation metaobject
         def self.{{name.id}}_relation
           RELATIONS["{{name.id}}"].as(::Jennifer::Relation::HasMany({{klass}}, {{@type}}))
         end
 
-        # returns relation query for the object
+        # Returns {{name.id}} relation query for the object
         def {{name.id}}_query
           primary_value = {{ primary ? primary.id : "primary".id }}
           {{@type}}.{{name.id}}_relation.query(primary_value).as(::Jennifer::QueryBuilder::ModelQuery({{klass}}))
         end
 
-        # returns array of related objects
+        # Returns array of related objects
         def {{name.id}}
           if !@__{{name.id}}_retrieved && @{{name.id}}.empty? && !new_record?
             set_{{name.id}}_relation({{name.id}}_query.to_a.as(Array({{klass}})))
@@ -114,7 +116,7 @@ module Jennifer
           @{{name.id}}
         end
 
-        # builds related object from hash and adds to relation
+        # Builds related object from hash and adds to relation
         def append_{{name.id}}(rel : Hash)
           obj = {{klass}}.build(rel, false)
           set_{{name.id}}_relation(obj)
@@ -132,7 +134,7 @@ module Jennifer
           obj
         end
 
-        # removes given object from relation array
+        # Removes given object from relation array
         def remove_{{name.id}}(rel : {{klass}})
           index = @{{name.id}}.index { |e| e.primary == rel.primary }
           if index
@@ -164,7 +166,7 @@ module Jennifer
 
         before_destroy :__{{name.id}}_clean
 
-        # Cleans up all join table records for given relation
+        # :nodoc:
         def __{{name.id}}_clean
           relation = self.class.{{name.id}}_relation
           this = self
@@ -176,13 +178,11 @@ module Jennifer
         @{{name.id}} = [] of {{klass}}
         @__{{name.id}}_retrieved = false
 
-        # :nodoc:
         private def set_{{name.id}}_relation(object : Array)
           @__{{name.id}}_retrieved = true
           @{{name.id}} = object
         end
 
-        # :nodoc:
         private def set_{{name.id}}_relation(object)
           @__{{name.id}}_retrieved = true
           @{{name.id}} << object
@@ -229,7 +229,6 @@ module Jennifer
           rel
         end
 
-        # ... ; doesn't support `inverse_of` option
         def add_{{name.id}}(rel : Hash)
           @{{name.id}} << {{@type}}.{{name.id}}_relation.insert(self, rel)
         end
@@ -319,7 +318,6 @@ module Jennifer
         @{{name.id}} : {{klass}}?
         @__{{name.id}}_retrieved = false
 
-        # :nodoc:
         private def set_{{name.id}}_relation(object)
           @__{{name.id}}_retrieved = true
           @{{name.id}} = object
@@ -382,11 +380,15 @@ module Jennifer
         end
       end
 
+      # :nodoc:
       macro inherited_hook
+        # :nodoc:
         RELATION_NAMES = [] of String
+        # :nodoc:
         RELATIONS = {} of String => ::Jennifer::Relation::IRelation
 
         {% verbatim do %}
+          # :nodoc:
           def append_relation(name : String, hash_or_object)
             {% if !RELATION_NAMES.empty? %}
               case name
@@ -402,6 +404,7 @@ module Jennifer
             {% end %}
           end
 
+          # :nodoc:
           def relation_retrieved(name : String)
             {% if !RELATION_NAMES.empty? %}
               case name
@@ -417,6 +420,7 @@ module Jennifer
             {% end %}
           end
 
+          # :nodoc:
           def get_relation(name : String)
             {% relations = RELATION_NAMES %}
             {% if relations.size > 0 %}

--- a/src/jennifer/model/resource.cr
+++ b/src/jennifer/model/resource.cr
@@ -16,15 +16,25 @@ module Jennifer
         abstract def build
         abstract def all
         abstract def superclass
+        abstract def primary
+
+        # Returns field count
+        abstract def field_count
+
+        # Returns array of field names
+        abstract def field_names
+
+        # Returns named tuple of column metadata
+        abstract def columns_tuple
       end
 
       extend AbstractClassMethods
-      extend Ifrit
       extend Translation
       include Scoping
       include RelationDefinition
       include Macros
 
+      # :nodoc:
       def self.superclass; end
 
       alias Supportable = DBAny | self
@@ -135,8 +145,17 @@ module Jennifer
         raise Jennifer::UnknownRelation.new(self.class, name)
       end
 
+      # Returns value of attribute *name*
       abstract def attribute(name)
+
+      # Returns value of primary field
       abstract def primary
+
+      # Returns hash with model attributes; keys are symbols
+      abstract def to_h
+
+      # Returns hash with model attributes; keys are strings
+      abstract def to_str_h
     end
   end
 end

--- a/src/jennifer/model/scoping.cr
+++ b/src/jennifer/model/scoping.cr
@@ -3,7 +3,7 @@ module Jennifer
     module Scoping
       macro scope(name, &block)
         {% underscored_arg_list = block.args.map(&.stringify).map { |e| "__" + e }.join(", ").id %}
-
+        # :nodoc:
         class Jennifer::QueryBuilder::ModelQuery(T)
           def {{name.id}}({{ block.args.splat }})
             # NOTE: this is workaround for #responds_to?
@@ -29,6 +29,7 @@ module Jennifer
       end
 
       macro scope(name, klass)
+        # :nodoc:
         class Jennifer::QueryBuilder::ModelQuery(T)
           def {{name.id}}(*args)
             T.{{name.id}}(self, *args)

--- a/src/jennifer/model/translation.cr
+++ b/src/jennifer/model/translation.cr
@@ -65,6 +65,8 @@ end
 I18n.load_path << File.join(__DIR__, "../locale")
 
 # TODO: make a PR to the i18n repo
+
+# :nodoc:
 module I18n
   def self.exists?(key, locale = config.locale, count = nil)
     key += (count == 1 ? ".one" : ".other") if count

--- a/src/jennifer/model/validation.cr
+++ b/src/jennifer/model/validation.cr
@@ -25,10 +25,13 @@ module Jennifer
         true
       end
 
+      # :nodoc:
       macro inherited_hook
+        # :nodoc:
         VALIDATION_METHODS = [] of String
       end
 
+      # :nodoc:
       macro finished_hook
         def validate(skip = false)
           return if skip
@@ -39,6 +42,7 @@ module Jennifer
         end
       end
 
+      # :nodoc:
       macro _not_nil_validation(field, allow_blank)
         begin
           {% if allow_blank %}
@@ -59,6 +63,7 @@ module Jennifer
       macro validates_with(klass, **options)
         validates_with_method(%validate_method)
 
+        # :nodoc:
         def %validate_method
           {% if options %}
             {{klass}}.new(errors).validate(self, {{**options}})
@@ -71,6 +76,7 @@ module Jennifer
       macro validates_inclusion(field, in, allow_blank = false)
         validates_with_method(%validate_method)
 
+        # :nodoc:
         def %validate_method
           value = _not_nil_validation({{field}}, {{allow_blank}})
           unless ({{in}}).includes?(value)
@@ -82,6 +88,7 @@ module Jennifer
       macro validates_exclusion(field, in, allow_blank = false)
         validates_with_method(%validate_method)
 
+        # :nodoc:
         def %validate_method
           value = _not_nil_validation({{field}}, {{allow_blank}})
           if ({{in}}).includes?(value)
@@ -93,6 +100,7 @@ module Jennifer
       macro validates_format(field, value, allow_blank = false)
         validates_with_method(%validate_method)
 
+        # :nodoc:
         def %validate_method
           value = _not_nil_validation({{field}}, {{allow_blank}})
           unless {{value}} =~ value
@@ -104,6 +112,7 @@ module Jennifer
       macro validates_length(field, **options)
         validates_with_method(%validate_method)
 
+        # :nodoc:
         def %validate_method
           value = _not_nil_validation({{field}}, {{options[:allow_blank] || false}})
           size = value.size
@@ -134,6 +143,7 @@ module Jennifer
       macro validates_uniqueness(field, allow_blank = false)
         validates_with_method(%validate_method)
 
+        # :nodoc:
         def %validate_method
           value = _not_nil_validation({{field}}, {{allow_blank}})
           query = self.class.where { _{{field.id}} == value }
@@ -149,6 +159,7 @@ module Jennifer
       macro validates_presence(field)
         validates_with_method(%validate_method)
 
+        # :nodoc:
         def %validate_method
           value = @{{field.id}}
           if value.blank?
@@ -160,6 +171,7 @@ module Jennifer
       macro validates_absence(field)
         validates_with_method(%validate_method)
 
+        # :nodoc:
         def %validate_method
           value = @{{field.id}}
           if value.present?
@@ -171,6 +183,7 @@ module Jennifer
       macro validates_numericality(field, **options)
         validates_with_method(%validate_method)
 
+        # :nodoc:
         def %validate_method
           value = _not_nil_validation({{field}}, {{options[:allow_blank] || false}})
           {% if options[:greater_than] %}
@@ -219,6 +232,7 @@ module Jennifer
       macro validates_acceptance(field, accept = nil)
         validates_with_method(%validate_method)
 
+        # :nodoc:
         def %validate_method
           value = @{{field.id}}
           {% condition = accept ? "!(#{accept}).includes?(value)" : "value != true && value != '1'" %}
@@ -231,6 +245,7 @@ module Jennifer
       macro validates_confirmation(field, case_sensitive = true)
         validates_with_method(%validate_method)
 
+        # :nodoc:
         def %validate_method
           return if @{{field.id}}_confirmation.nil?
           value = _not_nil_validation({{field}}, false)

--- a/src/jennifer/query_builder/aggregations.cr
+++ b/src/jennifer/query_builder/aggregations.cr
@@ -30,7 +30,7 @@ module Jennifer
         @raw_select = "MAX(#{field}) as m"
         result = to_a.map(&.["m"])
         @raw_select = _select
-        typed_array_cast(result, T)
+        Ifrit.typed_array_cast(result, T)
       end
 
       def group_min(field, klass : T.class) : Array(T) forall T
@@ -38,7 +38,7 @@ module Jennifer
         @raw_select = "MIN(#{field}) as m"
         result = to_a.map(&.["m"])
         @raw_select = _select
-        typed_array_cast(result, T)
+        Ifrit.typed_array_cast(result, T)
       end
 
       def group_sum(field, klass : T.class) : Array(T) forall T
@@ -46,7 +46,7 @@ module Jennifer
         @raw_select = "SUM(#{field}) as m"
         result = to_a.map(&.["m"])
         @raw_select = _select
-        typed_array_cast(result, T)
+        Ifrit.typed_array_cast(result, T)
       end
 
       def group_avg(field, klass : T.class) : Array(T) forall T
@@ -54,7 +54,7 @@ module Jennifer
         @raw_select = "AVG(#{field}) as m"
         result = to_a.map(&.["m"])
         @raw_select = _select
-        typed_array_cast(result, T)
+        Ifrit.typed_array_cast(result, T)
       end
 
       def group_count(field)

--- a/src/jennifer/query_builder/query.cr
+++ b/src/jennifer/query_builder/query.cr
@@ -7,7 +7,6 @@ require "./executables"
 module Jennifer
   module QueryBuilder
     class Query
-      extend Ifrit
       include Aggregations
       include Ordering
       include Joining

--- a/src/jennifer/relation/base.cr
+++ b/src/jennifer/relation/base.cr
@@ -1,8 +1,6 @@
 module Jennifer
   module Relation
     abstract class IRelation
-      extend Ifrit
-
       abstract def name
       abstract def table_name
       abstract def model_class
@@ -16,8 +14,8 @@ module Jennifer
       abstract def preload_relation(collection, out_collection, pk_repo)
     end
 
-    # T - related model
-    # Q - parent model
+    # *T* - related model
+    # *Q* - parent model
     class Base(T, Q) < IRelation
       getter join_query : QueryBuilder::Condition | QueryBuilder::LogicOperator?
       getter foreign : String?, primary : String?, through : Symbol?
@@ -74,7 +72,7 @@ module Jennifer
       end
 
       def insert(obj : Q, rel : Hash(Symbol, Jennifer::DBAny))
-        insert(obj, stringify_hash(rel, Jennifer::DBAny))
+        insert(obj, Ifrit.stringify_hash(rel, Jennifer::DBAny))
       end
 
       def insert(obj : Q, rel : T)

--- a/src/jennifer/relation/belongs_to.cr
+++ b/src/jennifer/relation/belongs_to.cr
@@ -34,49 +34,11 @@ module Jennifer
         query.join(model_class, type: type, relation: @name) do |eb|
           this.condition_clause.not_nil! & (yield eb)
         end
-        # if @join_table
-        #  _foreign = foreign_field
-        #  _primary = primary_field
-        #  jt = @join_table.not_nil!
-        #  jtk = @join_foreign || T.to_s.foreign_key
-
-        #  q = query.join(jt, type: type) { Q.c(_primary) == c(_foreign) }.join(T, type: type) do |eb|
-        #    (T.c(_primary) == c(jtk, jt)) & (yield eb)
-        #  end
-        #  if @join_query
-        #    _tree = @join_query.not_nil!
-        #    q.where { _tree }
-        #  else
-        #    q
-        #  end
-        # else
-        #  query.join(model_class, type: type, relation: @name) do |eb|
-        #    this.condition_clause.not_nil! & (yield eb)
-        #  end
-        # end
       end
 
       def query(primary_value)
         condition = condition_clause(primary_value)
         T.where { condition }
-        # if @join_table
-        #  jt = @join_table.not_nil!
-        #  jtk = join_table_foreign_key
-        #  _primary_value = primary_value
-        #  _pf = primary_field
-        #  _ff = foreign_field
-        #  q = T.all.join(jt) { (c(jtk) == T.c(_pf)) & (c(_ff) == _primary_value) }
-        #
-        #  if @join_query
-        #    _tree = @join_query.not_nil!
-        #    q.where { _tree }
-        #  else
-        #    q
-        #  end
-        # else
-        #  condition = condition_clause(primary_value)
-        #  T.where { condition }
-        # end
       end
 
       def insert(obj : Q, rel : Hash(String, Jennifer::DBAny))

--- a/src/jennifer/relation/relation_stub.cr
+++ b/src/jennifer/relation/relation_stub.cr
@@ -1,5 +1,7 @@
 module Jennifer
   # This is a stub for the case when no relation has been defined yet.
+
+  # :nodoc:
   class RelationStub < ::Jennifer::Relation::IRelation
     def name
       raise "stubbed relation"

--- a/src/jennifer/view/base.cr
+++ b/src/jennifer/view/base.cr
@@ -19,7 +19,7 @@ module Jennifer
         @@view_name = value
       end
 
-      # NOTE: is used for query generating
+      # NOTE: it is used for query generating
       def self.table_name
         view_name
       end
@@ -48,7 +48,7 @@ module Jennifer
         {% end %}
       end
 
-      def __after_initialize_callback
+      protected def __after_initialize_callback
         true
       end
 
@@ -57,27 +57,33 @@ module Jennifer
       end
 
       macro inherited
+        # :nodoc:
         AFTER_INITIALIZE_CALLBACKS = [] of String
+        # :nodoc:
         RELATIONS = {} of String => ::Jennifer::Relation::IRelation
 
+        # :nodoc:
         def self.relation(name : String)
           RELATIONS[name]
         rescue e : KeyError
           super(name)
         end
 
+        # :nodoc:
         # NOTE: override regular behavior - used fields count instead of
         # querying db
         def self.actual_table_field_count
           COLUMNS_METADATA.size
         end
 
+        # :nodoc:
         def self.superclass
           {{@type.superclass}}
         end
 
         macro finished
-          def __after_initialize_callback
+          # :nodoc:
+          protected def __after_initialize_callback
             return false unless super
             \{{AFTER_INITIALIZE_CALLBACKS.join("\n").id}}
             true


### PR DESCRIPTION
# What does this PR do?

Remove documentation from the internal constructions or generated implementation of abstract methods

# Any background context you want to provide?

This removes unnecessary methods and constants from the generated application documentation. Fixes #163 . 

# Release notes

**General**

* add `:nodoc:` to all internal constants and generated methods (implementing standard ORM methods) from the macros

**QueryBuilder**

* `Query` isn't extended by `Ifrit`

**Model**

* next `Base` methods become abstract: `.primary_auto_incrementable?`, `.build_params`, `#destroy`, `#arguments_to_save`, `#arguments_to_insert`
* `Base#_extract_attributes` and `Base#_sti_extract_attributes` become **private**
* all callback invocation methods become **protected**
* next `Resource` methods become abstract: `.primary`, `.field_count`, `.field_names`, `.columns_tuple`, `#to_h`, `#to_str_h`
* `Resource` isn't extended by `Ifrit` 
* regenerate `.build_params` for STI models

**View**

* `Base#_after_initialize_callback` becomes **protected**
* `Base#_extract_attributes` becomes **private**

**Migration**

* `TableBuilder::Base` isn't extended by `Ifrit` 
