### PR TITLE
Enhance model authentication methods and related validations

### DIFF
--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -35,7 +35,7 @@ $ crystal sam.cr -- db:drop
 
 ### db:setup
 
-Creates database and invoke all pending migrations.
+Creates database, invokes all pending migrations and populate database with seeds.
 
 ```shell
 $ crystal sam.cr -- db:setup
@@ -84,6 +84,15 @@ Outputs current database version.
 
 ```shell
 $ crystal sam.cr -- db:version
+```
+
+### db:seed
+
+Populates database with seeds. By default this task is empty and should be defined per project
+bases.
+
+```shell
+$ crystal sam.cr -- db:seed
 ```
 
 ### db:schema:load

--- a/src/jennifer/model/authentication.cr
+++ b/src/jennifer/model/authentication.cr
@@ -16,26 +16,33 @@ module Jennifer
 
       # Adds methods to set and authenticate against a Crypto::Bcrypt password.
       # - `password` - password field name (default is `"password"`);
-      # - `password_hash` - password digest attribute name (default is `"password_digest"`).
-      macro with_authentication(password = "password", password_hash = "password_digest")
-        validates_length :{{password.id}}, in: PASSWORD_RANGE, allow_blank: true
-        validates_confirmation :{{password.id}}
-        validates_with_method :validate_{{password.id}}_presence
+      # - `password_hash` - password digest attribute name (default is `"password_digest"`);
+      # - `skip_validation` - whether validations shouldn't be generated (default is `false`).
+      macro with_authentication(password = "password", password_hash = "password_digest", skip_validation = false)
+        {% if !skip_validation %}
+          validates_length :{{password.id}}, in: PASSWORD_RANGE, allow_blank: true
+          validates_confirmation :{{password.id}}
+          validates_with_method :validate_{{password.id}}_presence
+        {% end %}
 
         def authenticate(given_password)
           self if Crypto::Bcrypt::Password.new({{password_hash.id}}) == given_password
         end
 
-        def {{password.id}}=(unencrypted_password)
+        def {{password.id}}=(unencrypted_password : String)
           @{{password.id}} = unencrypted_password
-          if unencrypted_password.nil? || unencrypted_password.empty? || !PASSWORD_RANGE.includes?(unencrypted_password.not_nil!.size)
-            self.{{password_hash.id}} = ""
+          if unencrypted_password.empty? || !PASSWORD_RANGE.includes?(unencrypted_password.size)
+            self.{{password.id}} = nil
           else
             self.{{password_hash.id}} = Crypto::Bcrypt::Password.create(
-              unencrypted_password.not_nil!,
+              unencrypted_password,
               cost: self.class.{{password_hash.id}}_cost
             ).to_s
           end
+        end
+
+        def {{password.id}}=(unencrypted_password : Nil)
+          self.{{password_hash.id}} = ""
         end
 
         def self.{{password_hash.id}}_cost

--- a/src/jennifer/sam.cr
+++ b/src/jennifer/sam.cr
@@ -36,8 +36,12 @@ Sam.namespace "db" do
     Jennifer::Migration::Runner.create
   end
 
-  desc "Runs db:create and db:migrate"
-  task "setup", ["create", "migrate"] do
+  desc "Populate database with default entities."
+  task "seed" do
+  end
+
+  desc "Runs db:create, db:migrate and db:seed"
+  task "setup", %w(create migrate seed) do
   end
 
   namespace "schema" do

--- a/src/jennifer/validations/macros.cr
+++ b/src/jennifer/validations/macros.cr
@@ -81,7 +81,13 @@ module Jennifer
 
         # :nodoc:
         def %validate_method
-          ::Jennifer::Validations::Uniqueness.instance.validate(self, {{field}}, {{field.id}}, {{allow_blank}}, self.class.where { _{{field.id}} == {{field.id}} })
+          ::Jennifer::Validations::Uniqueness.instance.validate(
+            self,
+            {{field}},
+            {{field.id}},
+            {{allow_blank}},
+            self.class.all.where { _{{field.id}} == {{field.id}} }
+          )
         end
       end
 
@@ -125,7 +131,8 @@ module Jennifer
         end
       end
 
-      # Encapsulates the pattern of wanting to validate the acceptance of a terms of service check box (or similar agreement)
+      # Encapsulates the pattern of wanting to validate the acceptance of a terms of service check
+      # box (or similar agreement).
       #
       # This check is performed only if *field* is not nil.
       macro validates_acceptance(field, accept = nil, if if_value = nil)
@@ -143,7 +150,14 @@ module Jennifer
 
         # :nodoc:
         def %validate_method
-          ::Jennifer::Validations::Confirmation.instance.validate(self, {{field}}, {{field.id}}, false, {{field.id}}_confirmation, {{case_sensitive}})
+          ::Jennifer::Validations::Confirmation.instance.validate(
+            self,
+            {{field}},
+            {{field.id}},
+            false,
+            {{field.id}}_confirmation,
+            {{case_sensitive}}
+          )
         end
       end
     end

--- a/src/jennifer/validations/uniqueness.cr
+++ b/src/jennifer/validations/uniqueness.cr
@@ -4,7 +4,7 @@ module Jennifer
       def validate(record, field : Symbol, value, allow_blank : Bool, query)
         with_blank_validation do
           _query = query.clone
-          _query = query.where { primary != record.primary } unless record.new_record?
+          _query.where { primary != record.primary } unless record.new_record?
 
           record.errors.add(field, :taken) if _query.exists?
         end


### PR DESCRIPTION
# What does this PR do?

- adjust authentication methods for the better integration with non-model classes
- make validations to explicitly use `Model#all` method

# Release notes

**General**

* add `db:seed` task as a placeholder seeding task
* `db:setup` now invokes `db:seed` after all `db:migrate`

**Model**

* add `skip_validation` argument to `Authentication.with_authentication` macro to specify whether validation should be added
