### PR TITLE
Fix postgres rename table and drop foreign key syntax

### DIFF
--- a/spec/adapter/mysql/schema_processor_spec.cr
+++ b/spec/adapter/mysql/schema_processor_spec.cr
@@ -1,0 +1,16 @@
+require "../../spec_helper"
+
+mysql_only do
+  describe Jennifer::Mysql::SchemaProcessor do
+    adapter = Jennifer::Adapter.adapter
+    processor = adapter.schema_processor
+
+    describe "#rename_table" do
+      it do
+        match_query_from_exception(/ALTER TABLE old_name RENAME new_name/) do
+          processor.rename_table("old_name", "new_name")
+        end
+      end
+    end
+  end
+end

--- a/spec/adapter/postgres/schema_processor_spec.cr
+++ b/spec/adapter/postgres/schema_processor_spec.cr
@@ -27,6 +27,15 @@ postgres_only do
     end
 
     describe "#change_column" do
+      pending "add"
+    end
+
+    describe "#rename_table" do
+      it do
+        match_query_from_exception(/ALTER TABLE old_name RENAME TO new_name/) do
+          processor.rename_table("old_name", "new_name")
+        end
+      end
     end
   end
 end

--- a/spec/adapter/schema_processor_spec.cr
+++ b/spec/adapter/schema_processor_spec.cr
@@ -1,0 +1,164 @@
+require "../spec_helper"
+
+alias DB_OPTION = Jennifer::Migration::TableBuilder::Base::EAllowedTypes | Array(Jennifer::Migration::TableBuilder::Base::EAllowedTypes)
+
+describe Jennifer::Adapter::SchemaProcessor do
+  adapter = Jennifer::Adapter.adapter
+  processor = adapter.schema_processor
+
+  describe "#add_index" do
+    it do
+      match_query_from_exception(/CREATE INDEX index_name ON table_name \(field1,field2\)/) do
+        processor.add_index("table_name", "index_name", ["field1", "field2"])
+      end
+    end
+
+    pending "test types"
+  end
+
+  describe "#drop_index" do
+    it do
+      match_query_from_exception(/DROP INDEX index_name/) do
+        processor.drop_index("table_name", "index_name")
+      end
+    end
+  end
+
+  describe "#drop_column" do
+    it do
+      match_query_from_exception(/ALTER TABLE table_name DROP COLUMN column/) do
+        processor.drop_column("table_name", "column")
+      end
+    end
+  end
+
+  describe "#add_column" do
+    it do
+      match_query_from_exception(/ALTER TABLE table_name ADD COLUMN column int/) do
+        processor.add_column("table_name", "column", { :type => :integer } of Symbol => DB_OPTION)
+      end
+    end
+
+    describe "serial" do
+      it do
+        match_query_from_exception(/ALTER TABLE table_name ADD COLUMN column serial/) do
+          processor.add_column("table_name", "column", { :type => :integer, :serial => true } of Symbol => DB_OPTION)
+        end
+      end
+    end
+
+    describe "primary key" do
+      it do
+        match_query_from_exception(/ALTER TABLE table_name ADD COLUMN column int PRIMARY KEY/) do
+          processor.add_column("table_name", "column", { :type => :integer, :primary => true } of Symbol => DB_OPTION)
+        end
+      end
+    end
+
+    describe "auto increment" do
+      pending "add"
+      # it do
+      #   match_query_from_exception(/ALTER TABLE table_name ADD COLUMN column int AUTO_INCREMENT/) do
+      #     processor.add_column("table_name", "column", { :type => :integer, :auto_increment => true } of Symbol => DB_OPTION)
+      #   end
+      # end
+    end
+
+    context "with default" do
+      it do
+        match_query_from_exception(/ALTER TABLE table_name ADD COLUMN column int DEFAULT 10/) do
+          processor.add_column("table_name", "column", { :type => :integer, :default => 10 } of Symbol => DB_OPTION)
+        end
+      end
+    end
+
+    describe "NULL" do
+      context "with" do
+        it do
+          match_query_from_exception(/ALTER TABLE table_name ADD COLUMN column int NOT NULL/) do
+            processor.add_column("table_name", "column", { :type => :integer, :null => false } of Symbol => DB_OPTION)
+          end
+        end
+      end
+
+      context "without" do
+        it do
+          match_query_from_exception(/ALTER TABLE table_name ADD COLUMN column int NULL/) do
+            processor.add_column("table_name", "column", { :type => :integer, :null => true } of Symbol => DB_OPTION)
+          end
+        end
+      end
+    end
+
+    describe "enum" do
+      pending "add"
+    end
+
+    context "with custom size" do
+      it do
+        match_query_from_exception(/ALTER TABLE table_name ADD COLUMN column int\(2\)/) do
+          processor.add_column("table_name", "column", { :type => :integer, :size => 2 } of Symbol => DB_OPTION)
+        end
+      end
+    end
+
+    context "with custom SQL type" do
+      it do
+        match_query_from_exception(/ALTER TABLE table_name ADD COLUMN column smallint/) do
+          processor.add_column("table_name", "column", { :type => :integer, :sql_type => :smallint } of Symbol => DB_OPTION)
+        end
+      end
+    end
+  end
+
+  describe "#change_column" do
+    pending "add"
+  end
+
+  describe "#drop_table" do
+    it do
+      match_query_from_exception(/DROP TABLE asd/) do
+        builder = Jennifer::Migration::TableBuilder::DropTable.new(adapter, "asd")
+        processor.drop_table(builder)
+      end
+    end
+  end
+
+  describe "#create_table" do
+    pending "add"
+  end
+
+  describe "#create_view" do
+    pending "add"
+  end
+
+  describe "#drop_view" do
+    it do
+      match_query_from_exception(/DROP VIEW view_name/) do
+        processor.drop_view("view_name", false)
+      end
+    end
+
+    context "with silent mode" do
+      it "doesn't raise exception when view doesn't exist" do
+        processor.drop_view("view_name", true)
+      end
+    end
+  end
+
+  describe "#add_foreign_key" do
+    it do
+      match_query_from_exception(/ALTER TABLE from_table ADD CONSTRAINT name FOREIGN KEY \(column\) REFERENCES to_table\(primary_key\)/) do
+        processor.add_foreign_key("from_table", "to_table", "column", "primary_key",  "name")
+      end
+    end
+  end
+
+  describe "#drop_foreign_key" do
+    it do
+      match_query_from_exception(/ALTER TABLE table_name DROP FOREIGN KEY key_name/) do
+        processor.drop_foreign_key("table_name", "key_name")
+      end
+    end
+  end
+end

