### PR TITLE
Make message of RecordNotFound more descriptive

### DIFF
--- a/spec/query_builder/executables_spec.cr
+++ b/spec/query_builder/executables_spec.cr
@@ -27,8 +27,10 @@ describe Jennifer::QueryBuilder::Executables do
     end
 
     it "raises error if there is no such records" do
-      expect_raises(Jennifer::RecordNotFound) do
-        Contact.all.first!
+      arg = db_specific(mysql: -> { "?" }, postgres: -> { "$1" })
+      message = "There is no record by given query:\nSELECT contacts.* FROM contacts WHERE contacts.id > #{arg}  | [2]"
+      expect_raises(Jennifer::RecordNotFound, message) do
+        Contact.all.where { _id > 2 }.first!
       end
     end
   end

--- a/src/jennifer/adapter/request_methods.cr
+++ b/src/jennifer/adapter/request_methods.cr
@@ -51,7 +51,7 @@ module Jennifer
         result
       end
 
-      def pluck(query, field)
+      def pluck(query, field : String | Symbol)
         result = [] of DBAny
         fields = [field.to_s]
         body = sql_generator.select(query, fields)

--- a/src/jennifer/config.cr
+++ b/src/jennifer/config.cr
@@ -197,10 +197,7 @@ module Jennifer
     def self.migration_failure_handler_method=(value)
       parsed_value = value.to_s
       unless ALLOWED_MIGRATION_FAILURE_HANDLER_METHODS.includes?(parsed_value)
-        allowed_methods = ALLOWED_MIGRATION_FAILURE_HANDLER_METHODS.map { |e| %("#{e}") }.join(" ")
-        raise Jennifer::InvalidConfig.new(
-          %(migration_failure_handler_method config may be only #{allowed_methods})
-        )
+        raise Jennifer::InvalidConfig.bad_migration_failure_handler(ALLOWED_MIGRATION_FAILURE_HANDLER_METHODS)
       end
       @@migration_failure_handler_method = parsed_value
     end
@@ -299,8 +296,8 @@ module Jennifer
     end
 
     protected def validate_config
-      raise Jennifer::InvalidConfig.new("No adapter configured") if adapter.empty?
-      raise Jennifer::InvalidConfig.new("No database configured") if db.empty?
+      raise Jennifer::InvalidConfig.bad_adapter if adapter.empty?
+      raise Jennifer::InvalidConfig.bad_database if db.empty?
       if max_idle_pool_size != max_pool_size || max_pool_size != initial_pool_size
         logger.warn("It is highly recommended to set max_idle_pool_size = max_pool_size = initial_pool_size to "\
                     "prevent blowing up count of DB connections. For any details take a look at "\

--- a/src/jennifer/model/base.cr
+++ b/src/jennifer/model/base.cr
@@ -247,11 +247,15 @@ module Jennifer
         update_columns({name => value})
       end
 
+      # Saves record or raises RecordInvalid exception.
       def save!(skip_validation : Bool = false)
         raise Jennifer::RecordInvalid.new(errors.to_a) unless save(skip_validation)
         true
       end
 
+      # Saves record.
+      #
+      # *skip_validation* allows to skip validation for current invocation.
       def save(skip_validation : Bool = false) : Bool
         unless self.class.adapter.under_transaction?
           self.class.transaction do
@@ -337,22 +341,28 @@ module Jennifer
         adapter.with_table_lock(table_name, type.to_s) { |t| yield t }
       end
 
+      # Returns record by given primary field.
       def self.find(id)
         _id = id
         this = self
         all.where { this.primary == _id }.first
       end
 
+      # Returns record by given primary field or raises RecordNotFound exception.
       def self.find!(id)
         _id = id
         this = self
         all.where { this.primary == _id }.first!
       end
 
+      # Destroys records by given ids.
+      #
+      # All `destroy` callbacks will be invoked for each record. All records are loaded in batches.
       def self.destroy(*ids)
         destroy(ids.to_a)
       end
 
+      # ditto
       def self.destroy(ids : Array)
         _ids = ids
         all.where do
@@ -364,10 +374,12 @@ module Jennifer
         end.destroy
       end
 
+      # Deletes records by given ids.
       def self.delete(*ids)
         delete(ids.to_a)
       end
 
+      # ditto
       def self.delete(ids : Array)
         _ids = ids
         all.where do
@@ -379,6 +391,7 @@ module Jennifer
         end.delete
       end
 
+      # Performs bulk import of given collection.
       def self.import(collection : Array(self))
         adapter.bulk_insert(collection)
       end

--- a/src/jennifer/query_builder/executables.cr
+++ b/src/jennifer/query_builder/executables.cr
@@ -24,7 +24,7 @@ module Jennifer
         result = to_a
         reverse_order
         @limit = old_limit
-        raise RecordNotFound.new(adapter.sql_generator.select(self)) if result.empty?
+        raise RecordNotFound.from_query(self, adapter) if result.empty?
         result[0]
       end
 
@@ -46,7 +46,7 @@ module Jennifer
         old_limit = @limit
         result = to_a
         @limit = old_limit
-        raise RecordNotFound.new(adapter.sql_generator.select(self)) if result.empty?
+        raise RecordNotFound.from_query(self, adapter) if result.empty?
         result[0]
       end
 
@@ -240,14 +240,14 @@ module Jennifer
         end
       end
 
-      def find_each(batch_size : Int32 = 1000, start : Int32 = 0, direction : String | Symbol = "asc", &block)
-        find_in_batches(batch_size, start) do |records|
+      def find_each(primary_key : String, batch_size : Int32 = 1000, start = nil, direction : String | Symbol = "asc", &block)
+        find_in_batches(primary_key, batch_size, start, direction) do |records|
           records.each { |rec| yield rec }
         end
       end
 
-      def find_each(primary_key : String, batch_size : Int32 = 1000, start = nil, direction : String | Symbol = "asc", &block)
-        find_in_batches(primary_key, batch_size, start, direction) do |records|
+      def find_each(batch_size : Int32 = 1000, start : Int32 = 0, direction : String | Symbol = "asc", &block)
+        find_in_batches(batch_size, start) do |records|
           records.each { |rec| yield rec }
         end
       end


### PR DESCRIPTION
# What does this PR do?

Make message of `RecordNotFound` more descriptive

# Release notes

**Exceptions**

* 'RecordNotFound' from `QueryBuilder::Query#first!` and `QueryBuilder::Query#last!` includes detailed parsed query 
