### PR TITLE
Allow grouping being passed to Join

### DIFF
--- a/spec/query_builder/join_spec.cr
+++ b/spec/query_builder/join_spec.cr
@@ -1,7 +1,19 @@
 require "../spec_helper"
 
 describe Jennifer::QueryBuilder::Join do
+  described_class = Jennifer::QueryBuilder::Join
   expression = Factory.build_expression
+
+  describe ".new" do
+    context "with Grouping" do
+      it do
+        q = Jennifer::QueryBuilder::Query["tests"]
+        condition = Factory.build_criteria(table: "t1") == 2
+        on_condition = Jennifer::QueryBuilder::Grouping.new(condition)
+        described_class.new(q, on_condition, :inner).on.should eq(on_condition.to_condition)
+      end
+    end
+  end
 
   describe "#as_sql" do
     it "includes table name" do

--- a/src/jennifer/query_builder/join.cr
+++ b/src/jennifer/query_builder/join.cr
@@ -13,6 +13,10 @@ module Jennifer
       def initialize(@table, @on : Condition | LogicOperator, @type, @aliass = nil, @relation = nil)
       end
 
+      def initialize(@table, on : Grouping, @type, @aliass = nil, @relation = nil)
+        @on = on.to_condition
+      end
+
       def table
         @table.is_a?(String) ? @table.as(String) : ""
       end


### PR DESCRIPTION
# What does this PR do?

`Jennifer::QueryBuilder::Join` now accepts `Grouping` as an `ON` section - it will be wrapped into `Condition`

# Release notes

**QueryBuilder**

* `Join` accepts `Grouping` for `ON` condition