--- a/spec/support/fake_adapter.cr
+++ b/spec/support/fake_adapter.cr
@@ -1,0 +1,37 @@
+# class FakeAdapter < Jennifer::Adapter::Base
+#   ZERO = Time::Span::ZERO
+
+#   ABSTRACT_METHODS = %i(
+#     sql_generator view_exists? update insert table_exists? foreign_key_exists? index_exists?
+#     column_exists? translate_type default_type_size table_column_count with_table_lock schema_processor
+#   )
+
+#   {% for method in ABSTRACT_METHODS %}
+#     def {{method.id}}(*args, **opts)
+#       raise "Abstract {{method.id}}"
+#     end
+#   {% end %}
+
+#   def self.command_interface
+#     raise "Abstract command_interface"
+#   end
+
+#   def exec(_query, args = [] of Jennifer::Adapter::Base::ArgsType)
+#     logger.debug { regular_query_message(ZERO, _query, args) }
+#     DB::ExecResult.new(0i64, -1i64)
+#   end
+
+#   def query(_query, args = [] of Jennifer::Adapter::Base::ArgsType)
+#     logger.debug { regular_query_message(ZERO, _query, args) }
+#     nil
+#   end
+
+#   def scalar(_query, args = [] of Jennifer::Adapter::Base::ArgsType)
+#     logger.debug { regular_query_message(ZERO, _query, args) }
+#     false
+#   end
+
+#   private def logger
+#     Jennifer::Config.logger
+#   end
+# end

