### PR TITLE
Refactor query object

### DIFF
--- a/docs/model_mapping.md
+++ b/docs/model_mapping.md
@@ -149,7 +149,7 @@ If you don't want to define all the table fields - pass `false` as second argume
 | `#{{field_name}}_changed?` | | shows if field was changed |
 | `#changed?` | | shows if any field was changed |
 | `#primary` | | value of primary key field |
-| `::primary` | | returns criteria for primary field (query dsl) |
+| `::primary` | | returns criterion for primary field (query dsl) |
 | `::primary_field_name` | | name of primary field |
 | `::primary_field_type` | | type of primary key |
 | `#new_record?` | | returns `true` if record has `nil` primary key (is not stored to db) |
@@ -167,6 +167,8 @@ If you don't want to define all the table fields - pass `false` as second argume
 | `#changed?` | | check if any field was changed |
 | `#set_attribute` | `String \| Symbol`, `DB::Any` | sets attribute by given name |
 | `#attribute` | `String \| Symbol` | returns attribute value by it's name |
+
+> `::build_params` is deprecated and will be removed in `0.7.0`. For the web argument parse tasks please use [form_object](https://github.com/imdrasil/form_object) shard.
 
 All allowed types are listed on the [Migration](https://imdrasil.github.io/jennifer.cr/docs/migration) page.
 

--- a/docs/query_dsl.md
+++ b/docs/query_dsl.md
@@ -65,7 +65,7 @@ Postgres specific:
 | `contained` |`<@` |
 | `overlap` | `&&` |
 
-Also Jennifer supports json field path methods for criterias: `Criteria#take` (also accessible as `Criteria#[]`) and `Criteria#path`.
+Also Jennifer supports json field path methods for criteria: `Criteria#take` (also accessible as `Criteria#[]`) and `Criteria#path`.
 
 ### MySQL
 
@@ -124,7 +124,7 @@ Contact.all.where { _id == any(nested_query) }
 To specify exact SQL query use `#sql` method:
 
 ```crystal
-# it behaves like regular criteria
+# it behaves like regular criterion
 Contact.all.where { sql("age > ?",  [15]) & (_name == "Stephan") }
 ```
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -9,7 +9,7 @@ class User < Jennifer::Model::Base
     login: String
   })
 
-  validates_length :login, in: [8..16]
+  validates_length :login, in: 8..16
 end
 
 user = User.build(login: "login")

--- a/spec/model/base_spec.cr
+++ b/spec/model/base_spec.cr
@@ -438,8 +438,8 @@ describe Jennifer::Model::Base do
       end
 
       context "with argument" do
-        it "is accessible from query object" do
-          Contact.by_age(12).as_sql.should match(/contacts\.age =/)
+        it do
+          Contact.by_gender("female").as_sql.should match(/contacts\.gender =/)
         end
       end
 

--- a/spec/models.cr
+++ b/spec/models.cr
@@ -1,16 +1,21 @@
 require "./views"
 require "../src/jennifer/model/authentication"
 
-struct JohnyQuery < Jennifer::QueryBuilder::QueryObject
+class JohnyQuery < Jennifer::QueryBuilder::QueryObject
   def call
     relation.where { _name == "Johny" }
   end
 end
 
-struct WithArgumentQuery < Jennifer::QueryBuilder::QueryObject
+class WithOwnArguments < Jennifer::QueryBuilder::QueryObject
+  private getter gender : String
+
+  def initialize(relation, @gender)
+    super(relation)
+  end
+
   def call
-    this = self
-    relation.where { _age == this.params[0] }
+    relation.where { _gender == gender }
   end
 end
 
@@ -112,7 +117,7 @@ class Contact < ApplicationRecord
   scope :ordered { order(name: :asc) }
   scope :with_main_address { relation(:addresses).where { _addresses__main } }
   scope :johny, JohnyQuery
