### PR TITLE
Add all internal model variables to JSON::Serializable ignore

### DIFF
--- a/src/jennifer/model/mapping.cr
+++ b/src/jennifer/model/mapping.cr
@@ -16,6 +16,7 @@ module Jennifer
       macro __field_declaration(properties, primary_auto_incrementable)
         {% for key, value in properties %}
           @{{key.id}} : {{value[:parsed_type].id}}
+          @[JSON::Field(ignore: true)]
           @{{key.id}}_changed = false
 
           {% if value[:setter] != false %}
@@ -186,7 +187,9 @@ module Jennifer
           COLUMNS_METADATA
         end
 
+        @[JSON::Field(ignore: true)]
         @new_record = true
+        @[JSON::Field(ignore: true)]
         @destroyed = false
 
         # Creates object from `DB::ResultSet`

--- a/src/jennifer/model/relation_definition.cr
+++ b/src/jennifer/model/relation_definition.cr
@@ -130,7 +130,9 @@ module Jennifer
             {{relation_class}}.new("{{name.id}}", {{foreign}}, {{primary}},
             {{klass}}.all{% if request %}.exec {{request}} {% end %})
           {% end %}
+        @[JSON::Field(ignore: true)]
         @{{name.id}} = [] of {{klass}}
+        @[JSON::Field(ignore: true)]
         @__{{name.id}}_retrieved = false
 
         private def set_{{name.id}}_relation(collection : Array)
@@ -257,7 +259,9 @@ module Jennifer
           end)
         end
 
+        @[JSON::Field(ignore: true)]
         @{{name.id}} = [] of {{klass}}
+        @[JSON::Field(ignore: true)]
         @__{{name.id}}_retrieved = false
 
         private def set_{{name.id}}_relation(object : Array)
@@ -420,7 +424,9 @@ module Jennifer
         {{"{% RELATION_NAMES << #{name.id.stringify} %}".id}}
         ::Jennifer::Model::RelationDefinition.declare_dependent({{name}}, {{dependent}}, :belongs_to, {{polymorphic}})
 
+        @[JSON::Field(ignore: true)]
         @{{name.id}} : {{klass}}?
+        @[JSON::Field(ignore: true)]
         @__{{name.id}}_retrieved = false
 
         def {{name.id}}
@@ -470,7 +476,7 @@ module Jennifer
           {% relation_class = "::Jennifer::Relation::BelongsTo(#{klass}, #{@type})".id %}
 
           RELATIONS["{{name.id}}"] =
-              {{relation_class}}.new("{{name.id}}", {{foreign}}, {{primary}}, {{klass}}.all{% if request %}.exec {{request}} {% end %})
+            {{relation_class}}.new("{{name.id}}", {{foreign}}, {{primary}}, {{klass}}.all{% if request %}.exec {{request}} {% end %})
 
           # :nodoc:
           def self.{{name.id}}_relation
@@ -545,7 +551,9 @@ module Jennifer
             {{klass}}.all{% if request %}.exec {{request}} {% end %})
           {% end %}
 
+        @[JSON::Field(ignore: true)]
         @{{name.id}} : {{klass}}?
+        @[JSON::Field(ignore: true)]
         @__{{name.id}}_retrieved = false
 
         private def set_{{name.id}}_relation(object)

--- a/src/jennifer/model/validation.cr
+++ b/src/jennifer/model/validation.cr
@@ -5,6 +5,9 @@ module Jennifer
     module Validation
       include Validations::Macros
 
+      @[JSON::Field(ignore: true)]
+      @errors : Errors?
+
       def errors
         @errors ||= Errors.new(self)
       end


### PR DESCRIPTION
# What does this PR do?

Fixes #190 

# Release notes

**Model**

* `@new_record`, `@destroyed`, `@errors`, changeset and relation attributes now is ignored by `JSON::Serializable`