--- a/spec/support/matchers.cr
+++ b/spec/support/matchers.cr
@@ -1,4 +1,32 @@
 module Spec
+  module Methods
+    # The following construction
+    #
+    # ```
+    # begin
+    #   processor.method_name(argument)
+    # rescue e
+    #   e.message.should match(/query/)
+    #   next
+    # end
+    # fail "Block wasn't executed"
+    # ```
+    #
+    # uses such `argument` that it makes DB to raise an exception because something doesn't exist (e.g. index name
+    # is missing or table). As Jennifer::BadQuery exception includes query this allows testing it until FakeAdapter
+    # is not ready.
+    macro match_query_from_exception(regex)
+      begin
+        {{yield}}
+        processor.drop_column("table_name", "column")
+      rescue e
+        e.message.should match({{regex}})
+        next
+      end
+      fail "Block wasn't executed"
+    end
+  end
+
   # :nodoc:
   struct BeValidExpectation
     def match(object)

--- a/src/jennifer/adapter/mysql.cr
+++ b/src/jennifer/adapter/mysql.cr
@@ -3,6 +3,7 @@ require "./base"
 
 require "./mysql/sql_generator"
 require "./mysql/command_interface"
+require "./mysql/schema_processor"
 
 module Jennifer
   module Mysql
@@ -51,6 +52,10 @@ module Jennifer
 
       def sql_generator
         SQLGenerator
+      end
+
+      def schema_processor
+        @schema_processor ||= SchemaProcessor.new(self)
       end
 
       def translate_type(name : Symbol)
@@ -118,13 +123,6 @@ module Jennifer
                               " Instead of this only transaction was started.")
           yield t
         end
-        # transaction do |t|
-        #   exec "LOCK TABLES #{table} #{TABLE_LOCK_TYPES[type]}"
-        #   yield t
-        #   exec "UNLOCK TABLES"
-        # end
-        # rescue e : KeyError
-        # raise BaseException.new("MySQL don't support table lock type '#{type}'.")
       end
 
       def self.command_interface

--- a/src/jennifer/adapter/mysql/schema_processor.cr
+++ b/src/jennifer/adapter/mysql/schema_processor.cr
@@ -1,0 +1,52 @@
+require "../schema_processor"
+
+module Jennifer
+  module Mysql
+    class SchemaProcessor < Adapter::SchemaProcessor
+      def rename_table(old_name, new_name)
+        adapter.exec "ALTER TABLE #{old_name.to_s} RENAME #{new_name.to_s}"
+      end
+
+      # NOTE: adding here type will bring a lot of small issues around
+      private def index_type_translate(name)
+        case name
+        when :unique, :uniq
+          "UNIQUE "
+        when :fulltext
+          "FULLTEXT "
+        when :spatial
+          "SPATIAL "
+        when nil
+          " "
+        else
+          raise ArgumentError.new("Unknown index type: #{name}")
+        end
+      end
+
+      private def column_definition(name, options, io)
+        type = options[:serial]? ? "serial" : (options[:sql_type]? || adapter.translate_type(options[:type].as(Symbol)))
+        size = options[:size]? || adapter.default_type_size(options[:type])
+        io << name << " " << type
+        io << "(#{size})" if size
+        if options[:type] == :enum
+          io << " ("
+          options[:values].as(Array).each_with_index do |e, i|
+            io << ", " if i != 0
+            io << "'#{e.as(String | Symbol)}'"
+          end
+          io << ") "
+        end
+        if options.has_key?(:null)
+          if options[:null]
+            io << " NULL"
+          else
+            io << " NOT NULL"
+          end
+        end
+        io << " PRIMARY KEY" if options[:primary]?
+        io << " DEFAULT #{adapter_class.t(options[:default])}" if options[:default]?
+        io << " AUTO_INCREMENT" if options[:auto_increment]?
+      end
+    end
+  end
+end