-  scope :by_age, WithArgumentQuery
+  scope :by_gender, WithOwnArguments
 
   def name_check
     if @description && @description.not_nil!.size > 10

--- a/src/jennifer/adapter.cr
+++ b/src/jennifer/adapter.cr
@@ -38,7 +38,7 @@ module Jennifer
       adapter.query(_query, args) { |rs| yield rs }
     end
 
-    # Allows to assign newly created adapter and call setupe methods with existing adapter
+    # Allows to assign newly created adapter and call setup methods with existing adapter
     private def self.adapter=(_adapter)
       @@adapter = _adapter
     end
@@ -59,6 +59,7 @@ module Jennifer
       adapter
     end
 
+    # Returns default adapter class.
     def self.default_adapter_class
       adapter_class
     end
@@ -67,10 +68,12 @@ module Jennifer
       @@adapter_class ||= adapters[Config.adapter]
     end
 
+    # Returns hash with all registered adapter classes
     def self.adapters
       @@adapters
     end
 
+    # Registers adapter class *adapter* with name *name*.
     def self.register_adapter(name, adapter)
       adapters[name] = adapter
     end

--- a/src/jennifer/config.cr
+++ b/src/jennifer/config.cr
@@ -2,6 +2,37 @@ require "yaml"
 require "logger"
 
 module Jennifer
