### PR TITLE
Extend query updating mechanism

### DIFF
--- a/docs/crud.md
+++ b/docs/crud.md
@@ -64,8 +64,10 @@ Will not trigger any callback.
 Also relative modification allowed as well:
 
 ```crystal
-# UPDATE contacts SET age = age + 2 WHERE id = 12
+# UPDATE contacts SET age = contacts.age + 2 WHERE contacts.id = 12
 Contact.where { _id == 12 }.increment(age: 2)
+# or
+Contact.where { _id == 12 }.update { { :age => _age + 12 } }
 ```
 
 #### Destroy

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -22,36 +22,38 @@ user.valid? # true
 
 ## Trigger validation
 
-The following methods triggers validations and will save the object only if all validations will pass:
+The following model methods triggers validations in a scope of own execution:
 
-- validate
-- validate!
-- valid?
-- create
-- create!
-- save
-- save_without_transaction
-- save!
-- update
-- update!
+- `#validate`
+- `#validate!`
+- `#valid?`
+- `.create`
+- `.create!`
+- `#save`
+- `#save_without_transaction`
+- `#save!`
+- `#update`
+- `#update!`
 
 > NOTE: Bang method version will raise an exception if record is invalid.
 >
 > NOTE: `#valid?` is an alias for `#validate!`.
+>
+> `Jennifer::Query#patch` also invokes validation (and callbacks) for each matched record.
 
-`#validate!` method will also invoke validation callbacks. Be aware: `after_validation` callbacks may not be triggered if record is invalid or `before_validation` has raised `Jennifer::Skip` exception.
+`#validate!` method invokes validation callbacks. Be aware: `after_validation` callbacks may not be triggered if record is invalid or `before_validation` has raised `Jennifer::Skip` exception.
 
 ## Skip validation
 
-Not all methods which hit db perform validation. They are:
+Some methods skip validation on invocation:
 
-- invalid?
-- save(skip_validation: true)
-- update_column
-- update_columns
-- modify
-- increment
-- decrement
+- `Model::Base#invalid?`
+- `Model::Base#save(skip_validation: true)`
+- `Model::Base#update_column`
+- `Model::Base#update_columns`
+- `QueryBuilder::Query#update`
+- `QueryBuilder::Query#increment`
+- `QueryBuilder::Query#decrement`
 
 > NOTE: `#invalid?` method will only check if `#errors` is empty.
 

--- a/spec/query_builder/executables_spec.cr
+++ b/spec/query_builder/executables_spec.cr
@@ -126,13 +126,13 @@ describe Jennifer::QueryBuilder::Executables do
     end
   end
 
-  describe "#modify" do
-    it "performs provided operations" do
-      c = Factory.create_contact(age: 13)
-      Contact.all.modify({:age => {value: 2, operator: :+}})
-      c.reload.age.should eq(15)
-    end
-  end
+  # describe "#modify" do
+  #   it "performs provided operations" do
+  #     c = Factory.create_contact(age: 13)
+  #     Contact.all.modify({:age => {value: 2, operator: :+}})
+  #     c.reload.age.should eq(15)
+  #   end
+  # end
 
   describe "#update" do
     it "updates given fields in all matched rows" do
@@ -143,19 +143,38 @@ describe Jennifer::QueryBuilder::Executables do
       Contact.where { _age < 15 }.update({:age => 20, :name => "b"})
       Contact.where { (_age == 20) & (_name == "b") }.count.should eq(2)
     end
+
+    context "with block" do
+      it do
+        c1 = Factory.create_contact(age: 13, name: "a")
+        c2 = Factory.create_contact(age: 14, name: "a")
+        c3 = Factory.create_contact(age: 15, name: "a")
+
+        Contact.where { _age < 15 }.update do
+          {
+            :age => _age - 1,
+            :name => "b"
+          }
+        end
+
+        c1.reload
+        c1.name.should eq("b")
+        c1.age.should eq(12)
+      end
+    end
   end
 
   describe "#increment" do
     it "accepts hash" do
       c = Factory.create_contact(name: "asd", gender: "male", age: 18)
       Contact.where { _id == c.id }.increment({:age => 2})
-      Contact.find!(c.id).age.should eq(20)
+      c.reload.age.should eq(20)
     end
 
     it "accepts named tuple literal" do
       c = Factory.create_contact(name: "asd", gender: "male", age: 18)
       Contact.where { _id == c.id }.increment(age: 2)
-      Contact.find!(c.id).age.should eq(20)
+      c.reload.age.should eq(20)
     end
   end
 
@@ -163,13 +182,13 @@ describe Jennifer::QueryBuilder::Executables do
     it "accepts hash" do
       c = Factory.create_contact(name: "asd", gender: "male", age: 20)
       Contact.where { _id == c.id }.decrement({:age => 2})
-      Contact.find!(c.id).age.should eq(18)
+      c.reload.age.should eq(18)
     end
 
     it "accepts named tuple literal" do
       c = Factory.create_contact({:name => "asd", :gender => "male", :age => 20})
       Contact.where { _id == c.id }.decrement(age: 2)
-      Contact.find!(c.id).age.should eq(18)
+      c.reload.age.should eq(18)
     end
   end
 