--- a/src/jennifer/adapter/postgres/schema_processor.cr
+++ b/src/jennifer/adapter/postgres/schema_processor.cr
@@ -46,6 +46,10 @@ module Jennifer
         adapter.exec "DROP INDEX #{name}"
       end
 
+      def rename_table(old_name, new_name)
+        adapter.exec "ALTER TABLE #{old_name.to_s} RENAME TO #{new_name.to_s}"
+      end
+
       # =========== overrides
 
       def add_index(table, name, fields : Array, type : Symbol? = nil, order : Hash? = nil, length : Hash? = nil)

--- a/src/jennifer/adapter/schema_processor.cr
+++ b/src/jennifer/adapter/schema_processor.cr
@@ -1,8 +1,11 @@
 require "../migration/table_builder/*"
+require "./table_builder_builders"
 
 module Jennifer
   module Adapter
-    class SchemaProcessor
+    abstract class SchemaProcessor
+      include TableBuilderBuilders
+
       macro unsupported_method(*names)
         {% for name in names %}
           def {{name.id}}(*args, **opts)
@@ -19,91 +22,9 @@ module Jennifer
       def initialize(@adapter)
       end
 
-      # ================
-      # Builder methods
-      # ================
-
-      def build_create_table(name, id = true)
-        tb = Migration::TableBuilder::CreateTable.new(@adapter, name)
-        tb.integer(:id, {:primary => true, :auto_increment => true}) if id
-        yield tb
-        tb.process
-      end
-
-      # Creates join table; raises table builder to given block
-      def build_create_join_table(table1, table2, table_name : String? = nil)
-        build_create_table(table_name || adapter_class.join_table_name(table1, table2), false) do |tb|
-          tb.integer(Inflector.foreign_key(Inflector.singularize(table1.to_s)))
-          tb.integer(Inflector.foreign_key(Inflector.singularize(table2.to_s)))
-          yield tb
-        end
-      end
-
-      # Creates join table.
-      def build_create_join_table(table1, table2, table_name : String? = nil)
-        build_create_join_table(table1, table2, table_name) { }
-      end
-
-      def build_drop_join_table(table1, table2)
-        build_drop_table(@adapter.class.join_table_name(table1, table2))
-      end
-
-      def build_exec(string)
-        Migration::TableBuilder::Raw.new(@adapter, string).process
-      end
-
-      def build_drop_table(name)
-        Migration::TableBuilder::DropTable.new(@adapter, name).process
-      end
-
-      def build_change_table(name)
-        tb = Migration::TableBuilder::ChangeTable.new(@adapter, name)
-        yield tb
-        tb.process
-      end
-
-      def build_create_view(name, source)
-        Migration::TableBuilder::CreateView.new(@adapter, name.to_s, source).process
-      end
-
-      def build_drop_view(name)
-        Migration::TableBuilder::DropView.new(@adapter, name.to_s).process
-      end
-
-      def build_add_index(table_name, name : String, fields : Array(Symbol), type : Symbol, lengths : Hash(Symbol, Int32) = {} of Symbol => Int32, orders : Hash(Symbol, Symbol) = {} of Symbol => Symbol)
-        Migration::TableBuilder::CreateIndex.new(@adapter, table_name, name, fields, type, lengths, orders).process
-      end
-
-      def build_add_index(table_name, name : String, field : Symbol, type : Symbol, length : Int32? = nil, order : Symbol? = nil)
-        build_add_index(
-          table_name,
-          name,
-          [field],
-          type: type,
-          orders: (order ? {field => order.not_nil!} : {} of Symbol => Symbol),
-          lengths: (length ? {field => length.not_nil!} : {} of Symbol => Int32)
-        )
-      end
-
-      def build_drop_index(table_name, name)
-        Migration::TableBuilder::DropIndex.new(@adapter, table_name, name).process
-      end
-
-      def build_add_foreign_key(from_table, to_table, column = nil, primary_key = nil, name = nil)
-        Migration::TableBuilder::CreateForeignKey.new(@adapter, from_table.to_s, to_table.to_s, column, primary_key, name).process
-      end
-
-      def build_drop_foreign_key(from_table, to_table, name = nil)
-        Migration::TableBuilder::DropForeignKey.new(@adapter, from_table.to_s, to_table.to_s, name).process
-      end
-
-      # ============================
-      # Schema manipulating methods
-      # ============================
-
-      def rename_table(old_name, new_name)
-        adapter.exec "ALTER TABLE #{old_name.to_s} RENAME #{new_name.to_s}"
-      end
+      abstract def rename_table(old_name, new_name)
+      private abstract def index_type_translate(name)
+      private abstract def column_definition(name, options, io)
 
       def add_index(table, name, fields : Array, type : Symbol? = nil, order : Hash? = nil, length : Hash? = nil)
         query = String.build do |s|
