### PR TITLE
Decouple Model::Errors from Model::Base

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -87,6 +87,36 @@ user.errors.add(:login, "Some custom message")
 
 The `#clear!` method is used when all error messages should be removed. It is automatically invoked by `#validate!`.
 
+### Non-model usage
+
+It is possible to use `Jennifer::Model::Errors` for handling errors of any class that includes `Jennifer::Model::Translation` and implements `.superclass` method.
+
+```crystal
+class Post
+  include Jennifer::Model::Translation
+
+  property title : String?
+  getter errors
+
+  def initialize
+    @errors = Jennifer::Model::Errors.new(self)
+  end
+
+  def validate
+    errors.clear
+    errors.add(:title, :blank) if title.nil?
+  end
+
+  # The following method is needed to be minimally implemented
+
+  def self.superclass; end
+end
+
+post = Post.new
+post.validate
+post.errors[:title] # "can't be blank"
+```
+
 ## Validation macros
 
 Please take into account that all validators described below implement singleton pattern - there is only one instance of each of them in application.

--- a/spec/model/errors_spec.cr
+++ b/spec/model/errors_spec.cr
@@ -1,10 +1,24 @@
 require "../spec_helper"
 
+class Spec::TestClassForError
+  include Jennifer::Model::Translation
+
+  def self.superclass; end
+end
+
 describe Jennifer::Model::Errors do
   # TODO: add test case descriptions
 
   described_class = Jennifer::Model::Errors
   facebook_profile = Factory.build_facebook_profile
+
+  describe ".new" do
+    context "with custom class" do
+      it do
+        described_class.new(Spec::TestClassForError.new).base.is_a?(Spec::TestClassForError).should be_true
+      end
+    end
+  end
 
   describe "#include?" do
     errors = described_class.new(facebook_profile)
@@ -34,16 +48,40 @@ describe Jennifer::Model::Errors do
   end
 
   describe "#[]" do
-    it do
-      errors = described_class.new(facebook_profile)
-      errors.add(:uid, "some message")
-      errors.add(:uid, :exclusion)
-      errors[:uid].should eq(["some message", "is reserved"])
+    context "with existing key" do
+      it do
+        errors = described_class.new(facebook_profile)
+        errors.add(:uid, "some message")
+        errors.add(:uid, :exclusion)
+        errors[:uid].should eq(["some message", "is reserved"])
+      end
+    end
+
+    context "without key" do
+      it do
+        errors = described_class.new(facebook_profile)
+        errors.add(:uid, "some message")
+        errors[:id].should eq([] of String)
+      end
     end
   end
 
   describe "#[]?" do
-    pending "add" do
+    context "with existing key" do
+      it do
+        errors = described_class.new(facebook_profile)
+        errors.add(:uid, "some message")
+        errors.add(:uid, :exclusion)
+        errors[:uid]?.should eq(["some message", "is reserved"])
+      end
+    end
+
+    context "without key" do
+      it do
+        errors = described_class.new(facebook_profile)
+        errors.add(:uid, "some message")
+        errors[:id]?.should be_nil
+      end
     end
   end
 
@@ -146,6 +184,14 @@ describe Jennifer::Model::Errors do
         errors.add(:uid, :exclusion)
         errors[:uid][0].should eq("is reserved")
       end
+
+      context "with custom class" do
+        it do
+          errors = described_class.new(Spec::TestClassForError.new)
+          errors.add(:uid)
+          errors[:uid][0].should eq("is invalid")
+        end
+      end
     end
 
     context "with count" do
@@ -172,6 +218,18 @@ describe Jennifer::Model::Errors do
       errors.add(:uid, :exclusion)
       errors.add(:id)
       errors.full_messages.should eq(["Uid is invalid", "Uid is reserved", "Id is invalid"])
+    end
+
+    context "with custom class" do
+      it do
+        errors = described_class.new(Spec::TestClassForError.new)
+        errors.add(:uid)
+        errors.add(:uid, :exclusion)
+        errors.add(:id)
+        errors.full_messages.should eq(["Uid is invalid", "Uid is reserved", "Id is invalid"])
+      end
+
+      pending "with custom context"
     end
   end
 

--- a/spec/model/translation_spec.cr
+++ b/spec/model/translation_spec.cr
@@ -1,7 +1,15 @@
 require "../spec_helper"
 
+class Spec::TestClassForTranslation
+  include Jennifer::Model::Translation
+
+  def self.superclass; end
+end
+
 describe Jennifer::Model::Translation do
-  describe "::human_attribute_name" do
+  test_class_instance = Spec::TestClassForTranslation.new
+
+  describe ".human_attribute_name" do
     context "when attributes has localization" do
       it { Contact.human_attribute_name(:id).should eq("tId") }
     end
@@ -17,11 +25,114 @@ describe Jennifer::Model::Translation do
     end
   end
 
-  describe "::human" do
+  describe ".human" do
     it { Contact.human.should eq("tContact") }
     it { FacebookProfile.human.should eq("Facebook profile") }
     it { Passport.human(1).should eq("Passport") }
     it { Passport.human(2).should eq("Many Passports") }
     it { Country.human(2).should eq("Countries") }