--- a/src/jennifer/adapter/base_sql_generator.cr
+++ b/src/jennifer/adapter/base_sql_generator.cr
@@ -132,7 +132,9 @@ module Jennifer
 
       def self.lock_clause(io : String::Builder, query)
         return if query._lock.nil?
-        io << (query._lock.is_a?(String) ? query._lock : " FOR UPDATE ")
+        io << ' '
+        io << (query._lock.is_a?(String) ? query._lock : "FOR UPDATE")
+        io << ' '
       end
 
       # Renders SELECT and FROM parts

--- a/src/jennifer/adapter/base_sql_generator.cr
+++ b/src/jennifer/adapter/base_sql_generator.cr
@@ -99,10 +99,12 @@ module Jennifer
       end
 
       def self.modify(q, modifications : Hash)
-        esc = escape_string(1)
         String.build do |s|
           s << "UPDATE " << q.table << " SET "
-          modifications.map { |field, value| "#{field.to_s} = #{field.to_s} #{value[:operator]} #{esc}" }.join(", ", s)
+          modifications.each_with_index do |(field, value), i|
+            s << ", " if i != 0
+            s << field_assign_statement(field.to_s, value)
+          end
           s << ' '
           body_section(s, q)
         end
@@ -278,6 +280,14 @@ module Jennifer
           args[i] = arg.as(Time).to_utc if arg.is_a?(Time)
         end
         {query % Array.new(args.size, "?"), args}
+      end
+
+      private def self.field_assign_statement(field, _value : DBAny)
+        "#{field} = #{escape_string(1)}"
+      end
+
+      private def self.field_assign_statement(field, value : QueryBuilder::Statement)
+        "#{field} = #{value.as_sql}"
       end
     end
   end

--- a/src/jennifer/adapter/request_methods.cr
+++ b/src/jennifer/adapter/request_methods.cr
@@ -32,8 +32,8 @@ module Jennifer
       def modify(q, modifications : Hash)
         query = sql_generator.modify(q, modifications)
         args = [] of DBAny
-        modifications.each do |k, v|
-          args << v[:value]
+        modifications.each do |_, v|
+          add_field_assign_arguments(args, v)
         end
         args.concat(q.sql_args)
         exec(*parse_query(query, args))
@@ -68,6 +68,14 @@ module Jennifer
         body = sql_generator.select(q)
         args = q.sql_args
         query(*parse_query(body, args)) { |rs| yield rs }
+      end
+
+      private def add_field_assign_arguments(container : Array, value : DBAny)
+        container << value
+      end
+
+      private def add_field_assign_arguments(container : Array, value : QueryBuilder::Statement)
+        container.concat(value.sql_args)
       end
     end
   end

--- a/src/jennifer/query_builder/condition.cr
+++ b/src/jennifer/query_builder/condition.cr
@@ -4,6 +4,7 @@ module Jennifer
   module QueryBuilder
     class Condition
       include LogicOperator::Operators
+      include Statement
 
       getter lhs : SQLNode, rhs : Criteria::Rightable?, operator : Symbol = :bool
       @negative = false

--- a/src/jennifer/query_builder/i_model_query.cr
+++ b/src/jennifer/query_builder/i_model_query.cr
@@ -33,12 +33,12 @@ module Jennifer
         super(model_class.primary, batch_size, start, direction) { |record| yield record }
       end
 
-      # Triggers `#destroy` on the each matched object
+      # Triggers `#destroy` on the each matched object.
       def destroy
         find_each(&.destroy)
       end
 
-      # Triggers `#update` on the each matched object
+      # Triggers `#update` on the each matched object.
       def patch(options : Hash | NamedTuple)
         find_each(&.update(options))
       end
@@ -47,11 +47,12 @@ module Jennifer
         patch(opts)
       end
 
-      # Triggers `#update!` on the each matched object
+      # Triggers `#update!` on the each matched object.
       def patch!(options : Hash | NamedTuple)
         find_each(&.update!(options))
       end
 
+      # ditto
       def patch!(**opts)
         patch!(opts)
       end

--- a/src/jennifer/query_builder/query.cr
+++ b/src/jennifer/query_builder/query.cr
@@ -305,6 +305,14 @@ module Jennifer
       # Specifies locking settings.
       #
       # `true` is default value. Also string declaration can be provide.
+      #
+      # Also `SKIP LOCKED` construction can be used with manual mode:
+      #
+      # ```
+      # Queue.all.where do
+      #   _id == g(Queue.all.limit(1).lock("FOR UPDATE SKIP LOCKED"))
+      # end.delete
+      # ```
       def lock(type : String | Bool = true)
         @lock = type
         self


### PR DESCRIPTION
# What does this PR do?

`Jennifer::QueryBuilder::Query#update` accepts block which allows to manually specify value to be set depending on other columns (or even same):

```crystal
Order.all.where { _created_at < current_date }.update do
  {
    :name => upper(_name),
    :price => _price + 120 
  }
end
```

# Release notes

**QueryBuilder**

* `Condition` includes `Statement`
* `Executables#update` accepts block expecting `Hash(Symbol, Statement)`
* `Executables#modify` is removed in favor of new `#update` method accepting block

**SqlGenerator**

* `.lock_clause` adds whitespaces around lock statement automatically