+  # Configuration container.
+  #
+  # At the moment it implements singleton pattern but can be scaled to support several
+  # configuration instances per application.
+  #
+  # Supported configurations:
+  #
+  # | Config | Default value |
+  # | --- | --- |
+  # | `migration_files_path` | `"./db/migrations"` |
+  # | `structure_folder` | parent folder of `migration_files_path` |
+  # | `host` | `"localhost"` |
+  # | `port` | -1 |
+  # | `logger` | `Logger.new(STDOUT)` |
+  # | `schema` | `"public"` |
+  # | `user` | - |
+  # | `password` | - |
+  # | `db` | - |
+  # | `adapter` | - |
+  # | `max_pool_size` | 1 |
+  # | `initial_pool_size` | 1 |
+  # | `max_idle_pool_size` | 1 |
+  # | `retry_attempts` | 1 |
+  # | `checkout_timeout` | 5.0 |
+  # | `retry_delay` | 1.0 |
+  # | `local_time_zone_name` | default time zone name |
+  # | `skip_dumping_schema_sql` | `false` |
+  # | `command_shell` | `"bash"` |
+  # | `docker_container` | `""` |
+  # | `docker_source_location` | `""` |
+  # | `command_shell_sudo` | `false` |
   class Config
     CONNECTION_URI_PARAMS = [
       :max_pool_size, :initial_pool_size, :max_idle_pool_size,

--- a/src/jennifer/macros.cr
+++ b/src/jennifer/macros.cr
@@ -1,16 +1,22 @@
 module Jennifer
   # This module contains constants needed only during compilation process to avoid their recreating.
   module Macros
+    # :nodoc:
     TYPES                       = %w(Primary32 Primary64)
+    # :nodoc:
     NILLABLE_REGEXP             = /(::Nil)|( Nil)/
+    # :nodoc:
     JSON_REGEXP                 = /JSON::Any/
+    # :nodoc:
     AUTOINCREMENTABLE_STR_TYPES = %w(Int32 Int64)
 
+    # Primary key type (Int32).
     Primary32 = {
       type: Int32,
       primary: true
     }
 
+    # Primary key type (Int64).
     Primary64 = {
       type: Int64,
       primary: true

--- a/src/jennifer/migration/base.cr
+++ b/src/jennifer/migration/base.cr
@@ -8,6 +8,7 @@ module Jennifer
 
       extend AbstractClassMethods
 
+      # :nodoc:
       macro delegate(*methods, to object, prefix pref = "")
         {% for method in methods %}
           def {{method.id}}(*args, **options)
@@ -50,20 +51,25 @@ module Jennifer
       abstract def up
       abstract def down
 
+      # After failed #up method invocation.
       def after_up_failure
       end
 
+      # After failed #down method invocation.
       def after_down_failure
       end
 
+      # Returns migration timestamp.
       def self.version
         raise AbstractMethod.new(self, :version)
       end
 
+      # Returns all existing migration timestamps based on available classes.
       def self.versions
         migrations.keys
       end
 
+      # Returns all available migration classes.
       def self.migrations
         {% begin %}
           {% if @type.all_subclasses.size > 0 %}

--- a/src/jennifer/migration/version.cr
+++ b/src/jennifer/migration/version.cr
@@ -1,5 +1,6 @@
 module Jennifer
   module Migration
+    # :nodoc:
     class Version < Model::Base
       table_name "migration_versions"
       mapping(
@@ -7,6 +8,7 @@ module Jennifer
         version: String
       )
 
+      # :nodoc:
       def self.has_table?
         false
       end

--- a/src/jennifer/model/base.cr
+++ b/src/jennifer/model/base.cr
@@ -18,6 +18,8 @@ module Jennifer
         abstract def primary_auto_incrementable?
 
         # Converts String based hash to `Hash(String, Jennifer::DBAny)`
+        #
+        # NOTE: Deprecated - will be removed in 0.7.0. Please, use https://github.com/imdrasil/form_object instead
         abstract def build_params(hash)
       end
 
@@ -32,12 +34,10 @@ module Jennifer
       @@actual_table_field_count : Int32?
       @@has_table : Bool?
 
+      # Returns whether model has a table.
       def self.has_table?
-        if @@has_table.nil?
-          @@has_table = adapter.table_exists?(table_name).as(Bool)
-        else
-          @@has_table
-        end
+        @@has_table = adapter.table_exists?(table_name).as(Bool) if @@has_table.nil?
+        @@has_table
       end
 
       # Represent actual amount of model's table column amount (is grepped from db).
@@ -45,12 +45,14 @@ module Jennifer
         @@actual_table_field_count ||= adapter.table_column_count(table_name)
       end
 
+      # Sets custom table name.
       def self.table_name(value : String | Symbol)
         @@table_name = value.to_s
         @@actual_table_field_count = nil
         @@has_table = nil
       end
 
+      # Returns table name.
       def self.table_name : String
         @@table_name ||=
           begin
@@ -61,15 +63,18 @@ module Jennifer
           end
       end
 
+      # Sets custom model foreign key name.
       def self.foreign_key_name(value : String | Symbol)
         @@foreign_key_name = value.to_s
         @@foreign_key_name = nil
       end
 
+      # Returns model foreign key name.
       def self.foreign_key_name
         @@foreign_key_name ||= Inflector.singularize(table_name) + "_id"
       end
 
+      # Returns default model parameter converter.
       def self.parameter_converter
         @@converter ||= ParameterConverter.new
       end
@@ -84,10 +89,12 @@ module Jennifer
         o
       end
 
+      # Returns if record isn't persisted
       def new_record?
         @new_record
       end
 
+      # Returns if record isn't deleted.
       def destroyed?
         @destroyed
       end
@@ -159,6 +166,7 @@ module Jennifer
       # Returns named tuple of all model fields to insert.
       abstract def arguments_to_insert
 
+      # Returns list of available model classes.
       def self.models
         {% begin %}
           {% if !@type.all_subclasses.empty? %}

--- a/src/jennifer/model/scoping.cr
+++ b/src/jennifer/model/scoping.cr
@@ -1,6 +1,17 @@
 module Jennifer
   module Model
     module Scoping
+      # Adds a class method for retrieving and querying objects.
+      #
+      # A `.scope` represents a narrowing of a database query, such as
+      # `where { _color == "red" }.includes(:washing_instructions)`.
+      #
+      # ```
+      # class Shirt < Jennifer::Model::Base
+      #   # ...
+      #   scope :red, { where { _color == "red" } }
+      # end
+      # ```
       macro scope(name, &block)
         {% underscored_arg_list = block.args.map(&.stringify).map { |e| "__" + e }.join(", ").id %}
         # :nodoc:
@@ -20,6 +31,7 @@ module Jennifer
           {{name.id}}(all{% if !block.args.empty? %}, {{underscored_arg_list}} {% end %})
         end
 
+        # :nodoc:
         def self.{{name.id}}(_query : ::Jennifer::QueryBuilder::ModelQuery({{@type}}){% if !block.args.empty? %}, {{ underscored_arg_list }} {% end %})
           {% if !block.args.empty? %}
             {{ block.args.splat }} = {{underscored_arg_list}}
@@ -28,14 +40,30 @@ module Jennifer
         end
       end
 
+      # Adds a class method for retrieving and querying objects.
+      #
+      # A `.scope` represents a narrowing of a database query, such as `where { _color == "red" }.includes(:washing_instructions)`.
+      #
+      # ```
+      # class Shirt < Jennifer::Model::Base
+      #   # ...
+      #   scope :red, { where { _color == "red" } }
+      # end
+      # ```
       macro scope(name, klass)
         # :nodoc:
         class Jennifer::QueryBuilder::ModelQuery(T)
           def {{name.id}}(*args)
-            T.{{name.id}}(self, *args)
+            klass = T
+            if klass.responds_to?(:{{name.id}})
+              klass.{{name.id}}(self, *args)
+            else
+              raise Jennifer::BaseException.new("#{T} class has no {{name.id}} scope.")
+            end
           end
         end
 
+        # :nodoc:
         def self.{{name.id}}(_query : ::Jennifer::QueryBuilder::ModelQuery({{@type}}), *args)
           {{klass}}.new(_query, *args).call
         end

--- a/src/jennifer/model/translation.cr
+++ b/src/jennifer/model/translation.cr
@@ -6,6 +6,7 @@ module Jennifer
     module Translation
       alias LocalizeableTypes = Int32 | Int64 | Nil | Float32 | Float64 | Time | String | Symbol | Bool
 
+      # Default global translation scope.
       GLOBAL_SCOPE = "jennifer"
 
       # Search translation for given attribute.
@@ -36,6 +37,7 @@ module Jennifer
         name
       end
 
+      # Returns the i18n scope for the class.
       def i18n_scope
         :models
       end
@@ -46,7 +48,7 @@ module Jennifer
         @@i18n_key = Inflector.underscore(Inflector.demodulize(to_s)).downcase
       end
 
-      # Yields all ancestors which respond to `.superclass`.
+      # Yields all ancestors until `Base`.
       def lookup_ancestors(&block)
         klass = self
         while klass

--- a/src/jennifer/query_builder/aggregations.cr
+++ b/src/jennifer/query_builder/aggregations.cr
@@ -6,22 +6,22 @@ module Jennifer
       end
 
       def max(field, klass : T.class) : T forall T
-        raise ArgumentError.new("Cannot use with grouping") unless @groups.empty?
+        raise ArgumentError.new("Cannot be used with grouping") unless @groups.empty?
         group_max(field, klass)[0]
       end
 
       def min(field, klass : T.class) : T forall T
-        raise ArgumentError.new("Cannot use with grouping") unless @groups.empty?
+        raise ArgumentError.new("Cannot be used with grouping") unless @groups.empty?
         group_min(field, klass)[0]
       end
 
       def sum(field, klass : T.class) : T forall T
-        raise ArgumentError.new("Cannot use with grouping") unless @groups.empty?
+        raise ArgumentError.new("Cannot be used with grouping") unless @groups.empty?
         group_sum(field, klass)[0]
       end
 
       def avg(field, klass : T.class) : T forall T
-        raise ArgumentError.new("Cannot use with grouping") unless @groups.empty?
+        raise ArgumentError.new("Cannot be used with grouping") unless @groups.empty?
         group_avg(field, klass)[0]
       end
 

--- a/src/jennifer/query_builder/criteria.cr
+++ b/src/jennifer/query_builder/criteria.cr
@@ -3,6 +3,7 @@ require "./order_item"
 
 module Jennifer
   module QueryBuilder
+    # TODO: rename to Criterion
     class Criteria < SQLNode
       alias Rightable = SQLNode | DBAny | Array(DBAny)
 

--- a/src/jennifer/query_builder/query_object.cr
+++ b/src/jennifer/query_builder/query_object.cr
@@ -1,12 +1,45 @@
 module Jennifer
   module QueryBuilder
-    abstract struct QueryObject
+    # Base abstract class for query object.
+    #
+    # ```
+    # class OrderedArticlesQuery < Jennifer::QueryBuilder::QueryObject
+    #   SORTABLE_FIELDS = %w(by_date by_title by_author)
+    #
+    #   private getter field : Sting, order : String
+    #
+    #   def initialize(relation, field, order)
+    #     super(relation)
+    #     @order = order == "asc" ? order : "desc"
+    #     @field = SORTABLE_FIELDS.includes?(field) ? field : "by_date"
+    #   end
+    #
+    #   def call
+    #     relation.order { article_order }
+    #   end
+    #
+    #   private def article_order
+    #     article_order = Article.c(params["field"].as(String))
+    #     article_order.direction = params["order"].as(String)
+    #     article_order
+    #   end
+    # end
+    #
+    # class Article < Jennifer::Model::Base
+    #   # ...
+    #   scope :ordered, OrderedArticlesQuery
+    # end
+    # ```
+    abstract class QueryObject
       getter relation : ::Jennifer::QueryBuilder::IModelQuery, params : Array(Jennifer::DBAny)
 
       def initialize(@relation)
         @params = [] of Jennifer::DBAny
       end
 
+      # Creates QueryObject based on given *relation* and *options*.
+      #
+      # NOTE: deprecated - will be removed in 0.7.0.
       def initialize(@relation, *options)
         @params = Ifrit.typed_array_cast(options, Jennifer::DBAny)
       end

--- a/src/jennifer/view/base.cr
+++ b/src/jennifer/view/base.cr
@@ -70,9 +70,9 @@ module Jennifer
         end
 
         # :nodoc:
-        # NOTE: override regular behavior - used fields count instead of
-        # querying db
         def self.actual_table_field_count
+          # NOTE: override regular behavior - used fields count instead of
+          # querying db
           COLUMNS_METADATA.size
         end
 

--- a/src/jennifer/view/materialized.cr
+++ b/src/jennifer/view/materialized.cr
@@ -1,6 +1,7 @@
 module Jennifer
   module View
     abstract class Materialized < Base
+      # Refresh materialized view data in th DB.
       def self.refresh
         adapter.refresh_materialized_view(view_name)
       end


### PR DESCRIPTION
# What does this PR do?

- changes `Jennifer::QueryBulder:QueryObject` from struct to class
- extends existing documentation
- minor code clean-up
- fix a bug with `.scope(Symbol, QueryObject)` - adds `#respond_to?` for the similar readon as `.scope(Symbol, &block)` has 

# Release notes

**QueryBuilder**

* `QueryObject` now is an abstract class
* changed wording for the `ArgumentError` in `#max`, `#min`, `#sum`, `#avg` methods of `Aggregation` to "Cannot be used with grouping"
* change `Query#from(_from : String | Query)` signature to `Query#from(from : String | Query)` 

**Model**

* `Scoping.scope(Symbol,QueryObject)` now checks in runtime whether `T` of `Jennifer::QueryBuilder::ModelQuery(T)` responds to method named after the scope

**Migration**

* `.pending_versions`, `.assert_outdated_pending_migrations` and `.default_adapter` methods of `Runner`become private
* `Runner.config` is removed