+  end
+
+  describe ".i18n_scope" do
+    it { Contact.i18n_scope.should eq(:models) }
+  end
+
+  describe ".i18n_key" do
+    it { Contact.i18n_key.should eq("contact") }
+    it { FacebookProfile.i18n_key.should eq("facebook_profile") }
+    it { Spec::TestClassForTranslation.i18n_key.should eq("test_class_for_translation") }
+  end
+
+  describe ".lookup_ancestors" do
+    it do
+      index = 0
+      FacebookProfile.lookup_ancestors do |klass|
+        klass.should eq(
+          case index
+          when 0
+            FacebookProfile
+          when 1
+            Profile
+          when 2
+            ApplicationRecord
+          when 3
+            Jennifer::Model::Base
+          else
+            fail "Invalid lookup ancestor class: #{klass}"
+          end
+        )
+        index += 1
+      end
+      index.should eq(4)
+    end
+
+    describe "non-model class" do
+      it do
+        executed = false
+        Spec::TestClassForTranslation.lookup_ancestors do |klass|
+          klass.should eq(Spec::TestClassForTranslation)
+          executed = true
+        end
+        executed.should be_true
+      end
+    end
+  end
+
+  describe "#lookup_ancestors" do
+    it do
+      index = 0
+      Factory.build_facebook_profile.lookup_ancestors do |klass|
+        klass.should eq(
+          case index
+          when 0
+            FacebookProfile
+          when 1
+            Profile
+          when 2
+            ApplicationRecord
+          when 3
+            Jennifer::Model::Base
+          else
+            fail "Invalid lookup ancestor class: #{klass}"
+          end
+        )
+        index += 1
+      end
+      index.should eq(4)
+    end
+
+    describe "non-model class" do
+      it do
+        executed = false
+        test_class_instance.lookup_ancestors do |klass|
+          klass.should eq(Spec::TestClassForTranslation)
+          executed = true
+        end
+        executed.should be_true
+      end
+    end
+  end
+
+  describe "#human_attribute_name" do
+    context "when attributes has localization" do
+      it { Factory.build_contact.human_attribute_name(:id).should eq("tId") }
+    end
+
+    context "when attributes have no localization" do
+      it { Factory.build_contact.human_attribute_name(:tags).should eq("Tags") }
+      it { Factory.build_contact.human_attribute_name(:created_at).should eq("Created at") }
+    end
+
+    context "when attributes defined by parent class" do
+      it { Factory.build_facebook_profile.human_attribute_name(:login).should eq("tLogin") }
+      it { Factory.build_twitter_profile.human_attribute_name(:login).should eq("phone") }
+    end
+
+    describe "non-model class" do
+      context "when attributes have no localization" do
+        it { test_class_instance.human_attribute_name(:tags).should eq("Tags") }
+        it { test_class_instance.human_attribute_name(:created_at).should eq("Created at") }
+      end
+    end
   end
 end

--- a/spec/query_builder/function_spec.cr
+++ b/spec/query_builder/function_spec.cr
@@ -126,6 +126,7 @@ describe Jennifer::QueryBuilder::Function do
       end
     end
 
+    # NOTE: next spec fails on high performance computers
     it do
       Factory.create_contact
       time = Time.now

--- a/src/jennifer/model/errors.cr
+++ b/src/jennifer/model/errors.cr
@@ -1,7 +1,36 @@
 module Jennifer
   module Model
+    # Container that you can include in your object for handling error messages.
+    #
+    # An example of a minimal implementation could be:
+    #
+    # ```
+    # class Post
+    #   include Jennifer::Model::Translation
+    #
+    #   property title : String?
+    #   getter errors
+    #
+    #   def initialize
+    #     @errors = Jennifer::Model::Errors.new(self)
+    #   end
+    #
+    #   def validate
+    #     errors.add(:title, :blank) if title.nil?
+    #   end
+    #
+    #   # The following method is needed to be minimally implemented
+    #
+    #   def self.superclass; end
+    # end
+    # ```
+    #
+    # The last method in the described class is required to be implemented to allow Jennifer::Model::Errors to
+    # correctly work with class translation lookup. `nil` return value presents that class has no lookup.
     class Errors
-      getter base : Base
+      # :nodoc:
+      getter base : Translation
+      # :nodoc:
       getter messages : Hash(Symbol, Array(String))
 
       def initialize(@base)
@@ -15,8 +44,7 @@ module Jennifer
         @base = other.@base
       end
 
-      # Returns `true` if the error messages include an error for the given key
-      # `attribute`, `false` otherwise.
+      # Returns whether error messages include an error for the given key `attribute`.
       def include?(attribute : Symbol)
         messages.has_key?(attribute) && messages[attribute].present?
       end

--- a/src/jennifer/model/resource.cr
+++ b/src/jennifer/model/resource.cr
@@ -29,7 +29,7 @@ module Jennifer
       end
 
       extend AbstractClassMethods
-      extend Translation
+      include Translation
       include Scoping
       include RelationDefinition
       include Macros


### PR DESCRIPTION
# What does this PR do?

Adds all needed changes to allow `Jennifer::Model::Errors` usage by non-model class.

# Any background context you want to provide?

This reduce coupling and provide possibility of functionality re-usage.

# Release notes

**Model**

* `Translation` model now is includeable module
* all class methods of `Translation` are moved to `Translation::ClassMethods` which is automatically extended by target class using `extended` macro
* `#lookup_ancestors` and `#human_attribute_name` methods of `Translation` are added
* `Errors#base` now is type of `Translation` instead of `Base`
