### PR TITLE
Add logic operator shortcuts

### DIFF
--- a/docs/query_dsl.md
+++ b/docs/query_dsl.md
@@ -43,7 +43,15 @@ Supported operators:
 | `|` | `OR` |
 | `xor` | `XOR` |
 
-And operator-like methods:
+Also there are shortcuts for `AND`, `OR` and `XOR` operators to emit extra brackets around operands and wraps the result into them:
+
+```crystal
+Post.all.where { _active & (_likes > 10) } # WHERE posts.active AND users.likes > 10
+
+Post.all.where { and(_active, _likes > 10) } # WHERE (posts.active AND users.likes > 10)
+```
+
+Operator-like methods:
 
 | Method | SQL variant |
 | --- | --- |

--- a/spec/query_builder/expression_builder_spec.cr
+++ b/spec/query_builder/expression_builder_spec.cr
@@ -123,4 +123,67 @@ describe ::Jennifer::QueryBuilder::ExpressionBuilder do
       g.is_a?(Jennifer::QueryBuilder::Grouping).should be_true
     end
   end
+
+  describe "#and" do
+    context "with 2 criteria" do
+      it do
+        c1 = Factory.build_criteria
+        c2 = Factory.build_criteria
+        e = Factory.build_expression
+        e.and(c1, c2).as_sql.should eq(e.g(c1 & c2).as_sql)
+      end
+    end
+
+    context "with 3 criteria" do
+      it do
+        c1 = Factory.build_criteria(field: "f1")
+        c2 = Factory.build_criteria(field: "f2")
+        c3 = Factory.build_criteria(field: "f3")
+        e = Factory.build_expression
+        e.and(c1, c2, c3).as_sql.should eq(e.g(c1 & c2 & c3).as_sql)
+      end
+    end
+  end
+
+  describe "#or" do
+    context "with 2 criteria" do
+      it do
+        c1 = Factory.build_criteria
+        c2 = Factory.build_criteria
+        e = Factory.build_expression
+        e.or(c1, c2).as_sql.should eq(e.g(c1 | c2).as_sql)
+      end
+    end
+
+    context "with 3 criteria" do
+      it do
+        c1 = Factory.build_criteria(field: "f1")
+        c2 = Factory.build_criteria(field: "f2")
+        c3 = Factory.build_criteria(field: "f3")
+        e = Factory.build_expression
+        e.or(c1, c2, c3).as_sql.should eq(e.g(c1 | c2 | c3).as_sql)
+      end
+    end
+  end
+
+  describe "#xor" do
+    context "with 2 criteria" do
+      it do
+        c1 = Factory.build_criteria
+        c2 = Factory.build_criteria
+        e = Factory.build_expression
+        e.xor(c1, c2).as_sql.should eq(e.g(c1.xor(c2)).as_sql)
+      end
+    end
+
+    context "with 3 criteria" do
+      it do
+        c1 = Factory.build_criteria(field: "f1")
+        c2 = Factory.build_criteria(field: "f2")
+        c3 = Factory.build_criteria(field: "f3")
+        e = Factory.build_expression
+        e.xor(c1, c2, c3).as_sql.should eq(e.g(c1.xor(c2.xor(c3))).as_sql)
+      end
+    end
+  end
 end

--- a/src/jennifer/query_builder/criteria.cr
+++ b/src/jennifer/query_builder/criteria.cr
@@ -109,7 +109,7 @@ module Jennifer
       end
 
       def not
-        Condition.new(self).not
+        to_condition.not
       end
 
       def in(arr : Array)
@@ -118,11 +118,11 @@ module Jennifer
       end
 
       def &(other : LogicOperator::Operandable)
-        Condition.new(self) & other
+        to_condition & other
       end
 
       def |(other : LogicOperator::Operandable)
-        Condition.new(self) | other
+        to_condition | other
       end
 
       def xor(other : LogicOperator::Operandable)

--- a/src/jennifer/query_builder/expression_builder.cr
+++ b/src/jennifer/query_builder/expression_builder.cr
@@ -15,18 +15,26 @@ module Jennifer
         @query = other.@query
       end
 
