### PR TITLE
Allow model setter to accept DBAny

### DIFF
--- a/spec/model/mapping_spec.cr
+++ b/spec/model/mapping_spec.cr
@@ -362,6 +362,34 @@ describe Jennifer::Model::Mapping do
         c.name = "b"
         c.name.should eq("b")
       end
+
+      context "with DBAny" do
+        it do
+          hash = { :name => "new_name" } of Symbol => Jennifer::DBAny
+          c = Factory.build_contact(name: "a")
+          c.name = hash[:name]
+          c.name.should eq("new_name")
+        end
+      end
+
+      context "with subset of DBAny" do
+        it do
+          hash = { :name => "new_name", :age => 12 }
+          c = Factory.build_contact(name: "a")
+          c.name = hash[:name]
+          c.name.should eq("new_name")
+        end
+
+        context "with wrong type" do
+          it do
+            hash = { :name => "new_name", :age => 12 }
+            c = Factory.build_contact(name: "a")
+            expect_raises(TypeCastError) do
+              c.name = hash[:age]
+            end
+          end
+        end
+      end
     end
 
     describe "criteria attribute class shortcut" do

--- a/src/jennifer/model/mapping.cr
+++ b/src/jennifer/model/mapping.cr
@@ -26,6 +26,13 @@ module Jennifer
               {% end %}
               @{{key.id}} = _{{key.id}}
             end
+
+            def {{key.id}}=(_{{key.id}} : ::Jennifer::DBAny)
+              {% if !value[:virtual] %}
+                @{{key.id}}_changed = true if _{{key.id}} != @{{key.id}}
+              {% end %}
+              @{{key.id}} = _{{key.id}}.as({{value[:parsed_type].id}})
+            end
           {% end %}
 
           {% if value[:getter] != false %}


### PR DESCRIPTION
# What does this PR do?

Allow `Jennifer::Model::Base#attribute=` to accept not only defined type but also `Jennifer::DBAny`.

# Any background context you want to provide?

This was done to allow assignments of kind:

```crystal
hash = { :name => "name", :age => 99 }
user.name = hash[:name]
user.age = hash[:age]
```

# Release notes

**Model**

* allow `Jennifer::Model::Base#attribute=` to accept not only defined type but also `Jennifer::DBAny`