### PR TITLE
Unify #parse_query usage by adapter and sql generator

### DIFF
--- a/docs/crud.md
+++ b/docs/crud.md
@@ -29,7 +29,7 @@ Contact.import(objects)
 
 #### Read
 
-Object could be retrieved by id using `#find` (returns `T?`) and `#find!` (returns `T` or raise `RecordNotFound` exception) methods.
+Object could be retrieved by id using `#find` (returns `T?`) and `#find!` (returns `T` or raises `RecordNotFound` exception) methods.
 
 ```crystal
 Contact.find!(1)

--- a/spec/adapter/base_spec.cr
+++ b/spec/adapter/base_spec.cr
@@ -299,18 +299,6 @@ describe Jennifer::Adapter::Base do
     end
   end
 
-  describe "::extract_arguments" do
-    res = described_class.extract_arguments({:asd => 1, "qwe" => "2"})
-
-    it "converts all field names to string" do
-      res[:fields].should eq(%w(asd qwe))
-    end
-
-    it "extracts all values to :args" do
-      res[:args].should eq(db_array(1, "2"))
-    end
-  end
-
   describe "#query_array" do
     it "returns array of given type" do
       Factory.create_contact

--- a/src/jennifer/adapter/postgres.cr
+++ b/src/jennifer/adapter/postgres.cr
@@ -209,19 +209,8 @@ module Jennifer
         ExecResult.new(id, affected)
       end
 
-      def self.bulk_insert(collection : Array(Model::Base))
-        opts = collection.flat_map(&.arguments_to_insert[:args])
-        # TODO: unify parse_query
-        query_opts = parse_query(sql_generator.bulk_insert(collection))
-        # TODO: change to checking for autoincrementability
-        affected = exec(qyery, opts).rows_affected
-        if affected != collection.size
-          raise ::Jennifer::BaseException.new("Bulk insert failed with #{collection.size - affected} records.")
-        end
-      end
-
       def exists?(query)
-        scalar(*sql_generator.exists(query))
+        scalar(*parse_query(sql_generator.exists(query), query.sql_args))
       end
     end
   end

--- a/src/jennifer/adapter/record.cr
+++ b/src/jennifer/adapter/record.cr
@@ -18,6 +18,7 @@ module Jennifer
       @attributes.keys
     end
 
+    # Alias for #attribute.
     def [](name : Symbol | String)
       attribute(name)
     end

--- a/src/jennifer/migration/table_builder/create_view.cr
+++ b/src/jennifer/migration/table_builder/create_view.cr
@@ -8,8 +8,6 @@ module Jennifer
           initialize(adapter, name)
         end
 
-        # TODO: move query generating to SqlGenerator class and make
-        # table builder classes to call executions by themselves
         def process
           schema_processor.create_view(@name, @query)
         end

--- a/src/jennifer/query_builder/criteria.cr
+++ b/src/jennifer/query_builder/criteria.cr
@@ -3,6 +3,8 @@ require "./order_item"
 
 module Jennifer
   module QueryBuilder
+    # Basic class describing table field.
+    #
     # TODO: rename to Criterion
     class Criteria < SQLNode
       alias Rightable = SQLNode | DBAny | Array(DBAny)

--- a/src/jennifer/query_builder/model_query.cr
+++ b/src/jennifer/query_builder/model_query.cr
@@ -88,8 +88,7 @@ module Jennifer
         add_preloaded(result)
       end
 
-      # TODO: brake this method to smaller ones
-      # Perform request and maps results set to objects and related objects grepping fields from joined tables; preloading also
+      # Perform request and maps resultset to objects and related objects grepping fields from joined tables; preloading also
       # are performed
       private def to_a_with_relations
         result = adapter.select(self) do |rs|

--- a/src/jennifer/relation/has_one.cr
+++ b/src/jennifer/relation/has_one.cr
@@ -10,7 +10,6 @@ module Jennifer
         super
       end
 
-      # TODO: find way to update exactly one record, not all
       def remove(obj : Q)
         this = self
         _pf = obj.attribute(primary_field)


### PR DESCRIPTION
# What does this PR do?

- unify `#parse_query` method by adapter and sql generator - sql generator returns only string of SQL
- all `_query` arguments in `Adapter::Base` methods renamed to `query`

# Release notes

**Adapter**

* all `_query` arguments in `Base` methods are renamed to `query`
* `Base.extract_arguments` is removed
* `.delete`, `.exists` and `.count` of `BaseSQLGenerator` now returns string
* `Postgres.bulk_insert` is removed