@@ -111,7 +32,7 @@ module Jennifer
 
           s << index_type_translate(type) if type
 
-          s << "INDEX " << name << " ON " << table << "("
+          s << "INDEX " << name << " ON " << table << " ("
           fields.each_with_index do |f, i|
             s << "," if i != 0
             s << f
@@ -131,7 +52,7 @@ module Jennifer
         adapter.exec "ALTER TABLE #{table} DROP COLUMN #{name}"
       end
 
-      def add_column(table, name, opts)
+      def add_column(table, name, opts : Hash)
         query = String.build do |s|
           s << "ALTER TABLE " << table << " ADD COLUMN "
           column_definition(name, opts, s)
@@ -140,7 +61,7 @@ module Jennifer
         adapter.exec query
       end
 
-      def change_column(table, old_name, new_name, opts)
+      def change_column(table, old_name, new_name, opts : Hash)
         query = String.build do |s|
           s << "ALTER TABLE " << table << " CHANGE COLUMN " << old_name << " "
           column_definition(new_name, opts, s)
@@ -197,63 +118,13 @@ module Jennifer
       def drop_foreign_key(from_table, name)
         query = String.build do |s|
           s << "ALTER TABLE " << from_table
-          s << "DROP FOREIGN KEY " << name
+          s << " DROP FOREIGN KEY " << name
         end
         adapter.exec query
       end
 
       private def adapter_class
         @adapter.class
-      end
-
-      # NOTE: adding here type will bring a lot of small issues around
-
-      private def index_type_translate(name)
-        case name
-        when :unique, :uniq
-          "UNIQUE "
-        when :fulltext
-          "FULLTEXT "
-        when :spatial
-          "SPATIAL "
-        when nil
-          " "
-        else
-          raise ArgumentError.new("Unknown index type: #{name}")
-        end
-      end
-
-      private def column_definition(name, options, io)
-        type = options[:serial]? ? "serial" : (options[:sql_type]? || adapter.translate_type(options[:type].as(Symbol)))
-        size = options[:size]? || adapter.default_type_size(options[:type])
-        io << name << " " << type
-        io << "(#{size})" if size
-        if options[:type] == :enum
-          io << " ("
-          options[:values].as(Array).each_with_index do |e, i|
-            io << ", " if i != 0
-            io << "'#{e.as(String | Symbol)}'"
-          end
-          io << ") "
-        end
-        if options.has_key?(:null)
-          if options[:null]
-            io << " NULL"
-          else
-            io << " NOT NULL"
-          end
-        end
-        io << " PRIMARY KEY" if options[:primary]?
-        io << " DEFAULT #{adapter_class.t(options[:default])}" if options[:default]?
-        io << " AUTO_INCREMENT" if options[:auto_increment]?
-      end
-    end
-
-    # NOTE: because of cyclic dependency this is the easiest solution ATM
-
-    class Base
-      def schema_processor
-        @schema_processor ||= SchemaProcessor.new(self)
       end
     end
   end

