### PR TITLE
Create foreign key for a reference table type

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -20,7 +20,9 @@ Regular example for creating table:
 
 ```crystal
 create_table(:addresses) do |t|
-  t.reference :contact # creates field contact_id with Int type and allows null values
+  # creates field contact_id with Int type, allows null values and creates foreign key
+  t.reference :contact
+
   t.string :street, {:size => 20, :sql_type => "char"} # creates string field with CHAR(20) db type
   t.bool :main, {:default => false} # sets false as default value
 end
@@ -116,6 +118,7 @@ Also next support methods are available:
 - `#table_exists?(name)`
 - `#index_exists?(table, name)`
 - `#column_exists?(table, name)`
+- `#foreign_key_exists?(from_table, to_table)`
 - `#data_type_exists?(name)` for postgres ENUM
 - `#material_view_exists?(name)`
 

--- a/examples/migrations/20170119011507724_create_address.cr
+++ b/examples/migrations/20170119011507724_create_address.cr
@@ -1,16 +1,12 @@
 class CreateAddress20170119011507724 < Jennifer::Migration::Base
   def up
     create_table(:addresses) do |t|
-      t.integer :contact_id, {:null => true}
+      t.reference :contact
       t.string :street
       t.bool :main, {:default => false}
 
-      t.foreign_key :contacts
-
       t.timestamps
     end
-
-    # add_foreign_key :addresses, :contacts
   end
 
   def down

--- a/examples/migrations/20170122152105921_add_passport.cr
+++ b/examples/migrations/20170122152105921_add_passport.cr
@@ -7,6 +7,7 @@ class AddPassport < Jennifer::Migration::Base
   end
 
   def down
+    drop_foreign_key(:passports, :contacts)
     drop_table(:passports)
   end
 end

--- a/spec/adapter/base_spec.cr
+++ b/spec/adapter/base_spec.cr
@@ -169,6 +169,26 @@ describe Jennifer::Adapter::Base do
     end
   end
 
+  describe "#foreign_key_exists?" do
+    context "with given connected tables names" do
+      it do
+        adapter.foreign_key_exists?(:addresses, :contacts).should be_true
+      end
+    end
+
+    context "with given foreign key name" do
+      it do
+        adapter.foreign_key_exists?("fk_cr_addresses_contacts").should be_true
+      end
+    end
+
+    context "with invalid name" do
+      it do
+        adapter.foreign_key_exists?("fk_cr_contacts_addresses").should be_false
+      end
+    end
+  end
+
   describe "#bulk_insert" do
     it "do nothing if empty array was given" do
       expect_query_silence do

--- a/spec/fixtures/generators/create_migration_with_references.cr
+++ b/spec/fixtures/generators/create_migration_with_references.cr
@@ -11,6 +11,7 @@ class CreateArticles < Jennifer::Migration::Base
   end
 
   def down
+    drop_foreign_key :articles, :authors if foreign_key_exists? :articles, :authors
     drop_table :articles if table_exists? :articles
   end
 end

--- a/src/jennifer/adapter/base.cr
+++ b/src/jennifer/adapter/base.cr
@@ -248,8 +248,20 @@ module Jennifer
       abstract def update(obj)
       abstract def update(q, h)
       abstract def insert(obj)
+
+      # Returns where table with given *table* name exists.
       abstract def table_exists?(table)
+
+      # Returns whether foreign key between *from_table* and *to_table* exists.
+      abstract def foreign_key_exists?(from_table, to_table)
+
+      # Returns whether foreign key with given *name* exists.
+      abstract def foreign_key_exists?(name)
+
+      # Returns whether index for the *table` with *name* exists.
       abstract def index_exists?(table, name)
+
+      # Returns whether column of *table* with *name* exists.
       abstract def column_exists?(table, name)
       abstract def translate_type(name)
       abstract def default_type_size(name)

--- a/src/jennifer/adapter/mysql.cr
+++ b/src/jennifer/adapter/mysql.cr
@@ -79,6 +79,12 @@ module Jennifer
           .exists?
       end
 
+      def view_exists?(name)
+        Query["information_schema.TABLES"]
+          .where { (_table_schema == Config.db) & (_table_type == "VIEW") & (_table_name == name) }
+          .exists?
+      end
+
       def index_exists?(table, name)
         Query["information_schema.statistics"].where do
           (_table_name == table) &
@@ -95,9 +101,14 @@ module Jennifer
         end.exists?
       end
 
-      def view_exists?(name)
-        Query["information_schema.TABLES"]
-          .where { (_table_schema == Config.db) & (_table_type == "VIEW") & (_table_name == name) }
+      def foreign_key_exists?(from_table, to_table)
+        name = self.class.foreign_key_name(from_table, to_table)
+        foreign_key_exists?(name)
+      end
+
+      def foreign_key_exists?(name)
+        Query["information_schema.KEY_COLUMN_USAGE"]
+          .where { and(_constraint_name == name, _table_schema == Config.db) }
           .exists?
       end
 