+      # Query's model primary field criterion.
       def primary
         query.not_nil!.as(IModelQuery).model_class.primary
       end
 
-      def sql(_query : String, args : Array(DBAny) = [] of DBAny, use_brackets : Bool = true)
-        RawSql.new(_query, args, use_brackets)
+      # Adds plain query *query* with filtered arguments *args*.
+      #
+      # If you need to wrap query set *use_brackets* to `true`.
+      def sql(query : String, args : Array(DBAny) = [] of DBAny, use_brackets : Bool = true)
+        RawSql.new(query, args, use_brackets)
       end
 
-      def sql(_query : String, use_brackets : Bool = true)
-        RawSql.new(_query, use_brackets)
+      # Adds plain query *query*.
+      #
+      # If you need to wrap query set *use_brackets* to `true`.
+      def sql(query : String, use_brackets : Bool = true)
+        RawSql.new(query, use_brackets)
       end
 
+      # Creates criterion for current table by given name *name*.
       def c(name : String)
         Criteria.new(name, @table, @relation)
       end
@@ -38,6 +46,7 @@ module Jennifer
         Criteria.new(name, table_name || @table, relation || @relation)
       end
 
+      # Creates criterion by given name *name* for relation *relation*.
       def c_with_relation(name : String, relation : String)
         if @query
           @query.not_nil!.with_relation!
@@ -45,6 +54,7 @@ module Jennifer
         Criteria.new(name, @table, relation)
       end
 
+      # Creates grouping for the given *condition*.
       def g(condition : LogicOperator)
         Grouping.new(condition)
       end
@@ -65,15 +75,57 @@ module Jennifer
         Star.new(table)
       end
 
+      # Combines given *first_condition*, *second_condition* and all other *conditions* by `AND` operator.
+      #
+      # All given conditions will be wrapped in `Grouping`.
+      #
+      # ```
+      # User.all.where { and(_name.like("%on"), _age > 3) }
+      # # WHERE (users.name LIKE '%on' AND users.age > 3)
+      # ```
+      def and(first_condition, second_condition, *conditions)
+        g(
+          conditions.reduce(first_condition & second_condition) { |sum, e| sum &= e }
+        )
+      end
+
+      # Combines given *first_condition*, *second_condition* and all other *conditions* by `OR` operator.
+      #
+      # All given conditions will be wrapped in `Grouping`.
+      #
+      # ```
+      # User.all.where { or(_name.like("%on"), _age > 3) }
+      # # WHERE (users.name LIKE '%on' OR users.age > 3)
+      def or(first_condition, second_condition, *conditions)
+        g(
+          conditions.reduce(first_condition | second_condition) { |sum, e| sum |= e }
+        )
+      end
+
+      # Combines given *first_condition*, *second_condition* and all other *conditions* by `XOR` operator.
+      #
+      # All given conditions will be wrapped in `Grouping`.
+      #
+      # ```
+      # User.all.where { xor(_name.like("%on"), _age > 3) }
+      # # WHERE (users.name LIKE '%on' XOR users.age > 3)
+      def xor(first_condition, second_condition, *conditions)
+        g(
+          conditions.reduce(first_condition.xor second_condition) { |sum, e| sum.xor e }
+        )
+      end
+
       macro method_missing(call)
         {% method_name = call.name.stringify %}
         {% if method_name.starts_with?("__") %}
+          # :nodoc:
           def {{method_name.id}}
             eb = ExpressionBuilder.new(@table, {{method_name[2..-1]}}, @query)
             @query.not_nil!.with_relation! if @query
             with eb yield
           end
         {% elsif method_name.starts_with?("_") %}
+          # :nodoc:
           def {{method_name.id}}
             {%
               parts = method_name[1..-1].split("__")


### PR DESCRIPTION
# What does this PR do?

Adds query builder shortcut for logic operators `AND`, `OR` and `XOR`.

```crystal
Post.all.where { and(_active, _likes > 10) } # WHERE (posts.active AND posts.likes > 10)
```

# Release notes

**QueryBuilder**

* add `ExpressionBuilder#and`, `ExpressionBuilder#or` and `ExpressionBuilder#xor` shortcut methods