--- a/src/jennifer/adapter/table_builder_builders.cr
+++ b/src/jennifer/adapter/table_builder_builders.cr
@@ -1,0 +1,79 @@
+module Jennifer
+  module Adapter
+    module TableBuilderBuilders
+      def build_create_table(name, id = true)
+        tb = Migration::TableBuilder::CreateTable.new(@adapter, name)
+        tb.integer(:id, {:primary => true, :auto_increment => true}) if id
+        yield tb
+        tb.process
+      end
+
+      # Creates join table; raises table builder to given block
+      def build_create_join_table(table1, table2, table_name : String? = nil)
+        build_create_table(table_name || adapter_class.join_table_name(table1, table2), false) do |tb|
+          tb.integer(Inflector.foreign_key(Inflector.singularize(table1.to_s)))
+          tb.integer(Inflector.foreign_key(Inflector.singularize(table2.to_s)))
+          yield tb
+        end
+      end
+
+      # Creates join table.
+      def build_create_join_table(table1, table2, table_name : String? = nil)
+        build_create_join_table(table1, table2, table_name) { }
+      end
+
+      def build_drop_join_table(table1, table2)
+        build_drop_table(@adapter.class.join_table_name(table1, table2))
+      end
+
+      def build_exec(string)
+        Migration::TableBuilder::Raw.new(@adapter, string).process
+      end
+
+      def build_drop_table(name)
+        Migration::TableBuilder::DropTable.new(@adapter, name).process
+      end
+
+      def build_change_table(name)
+        tb = Migration::TableBuilder::ChangeTable.new(@adapter, name)
+        yield tb
+        tb.process
+      end
+
+      def build_create_view(name, source)
+        Migration::TableBuilder::CreateView.new(@adapter, name.to_s, source).process
+      end
+
+      def build_drop_view(name)
+        Migration::TableBuilder::DropView.new(@adapter, name.to_s).process
+      end
+
+      def build_add_index(table_name, name : String, fields : Array(Symbol), type : Symbol, lengths : Hash(Symbol, Int32) = {} of Symbol => Int32, orders : Hash(Symbol, Symbol) = {} of Symbol => Symbol)
+        Migration::TableBuilder::CreateIndex.new(@adapter, table_name, name, fields, type, lengths, orders).process
+      end
+
+      def build_add_index(table_name, name : String, field : Symbol, type : Symbol, length : Int32? = nil, order : Symbol? = nil)
+        build_add_index(
+          table_name,
+          name,
+          [field],
+          type: type,
+          orders: (order ? {field => order.not_nil!} : {} of Symbol => Symbol),
+          lengths: (length ? {field => length.not_nil!} : {} of Symbol => Int32)
+        )
+      end
+
+      def build_drop_index(table_name, name)
+        Migration::TableBuilder::DropIndex.new(@adapter, table_name, name).process
+      end
+
+      def build_add_foreign_key(from_table, to_table, column = nil, primary_key = nil, name = nil)
+        Migration::TableBuilder::CreateForeignKey.new(@adapter, from_table.to_s, to_table.to_s, column, primary_key, name).process
+      end
+
+      def build_drop_foreign_key(from_table, to_table, name = nil)
+        Migration::TableBuilder::DropForeignKey.new(@adapter, from_table.to_s, to_table.to_s, name).process
+      end
+    end
+  end
+end


### PR DESCRIPTION
# What does this PR do?

* fixes rename table for postgres adapter (#186)
* fixes `#drop_foreign_key` sql syntax

# Release notes

**Adapter**

* add `Mysql::SchameProcessor`
* now `Base#schema_processor` is abstract
* add `Postgres::SchemaProcessor#rename_table`
* `SchemaProcessor` now is abstract
* all builder methods are moved from `SchemaProcessor` class to `TableBuilderBuilders` module
* fix syntax in `SchemaProcessor#drop_foreign_key`