--- a/src/jennifer/adapter/postgres.cr
+++ b/src/jennifer/adapter/postgres.cr
@@ -141,10 +141,15 @@ module Jennifer
         end.exists?
       end
 
-      # Returns if table exists.
       def table_exists?(table)
         Query["information_schema.tables"]
           .where { _table_name == table }
+          .exists?
+      end
+
+      def view_exists?(name)
+        Query["information_schema.views"]
+          .where { (_table_schema == Config.schema) & (_table_name == name) }
           .exists?
       end
 
@@ -161,9 +166,14 @@ module Jennifer
           .exists?
       end
 
-      def view_exists?(name)
-        Query["information_schema.views"]
-          .where { (_table_schema == Config.schema) & (_table_name == name) }
+      def foreign_key_exists?(from_table, to_table)
+        name = self.class.foreign_key_name(from_table, to_table)
+        foreign_key_exists?(name)
+      end
+
+      def foreign_key_exists?(name)
+        Query["information_schema.table_constraints"]
+          .where { and(_constraint_name == name, _table_schema == Config.schema) }
           .exists?
       end
 

--- a/src/jennifer/generators/create_migration.ecr
+++ b/src/jennifer/generators/create_migration.ecr
@@ -16,6 +16,11 @@ class <%= class_name %> < Jennifer::Migration::Base
   end
 
   def down
+    <%- if fields.references.any? -%>
+    <%- fields.references.each do |reference| -%>
+    drop_foreign_key :<%= table_name %>, :<%= Inflector.pluralize(reference.name) %> if foreign_key_exists? :<%= table_name %>, :<%= Inflector.pluralize(reference.name) %>
+    <%- end -%>
+    <%- end -%>
     drop_table :<%= table_name %> if table_exists? :<%= table_name %>
   end
 end

--- a/src/jennifer/migration/base.cr
+++ b/src/jennifer/migration/base.cr
@@ -35,7 +35,7 @@ module Jennifer
       delegate adapter, to: Adapter
 
       delegate create_data_type, to: adapter
-      delegate table_exists?, index_exists?, column_exists?, view_exists?, to: adapter
+      delegate :table_exists?, :index_exists?, :column_exists?, :view_exists?, :foreign_key_exists?, to: adapter
       delegate schema_processor, to: adapter
 
       delegate create_table, create_join_table, drop_join_table, exec, drop_table,

--- a/src/jennifer/migration/table_builder/create_table.cr
+++ b/src/jennifer/migration/table_builder/create_table.cr
@@ -43,9 +43,10 @@ module Jennifer
         # Adds a reference.
         #
         # Defines foreign key field based on given relation name (*name*). By default it is integer and null value is allowed.
-        # TODO: add a foreign key
-        def reference(name)
-          integer(name.to_s + "_id", {:type => :integer, :null => true})
+        def reference(name, to_table = Inflector.pluralize(name), primary_key = nil, key_name = nil)
+          column = Inflector.foreign_key(name)
+          integer(column, { :type => :integer, :null => true })
+          foreign_key(to_table, column, primary_key, key_name)
         end
 
         # Defines `created_at` and `updated_at` timestamp fields.

--- a/src/jennifer/query_builder/criteria.cr
+++ b/src/jennifer/query_builder/criteria.cr
@@ -170,10 +170,6 @@ module Jennifer
       def filterable?
         false
       end
-
-      def to_condition
-        Condition.new(self)
-      end
     end
   end
 end

--- a/src/jennifer/query_builder/query.cr
+++ b/src/jennifer/query_builder/query.cr
@@ -335,8 +335,8 @@ module Jennifer
       end
 
       # ditto
-      def set_tree(other : Criteria)
-        set_tree(Condition.new(other))
+      def set_tree(other : SQLNode)
+        set_tree(other.to_condition)
       end
 
       # ditto

--- a/src/jennifer/query_builder/sql_node.cr
+++ b/src/jennifer/query_builder/sql_node.cr
@@ -10,6 +10,10 @@ module Jennifer
       # Returns whether node has an argument to be added to sql statement arguments.
       abstract def filterable?
 
+      def to_condition
+        Condition.new(self)
+      end
+
       def eql?(other)
         false
       end


### PR DESCRIPTION
# What does this PR do?

Invokes `#foreign_key` for the `Jennifer::Migration::TableBuilder::CreateTable#reference` 

# Release notes

**Adapter**

* add `Adapter#foreign_key_exists?`

**Migration**

* `TableBuilder::CreateTable#reference` triggers `#foreign_key` 
