### PR TITLE
Add class generators based on templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ jennifer.code-workspace
 /examples/test.cr
 /examples/test.db
 /examples/database.yml
+/examples/models

--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -1,0 +1,177 @@
+# Command Line
+
+For command management Jennifer now uses [Sam](https://github.com/imdrasil/sam.cr). So in your `sam.cr` just add loading migrations and Jennifer hooks.
+
+```crystal
+require "./your_configuration_folder/*" # with requiring jennifer and her adapter
+require "./migrations/*"
+require "sam"
+load_dependencies "jennifer"
+
+# your custom tasks here
+
+Sam.help
+```
+
+## DB namespace
+
+### db:create
+
+Creates database described in the configuration.
+
+```shell
+$ crystal sam.cr -- db:create
+```
+
+> Will create only **one** database. This means that for test environment this command should be invoked separately. This is common for all commands in this section.
+
+### db:drop
+
+Drops database described in the configuration.
+
+```shell
+$ crystal sam.cr -- db:drop
+```
+
+### db:setup
+
+Creates database and invoke all pending migrations.
+
+```shell
+$ crystal sam.cr -- db:setup
+```
+
+### db:migrate
+
+Runs all pending migrations and stores them in the `versions` table. After execution of new migrations database schema is dumped to the `structure.sql` file.
+
+```shell
+$ crystal sam.cr -- db:migrate
+```
+
+### db:step
+
+Runs exact count of migrations (1 by default).
+
+```shell
+$ crystal sam.cr -- db:step
+$ crystal sam.cr -- db:step <count>
+```
+
+### db:rollback
+
+Rollbacks the last run migration
+
+```shell
+$ crystal sam.cr -- db:rollback
+```
+
+To rollbacks specific count of migrations:
+
+```shell
+$ crystal sam.cr -- db:rollback <count>
+```
+
+To rollback to the specific version:
+
+```shell
+$ crystal sam.cr -- db:rollback -v <migration_version>
+```
+
+### db:version
+
+Outputs current database version.
+
+```shell
+$ crystal sam.cr -- db:version
+```
+
+### db:schema:load
+
+Creates database from the `structure.sql` file.
+
+```shell
+$ crystal sam.cr -- db:schema:load
+```
+
+> Running migration after this may cause error messages because of missing any information about run migrations in scope of current schema generating.
+
+## Generating namespace
+
+### generate:model
+
+Generates model and related migration based on the given definition.
+
+```shell
+$ crystal sam.cr -- generate:model <ModelName> [field1:type] ... [fieldN:type?]
+```
+
+Example:
+
+```shell
+$ crystal sam.cr -- generate:model Article title:string text:text? author:reference
+```
+
+```crystal
+# ./src/models/article.cr
+
+class Article < Jennifer::Model::Base
+  with_timestamps
+
+  mapping(
+    id: Primary32,
+    title: String,
+    text: String?,
+    author_id: Int32?,
+    created_at: Time?,
+    updated_at: Time?,
+  )
+
+  belongs_to :author, Author
+end
+
+# ./db/migrations/<timestamp>_create_articles.cr
+
+class CreateArticles < Jennifer::Migration::Base
+  def up
+    create_table :articles do |t|
+      t.string :title, { :null => false }
+      t.text :text
+
+      t.reference :author
+
+      t.timestamps
+    end
+  end
+
+  def down
+    drop_table :articles if table_exists? :articles
+  end
+end
+```
+
+Available types:
+
+* `bool`
+* `bigint`
+* `integer`
+* `short`
+* `tinyint`
+* `float`
+* `double`
+* `string`
+* `text`
+* `timestamp`
+* `date_time`
+* `json`
+* `reference`
+
+The `?` symbol at the end of type name means that this field is nilable.
+
+### generate:migration
+
+Generates simple migration template.
+
+```shell
+$ crystal sam.cr -- generate:migration CreateArticles
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,8 +65,6 @@ Jennifer::Config.from_uri(db)
 
 | Config | Default value |
 | --- | --- |
-| `migration_files_path` | `"./db/migrations"` |
-| `structure_folder` | parent folder of `migration_files_path` |
 | `host` | `"localhost"` |
 | `port` | -1 |
 | `logger` | `Logger.new(STDOUT)` |
@@ -88,6 +86,9 @@ Jennifer::Config.from_uri(db)
 | `docker_source_location` | `""` |
 | `command_shell_sudo` | `false` |
 | `migration_failure_handler_method` | `"none"` |
+| `migration_files_path` | `"./db/migrations"` |
+| `model_files_path` | `"./src/models"` |
+| `structure_folder` | parent folder of `migration_files_path` |
 
 > It is highly recommended to set `max_idle_pool_size = max_pool_size = initial_pool_size` to prevent blowing up count of DB connections. For any details take a look at `crystal-db` [issue](https://github.com/crystal-lang/crystal-db/issues/77).
 
@@ -106,6 +107,7 @@ Also take into account - some configs can't be initialized using URI string or y
 | --- | --- | --- |
 | `logger` | ❌ | ❌ |
 | `migration_files_path` | ✔ | ❌ |
+| `model_files_path` | ✔ | ❌ |
 | `local_time_zone_name` | ✔ | ❌ |
 | `schema` | ✔ | ❌ |
 | `structure_folder` | ✔ | ❌ |

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,7 @@
 ## Content
 
 * [Configuration](./configuration.md)
+* [Command Line](./command_line.md)
 * [Migration](./migration.md)
 * [Model. Mapping](./model_mapping.md)
 * [Model. STI](./model_sti.md)

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,69 +1,6 @@
 # Migration
 
-For command management Jennifer now uses [Sam](https://github.com/imdrasil/sam.cr). So in your `sam.cr` just add loading migrations and Jennifer hooks.
-
-```crystal
-require "./your_configuration_folder/*" # with requiring jennifer and her adapter
-require "./migrations/*"
-require "sam"
-load_dependencies "jennifer"
-# your another tasks here
-Sam.help
-```
-
-#### Commands
-Now you can use next commands:
-
-- create database
-```shell
-$ crystal sam.cr -- db:create
-```
-- drop database
-```shell
-$ crystal sam.cr -- db:drop
-```
-- run all migrations (only new ones will be run)
-```shell
-$ crystal sam.cr -- db:migrate
-```
-
-- run several migrations
-```shell
-$ crystal sam.cr -- db:step
-$ crystal sam.cr -- db:step 2
-```
-
-- create db and run all migrations (only new ones will be run)
-```shell
-$ crystal sam.cr -- db:setup
-```
-- rollback last migration
-```shell
-$ crystal sam.cr -- db:rollback
-```
-- rollback `n` migrations
-```shell
-$ crystal sam.cr -- db:rollback n
-```
-- rollback until version `a`
-```shell
-$ crystal sam.cr -- db:rollback -v a
-```
-- generate new migration file
-```shell
-$ crystal sam.cr -- generate:migration your_migration_name
-```
-- get last migration version
-```shell
-$ crystal sam.cr -- db:version
-```
-
-- load schema
-```shell
-$ crystal sam.cr -- db:schema:load
-```
-
-#### Migration DSL
+## DSL
 
 Generator will create template file for you with next name  pattern "timestamp_your_underscored_migration_name.cr". Empty file looks like this:
 
@@ -75,7 +12,6 @@ class YourCamelcasedMigrationName20170119011451314 < Jennifer::Migration::Base
   def down
   end
 end
-
 ```
 
 `up` method is needed for placing your db changes there, `down` - for reverting your changes back.
@@ -149,7 +85,7 @@ Also there is `#field` method which allows to directly define sql type.
 To drop table just write:
 
 ```crystal
-drop_table(:addresses) # drops if exists
+drop_table(:addresses)
 ```
 
 To create materialized view (postgres only):

--- a/docs/view.md
+++ b/docs/view.md
@@ -9,7 +9,7 @@ Both adapters support non materialized view. Here is an example of migration:
 ```crystal
 class AddView20170916095004544 < Jennifer::Migration::Base
   def up
-    create_view(:male_contacts, Jennifer::Query["contacts"].where { sql("gender = 'male'") })
+    create_view(:male_contacts, Jennifer::Query["contacts"].where { _gender == sql("'male'") })
   end
 
   def down

--- a/examples/database.yml.example
+++ b/examples/database.yml.example
@@ -1,6 +1,7 @@
 default: &default
   host: localhost
   migration_files_path: "./examples/migrations"
+  model_files_path: "./examples/models"
   db: jennifer_test
   # command_shell: docker
 

--- a/examples/migrations/20170916095004544_add_view.cr
+++ b/examples/migrations/20170916095004544_add_view.cr
@@ -1,7 +1,7 @@
 class AddView < Jennifer::Migration::Base
   def up
     # TODO: allow escaping arguments instead of prepared statement
-    create_view(:male_contacts, Jennifer::Query["contacts"].where { sql("gender = 'male'") })
+    create_view(:male_contacts, Jennifer::Query["contacts"].where { _gender == sql("'male'") })
   end
 
   def down

--- a/examples/setup.sh
+++ b/examples/setup.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
 cp ./examples/database.yml.example ./examples/database.yml
+mkdir ./examples/models

--- a/shard.yml
+++ b/shard.yml
@@ -21,7 +21,7 @@ development_dependencies:
 dependencies:
   sam:
     github: imdrasil/sam.cr
-    version: "~> 0.2.4"
+    version: "~> 0.3.0"
   inflector:
     github: phoffer/inflector.cr
     version: "~> 0.1.8"

--- a/spec/fixtures/generators/create_migration.cr
+++ b/spec/fixtures/generators/create_migration.cr
@@ -1,0 +1,14 @@
+class CreateArticles < Jennifer::Migration::Base
+  def up
+    create_table :articles do |t|
+      t.string :title, { :null => false }
+      t.text :text
+
+      t.timestamps
+    end
+  end
+
+  def down
+    drop_table :articles if table_exists? :articles
+  end
+end

--- a/spec/fixtures/generators/create_migration_with_references.cr
+++ b/spec/fixtures/generators/create_migration_with_references.cr
@@ -1,0 +1,16 @@
+class CreateArticles < Jennifer::Migration::Base
+  def up
+    create_table :articles do |t|
+      t.string :title, { :null => false }
+      t.text :text
+
+      t.reference :author
+
+      t.timestamps
+    end
+  end
+
+  def down
+    drop_table :articles if table_exists? :articles
+  end
+end

--- a/spec/fixtures/generators/migration.cr
+++ b/spec/fixtures/generators/migration.cr
@@ -1,0 +1,7 @@
+class CreateArticles < Jennifer::Migration::Base
+  def up
+  end
+
+  def down
+  end
+end

--- a/spec/fixtures/generators/model.cr
+++ b/spec/fixtures/generators/model.cr
@@ -1,0 +1,11 @@
+class Article < Jennifer::Model::Base
+  with_timestamps
+
+  mapping(
+    id: Primary32,
+    title: String,
+    text: String?,
+    created_at: Time?,
+    updated_at: Time?,
+  )
+end

--- a/spec/fixtures/generators/model_with_references.cr
+++ b/spec/fixtures/generators/model_with_references.cr
@@ -1,0 +1,14 @@
+class Article < Jennifer::Model::Base
+  with_timestamps
+
+  mapping(
+    id: Primary32,
+    title: String,
+    text: String?,
+    author_id: Int32?,
+    created_at: Time?,
+    updated_at: Time?,
+  )
+
+  belongs_to :author, Author
+end

--- a/spec/generators/create_migration_spec.cr
+++ b/spec/generators/create_migration_spec.cr
@@ -1,0 +1,5 @@
+require "../spec_helper"
+
+describe Jennifer::Generators::CreateMigration do
+  # is tested in the scope of ./model_spec.cr
+end

--- a/spec/generators/field_set_spec.cr
+++ b/spec/generators/field_set_spec.cr
@@ -1,0 +1,32 @@
+require "../spec_helper"
+
+describe Jennifer::Generators::FieldSet do
+  described_class = Jennifer::Generators::FieldSet
+  field_class = Jennifer::Generators::Field
+
+  describe ".new" do
+    context "without id definition" do
+      it do
+        described_class.new(%w(name:string)).id.should eq(field_class.new("id", "integer", true))
+      end
+    end
+  end
+
+  describe "#references" do
+    it do
+      described_class.new(%w(name:string author:reference)).references.should eq([field_class.new("author", "reference", true)])
+    end
+  end
+
+  describe "#common_fields" do
+    it do
+      described_class.new(%w(name:string author:reference)).common_fields.should eq([field_class.new("name", "string", false)])
+    end
+  end
+
+  describe "#timestamps" do
+    it do
+      described_class.new(%w(name:string author:reference)).timestamps.should eq([field_class.new("created_at", "timestamp", true), field_class.new("updated_at", "timestamp", true)])
+    end
+  end
+end

--- a/spec/generators/field_spec.cr
+++ b/spec/generators/field_spec.cr
@@ -1,0 +1,109 @@
+require "../spec_helper"
+
+describe Jennifer::Generators::Field do
+  described_class = Jennifer::Generators::Field
+
+  describe ".new" do
+    context "with bad type" do
+      it do
+        expect_raises(Exception) do
+          described_class.new("name", "test", false)
+        end
+      end
+    end
+
+    context "with reference type" do
+      it do
+        described_class.new("name", "reference", false).nilable.should be_true
+      end
+    end
+  end
+
+  describe "#field_name" do
+    context "with reference type" do
+      it do
+        described_class.new("name", "reference", false).field_name.should eq("name_id")
+      end
+    end
+
+    it do
+      described_class.new("name", "text", false).field_name.should eq("name")
+    end
+  end
+
+  describe "#cr_type" do
+    describe "id" do
+      describe "bigint" do
+        it do
+          described_class.new("id", "bigint", false).cr_type.should eq("Primary64")
+        end
+      end
+
+      describe "integer" do
+        it do
+          described_class.new("id", "integer", false).cr_type.should eq("Primary32")
+        end
+      end
+
+      describe "custom type" do
+        pending "add"
+      end
+
+      context "as nilable" do
+        it do
+          described_class.new("id", "bigint", true).cr_type.should eq("Primary64")
+        end
+      end
+    end
+
+    describe "reference" do
+      it do
+        described_class.new("name", "reference", false).cr_type.should eq("Int32?")
+      end
+    end
+
+    describe "nilable" do
+      it do
+        described_class.new("name", "integer", true).cr_type.should eq("Int32?")
+      end
+    end
+  end
+
+  describe "#id?" do
+    it do
+      described_class.new("name", "integer", false).id?.should be_false
+    end
+
+    it do
+      described_class.new("id", "integer", false).id?.should be_true
+    end
+  end
+
+  describe "#decimal?" do
+    pending "add"
+  end
+
+  describe "#reference?" do
+    it do
+      described_class.new("name", "integer", false).reference?.should be_false
+    end
+
+    it do
+      described_class.new("name", "reference", false).reference?.should be_true
+    end
+  end
+
+  describe "#timestamp?" do
+    it do
+      described_class.new("name", "integer", false).timestamp?.should be_false
+    end
+
+    it do
+      described_class.new("created_at", "integer", false).timestamp?.should be_true
+    end
+
+    it do
+      described_class.new("updated_at", "integer", false).timestamp?.should be_true
+    end
+  end
+end

--- a/spec/generators/migration_spec.cr
+++ b/spec/generators/migration_spec.cr
@@ -1,0 +1,21 @@
+require "../spec_helper"
+
+describe Jennifer::Generators::Migration do
+  described_class = Jennifer::Generators::Migration
+
+  describe "#render" do
+    timestamp = Time.now.to_s("%Y%m%d%H%M%S")
+    args = Sam::Args.new({} of String => String, %w(CreateArticles))
+
+    it "creates migration" do
+      described_class.new(args).render
+      expected_content = File.read("./spec/fixtures/generators/migration.cr")
+      migration_path = Dir["./examples/migrations/*.cr"].sort.last
+
+      migration_path.ends_with?("_create_articles.cr").should be_true
+      File.basename(migration_path).starts_with?(timestamp).should be_true
+
+      File.read(migration_path).should eq(expected_content)
+    end
+  end
+end

--- a/spec/generators/model_spec.cr
+++ b/spec/generators/model_spec.cr
@@ -1,0 +1,55 @@
+require "../spec_helper"
+
+describe Jennifer::Generators::Model do
+  described_class = Jennifer::Generators::Model
+
+  describe "#render" do
+    timestamp = Time.now.to_s("%Y%m%d%H%M%S")
+
+    context "with common fields only" do
+      args = Sam::Args.new({} of String => String, %w(Article title:string text:text?))
+
+      it "creates model" do
+        described_class.new(args).render
+        expected_content = File.read("./spec/fixtures/generators/model.cr")
+        model_path = "./examples/models/article.cr"
+        File.exists?(model_path).should be_true
+        File.read(model_path).should eq(expected_content)
+      end
+
+      it "creates migration" do
+        described_class.new(args).render
+        expected_content = File.read("./spec/fixtures/generators/create_migration.cr")
+        migration_path = Dir["./examples/migrations/*.cr"].sort.last
+
+        migration_path.ends_with?("_create_articles.cr").should be_true
+        File.basename(migration_path).starts_with?(timestamp).should be_true
+
+        File.read(migration_path).should eq(expected_content)
+      end
+    end
+
+    context "with references" do
+      args = Sam::Args.new({} of String => String, %w(Article title:string text:text? author:reference))
+
+      it "creates model" do
+        described_class.new(args).render
+        expected_content = File.read("./spec/fixtures/generators/model_with_references.cr")
+        model_path = "./examples/models/article.cr"
+        File.exists?(model_path).should be_true
+        File.read(model_path).should eq(expected_content)
+      end
+
+      it "creates migration" do
+        described_class.new(args).render
+        expected_content = File.read("./spec/fixtures/generators/create_migration_with_references.cr")
+        migration_path = Dir["./examples/migrations/*.cr"].sort.last
+
+        migration_path.ends_with?("_create_articles.cr").should be_true
+        File.basename(migration_path).starts_with?(timestamp).should be_true
+
+        File.read(migration_path).should eq(expected_content)
+      end
+    end
+  end
+end

--- a/spec/integration/sam_test.cr
+++ b/spec/integration/sam_test.cr
@@ -32,7 +32,7 @@ describe "Blank application" do
   end
 
   {% if env("DOCKER") == "1" %}
-    context "with dockerize mysql db" do
+    context "with dockerized mysql db" do
       it do
         clean(:docker) do
           execute("crystal spec/integration/sam/docker_blank_application.cr", ["db:create"]).should succeed

--- a/spec/query_builder/function_spec.cr
+++ b/spec/query_builder/function_spec.cr
@@ -115,7 +115,7 @@ describe Jennifer::QueryBuilder::Function do
 
     it do
       Factory.create_contact
-      Jennifer::Query["contacts"].select { [current_date.alias("current_d")] }.first!.current_d(Time).should eq(Time.epoch(Time.now.epoch).date)
+      Jennifer::Query["contacts"].select { [current_date.alias("current_d")] }.first!.current_d(Time).should eq(Time.unix(Time.now.to_unix).date)
     end
   end
 

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -27,6 +27,7 @@ end
 Spec.after_each do
   Jennifer::Adapter.adapter.rollback_transaction
   Spec.logger.clear
+  Spec.file_system.clean
 end
 
 # Helper methods ================

--- a/spec/support/array_logger.cr
+++ b/spec/support/array_logger.cr
@@ -1,0 +1,32 @@
+require "logger"
+
+class ArrayLogger < Logger
+  property silent : Bool
+  getter container = [] of {sev: String, msg: String}
+
+  def initialize(@io : IO?, @silent = true)
+    @level = Severity::INFO
+    @formatter = DEFAULT_FORMATTER
+    @progname = ""
+    @closed = false
+    @mutex = Mutex.new
+    @formatter = Formatter.new do |_, _, _, msg, io|
+      io << msg
+    end
+  end
+
+  def clear
+    @container.clear
+  end
+
+  private def write(severity, datetime, progname, message)
+    progname_to_s = progname.to_s
+    message_to_s = message.to_s
+    @mutex.synchronize do
+      new_message = String.build do |io|
+        formatter.call(severity, datetime, progname_to_s, message_to_s, io)
+      end
+      @container << {sev: severity.to_s, msg: new_message}
+    end
+  end
+end

--- a/spec/support/file_system.cr
+++ b/spec/support/file_system.cr
@@ -1,0 +1,21 @@
+class FileSystem
+  getter root : String, watchable : Array(String), files : Array(String)
+
+  def initialize(@root)
+    @watchable = [] of String
+    @files = [] of String
+  end
+
+  def watch(path)
+    watchable << path
+    files.concat(Dir[File.join(path, "**")])
+  end
+
+  def clean
+    watchable.each do |path|
+      (Dir[File.join(path, "**")] - files).each do |path|
+        File.delete(path)
+      end
+    end
+  end
+end

--- a/src/jennifer/config.cr
+++ b/src/jennifer/config.cr
@@ -10,6 +10,7 @@ module Jennifer
   # Supported configurations:
   #
   # * `migration_files_path = "./db/migrations"`
+  # * `model_files_path = "./src/models"`
   # * `structure_folder` parent folder of `migration_files_path`
   # * `host = "localhost"`
   # * `port = -1`
@@ -42,7 +43,7 @@ module Jennifer
     STRING_FIELDS = {
       :user, :password, :db, :host, :adapter, :migration_files_path, :schema,
       :structure_folder, :local_time_zone_name, :command_shell, :docker_container, :docker_source_location,
-      :migration_failure_handler_method
+      :migration_failure_handler_method, :model_files_path
     }
     # :nodoc:
     INT_FIELDS    = {:port, :max_pool_size, :initial_pool_size, :max_idle_pool_size, :retry_attempts}
@@ -103,6 +104,7 @@ module Jennifer
       @host = "localhost"
       @port = -1
       @migration_files_path = "./db/migrations"
+      @model_files_path = "./src/models"
       @schema = "public"
       @local_time_zone_name = Time::Location.local.name
       @local_time_zone = Time::Location.local

--- a/src/jennifer/generators/base.cr
+++ b/src/jennifer/generators/base.cr
@@ -1,0 +1,28 @@
+require "ecr"
+
+module Jennifer
+  module Generators
+    abstract class Base
+      getter name : String, args : Sam::Args
+
+      def initialize(@args)
+        @name = @args[0].as(String)
+      end
+
+      def render
+        File.write(file_path, to_s)
+        notify
+      end
+
+      private abstract def file_path : String
+
+      private def notify
+        puts "#{file_path} was successfully created."
+      end
+
+      private def definitions
+        args.raw[1..-1]
+      end
+    end
+  end
+end

--- a/src/jennifer/generators/create_migration.cr
+++ b/src/jennifer/generators/create_migration.cr
@@ -1,0 +1,28 @@
+require "./migration"
+require "./field_set"
+
+module Jennifer
+  module Generators
+    class CreateMigration < Migration
+      getter fields : FieldSet
+
+      def initialize(args, @fields)
+        super(args)
+      end
+
+      def table_name
+        Inflector.pluralize(model_name.downcase)
+      end
+
+      def name
+        "Create#{table_name.camelcase}"
+      end
+
+      private def model_name
+        @name
+      end
+
+      ECR.def_to_s __DIR__ + "/create_migration.ecr"
+    end
+  end
+end

--- a/src/jennifer/generators/create_migration.ecr
+++ b/src/jennifer/generators/create_migration.ecr
@@ -1,0 +1,21 @@
+class <%= class_name %> < Jennifer::Migration::Base
+  def up
+    create_table :<%= table_name %> do |t|
+      <%- fields.common_fields.each do |field| -%>
+      t.<%= field.type %> :<%= field.name %><% unless field.nilable %>, { :null => false }<% end %>
+      <%- end -%>
+
+      <%- if fields.references.any? -%>
+      <%- fields.references.each do |reference| -%>
+      t.reference :<%= reference.name %>
+      <%- end -%>
+
+      <%- end -%>
+      t.timestamps
+    end
+  end
+
+  def down
+    drop_table :<%= table_name %> if table_exists? :<%= table_name %>
+  end
+end

--- a/src/jennifer/generators/field.cr
+++ b/src/jennifer/generators/field.cr
@@ -1,0 +1,89 @@
+module Jennifer
+  module Generators
+    class Field
+      REFERENCE_TYPE = "reference"
+
+      DATA_TYPES = {
+        "bool" => "Bool",
+
+        "bigint" => "Int64",
+        "integer" => "Int32",
+        "short" => "Int16",
+        "tinyint" => "Int8",
+
+        "float" => "Float32",
+        "double" => "Double64",
+
+        "decimal" => "Float64", # PG::Numeric
+
+        "string" => "String",
+        "text" => "String",
+
+        "timestamp" => "Time",
+        "date_time" => "Time",
+
+        "json" => "JSON::Any",
+
+        REFERENCE_TYPE => "Int32"
+      }
+
+      getter name : String, type : String, nilable : Bool
+
+      def initialize(@name, @type, @nilable)
+        unless DATA_TYPES.has_key?(@type)
+          raise "Invalid type `#{@type}`. Only following data types are allowed: #{DATA_TYPES.keys.join(", ")}"
+        end
+        @nilable = true if @type == REFERENCE_TYPE
+      end
+
+      def ==(other)
+        name == other.name && type == other.type && nilable == other.nilable
+      end
+
+      def field_name
+        reference? ? Inflector.foreign_key(name) : name
+      end
+
+      def cr_type
+        definition =
+          if id?
+            primary_type
+          else
+            DATA_TYPES[type]
+          end
+        definition += "?" if nilable && !id?
+        definition
+      end
+
+      def reference_class
+        name.camelcase
+      end
+
+      def id?
+        name == "id"
+      end
+
+      def decimal?
+        type == "decimal"
+      end
+
+      def reference?
+        type == REFERENCE_TYPE
+      end
+
+      def timestamp?
+        name == "created_at" || name == "updated_at"
+      end
+
+      private def primary_type
+        if type == "bigint"
+          "Primary64"
+        elsif type == "integer"
+          "Primary32"
+        else
+          DATA_TYPES[type]
+        end
+      end
+    end
+  end
+end

--- a/src/jennifer/generators/field_set.cr
+++ b/src/jennifer/generators/field_set.cr
@@ -1,0 +1,40 @@
+require "./field"
+
+module Jennifer
+  module Generators
+    class FieldSet
+      getter fields : Array(Field), id : Field
+
+      def initialize(args : Array)
+        @fields = [] of Field
+        args.each do |definition|
+          @fields << Field.new(*parse_field_definition(definition))
+        end
+        @id = @fields.find(&.id?) || Field.new("id", "integer", true)
+      end
+
+      def references
+        fields.select(&.reference?)
+      end
+
+      def common_fields
+        fields.select { |field| !field.id? && !field.reference? && !field.timestamp? }
+      end
+
+      def timestamps
+        [Field.new("created_at", "timestamp", true), Field.new("updated_at", "timestamp", true)]
+      end
+
+      private def parse_field_definition(string)
+        parts = string.as(String).split(":")
+        type = parts[1]
+        nilable = false
+        if type.ends_with?("?")
+          type = type[0...-1]
+          nilable = true
+        end
+        {parts[0], type, nilable}
+      end
+    end
+  end
+end

--- a/src/jennifer/generators/migration.cr
+++ b/src/jennifer/generators/migration.cr
@@ -1,0 +1,25 @@
+require "./base"
+
+module Jennifer
+  module Generators
+    class Migration < Base
+      # Migration file name timestamp format.
+      DATE_FORMAT = "%Y%m%d%H%M%S%L"
+
+      private def file_path
+        File.join(Config.migration_files_path.to_s, file_name)
+      end
+
+      private def file_name
+        time = Time.now.to_s(DATE_FORMAT)
+        "#{time}_#{name.underscore}.cr"
+      end
+
+      private def class_name
+        name.camelcase
+      end
+
+      ECR.def_to_s __DIR__ + "/migration.ecr"
+    end
+  end
+end

--- a/src/jennifer/generators/migration.ecr
+++ b/src/jennifer/generators/migration.ecr
@@ -1,0 +1,7 @@
+class <%= class_name %> < Jennifer::Migration::Base
+  def up
+  end
+
+  def down
+  end
+end

--- a/src/jennifer/generators/model.cr
+++ b/src/jennifer/generators/model.cr
@@ -1,0 +1,33 @@
+require "./create_migration"
+
+module Jennifer
+  module Generators
+    class Model < Base
+      getter fields : FieldSet
+
+      def initialize(args)
+        super
+        @fields = FieldSet.new(definitions)
+      end
+
+      def render
+        super
+        CreateMigration.new(args, fields).render
+      end
+
+      private def file_path
+        File.join(Config.model_files_path.to_s, file_name)
+      end
+
+      private def file_name
+        "#{name.underscore}.cr"
+      end
+
+      private def class_name
+        name.camelcase
+      end
+
+      ECR.def_to_s __DIR__ + "/model.ecr"
+    end
+  end
+end

--- a/src/jennifer/generators/model.ecr
+++ b/src/jennifer/generators/model.ecr
@@ -1,0 +1,21 @@
+class <%= class_name %> < Jennifer::Model::Base
+  with_timestamps
+
+  mapping(
+    id: <%= fields.id.cr_type %>,
+    <%- fields.common_fields.each do |field| -%>
+    <%= field.field_name %>: <%= field.cr_type %>,
+    <%- end -%>
+    <%- fields.references.each do |field| -%>
+    <%= field.field_name %>: <%= field.cr_type %>,
+    <%- end -%>
+    <%- fields.timestamps.each do |field| -%>
+    <%= field.field_name %>: <%= field.cr_type %>,
+    <%- end -%>
+  )
+  <%- if fields.references.any? %>
+  <%- fields.references.each do |reference| -%>
+  belongs_to :<%= reference.name %>, <%= reference.reference_class %>
+  <%- end -%>
+  <%- end -%>
+end

--- a/src/jennifer/migration/runner.cr
+++ b/src/jennifer/migration/runner.cr
@@ -1,9 +1,6 @@
 module Jennifer
   module Migration
     module Runner
-      # Migration file name timestamp format.
-      MIGRATION_DATE_FORMAT = "%Y%m%d%H%M%S%L"
-
       @@pending_versions = [] of String
 
       # Invokes migrations. *count* with negative or zero value will invoke all pending migrations.
@@ -84,24 +81,6 @@ module Jennifer
         # TODO: load schema for each adapter
         default_adapter_class.load_schema
         puts "Schema loaded"
-      end
-
-      # Generates an empty migration file template.
-      def self.generate(name : String)
-        time = Time.now.to_s(MIGRATION_DATE_FORMAT)
-        migration_name = name.camelcase
-        str = <<-MIGRATION
-        class #{migration_name} < Jennifer::Migration::Base
-          def up
-          end
-
-          def down
-          end
-        end
-
-        MIGRATION
-        File.write(File.join(Config.migration_files_path.to_s, "#{time}_#{migration_name.underscore}.cr"), str)
-        puts "Migration #{migration_name.underscore} was generated"
       end
 
       private def self.default_adapter

--- a/src/jennifer/sam.cr
+++ b/src/jennifer/sam.cr
@@ -1,3 +1,5 @@
+require "./generators/*"
+
 Sam.namespace "db" do
   desc "Will call all pending migrations"
   task "migrate" do |t, args|
@@ -39,13 +41,13 @@ Sam.namespace "db" do
   end
 
   namespace "schema" do
-    desc "Loads database structure from structure.sql"
+    desc "Loads database structure from the structure.sql file"
     task "load" do
       Jennifer::Migration::Runner.load_schema
     end
   end
 
-  desc "Prints version of last runned migration"
+  desc "Prints version of the last run migration"
   task "version" do
     version = Jennifer::Migration::Version.all.last
     if version
@@ -57,8 +59,13 @@ Sam.namespace "db" do
 end
 
 Sam.namespace "generate" do
-  desc "Generates migration template. Usage generate:migration <migration_name>"
+  desc "Generates migration template. Usage - generate:migration <migration_name>"
   task "migration" do |t, args|
-    Jennifer::Migration::Runner.generate(args[0].as(String))
+    Jennifer::Generators::Migration.new(args).render
+  end
+
+  desc "Generates model and migrations template. Usage - generate:model <ModelName>"
+  task "model" do |t, args|
+    Jennifer::Generators::Model.new(args).render
   end
 end


### PR DESCRIPTION
# What does this PR do?

Move all file generating specific logic to the `Jennifer::Generators` space; adds extended model file generating mechanism.

# Release notes

**General**

* bump `sam` to `"~> 0.3.0"`
* added sam command `generate:model` to generate model and related migration
* move all logic regarding file generating to `Jennifer::Generators` space

**Config**

* add new property `model_files_path` representing model directory (is used in a scope of model generating)

**Migration**

* remove `Runner.generate` and `Runner::MIGRATION_DATE_FORMAT`
