### PR TITLE
Rename Model#update_attributes to #set_attributes

### DIFF
--- a/docs/crud.md
+++ b/docs/crud.md
@@ -51,7 +51,7 @@ puts c1.age # 30
 There are several ways which allows to update object. Some of them were mentioned in mapping section. There are few extra methods to do this:
 - `#update_column(name, value)` - sets directly attribute and store it to db without any callback
 - `#update_columns(values)` - same for several ones
-- `#update_attributes(values)` - just set attributes
+- `#set_attributes(values)` - just set attributes
 - `#set_attribute(name, value)` - set attribute by given name
 
 You can provide hash or named tuple with new field values to update all records satisfying given conditions:

--- a/spec/model/base_spec.cr
+++ b/spec/model/base_spec.cr
@@ -614,18 +614,18 @@ describe Jennifer::Model::Base do
     end
   end
 
-  describe "#update_attributes" do
+  describe "#set_attributes" do
     context "when given attribute exists" do
       it "raises exception if value has wrong type" do
         c = Factory.build_contact
         expect_raises(::Jennifer::BaseException) do
-          c.update_attributes({:name => 123})
+          c.set_attributes({:name => 123})
         end
       end
 
       it "marks changed field as modified" do
         c = Factory.build_contact
-        c.update_attributes({"name" => "asd"})
+        c.set_attributes({"name" => "asd"})
         c.name.should eq("asd")
         c.name_changed?.should be_true
       end
@@ -635,7 +635,7 @@ describe Jennifer::Model::Base do
       it "raises exception" do
         c = Factory.build_contact
         expect_raises(::Jennifer::BaseException) do
-          c.update_attributes({:asd => 123})
+          c.set_attributes({:asd => 123})
         end
       end
     end
@@ -643,7 +643,7 @@ describe Jennifer::Model::Base do
     context "with named tuple" do
       it do
         c = Factory.build_contact
-        c.update_attributes({name: "asd"})
+        c.set_attributes({name: "asd"})
         c.name.should eq("asd")
       end
     end
@@ -651,13 +651,13 @@ describe Jennifer::Model::Base do
     context "with splatted named tuple" do
       it do
         c = Factory.build_contact
-        c.update_attributes(name: "asd")
+        c.set_attributes(name: "asd")
         c.name.should eq("asd")
       end
 
       it do
         subject = ModelWithIntName.build(name: 1)
-        subject.update_attributes(name: 2)
+        subject.set_attributes(name: 2)
         subject.name.should eq(2)
       end
     end

--- a/src/jennifer/model/base.cr
+++ b/src/jennifer/model/base.cr
@@ -208,8 +208,9 @@ module Jennifer
         attribute(name.to_s, raise_exception)
       end
 
+      # Sets attributes base on given *hash* and saves the object.
       def update(hash : Hash | NamedTuple)
-        update_attributes(hash)
+        set_attributes(hash)
         save
       end
 
@@ -217,8 +218,9 @@ module Jennifer
         update(opts)
       end
 
+      # Sets attributes base on given *hash* and saves the object (using `#save!`).
       def update!(hash : Hash | NamedTuple)
-        update_attributes(hash)
+        set_attributes(hash)
         save!
       end
 
@@ -226,12 +228,17 @@ module Jennifer
         update!(opts)
       end
 
-      def update_attributes(hash : Hash | NamedTuple)
+      # Sets attributes based on `hash` where keys are attribute names.
+      #
+      # ```
+      # post.set_attributes({ :title => "New Title", :created_at => Time.now })
+      # ```
+      def set_attributes(hash : Hash | NamedTuple)
         hash.each { |k, v| set_attribute(k, v) }
       end
 
-      def update_attributes(**opts)
-        update_attributes(opts)
+      def set_attributes(**opts)
+        set_attributes(opts)
       end
 
       # Sets *value* to field with name *name* and stores them directly to db without


### PR DESCRIPTION
# What does this PR do?

Renames `Model::Base#update_attributes` to `#set_attributes` as this method just sets values and doesn't perform saving (#198 ).

# Release notes

**Model**

* rename `Base#update_attributes` to `Base#set_attributes`
