### PR TITLE
Fix migrating column changing logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,7 @@
 **Config**
 
 * fix `migration_failure_handler_method` property from being global
-* add new property `model_files_path` representing model directory (is used in a scope of model generating)
+* add new property `model_files_path` presenting model directory (is used in a scope of model generating)
 * fix ignoring `skip_dumping_schema_sql` config
 
 **SqlGenerator**
@@ -362,7 +362,7 @@
 
 **Exceptions**
 
-* add `AbstractMethod` exception which represents expectation of overriding current method by parents (is useful when method can't be real abstract one)
+* add `AbstractMethod` exception which presents expectation of overriding current method by parents (is useful when method can't be real abstract one)
 * add `UnknownSTIType`
 
 ## 0.4.2 (24-11-2017)
@@ -470,7 +470,7 @@
 * `Query#order` realize same idea as with `Query#select` but with hashes
 * added `Criteria#alias` method which allows to alias field in the `SELECT` clause
 * `ExpressionBuilder#star` creates "all" attribute; allows optional argument specifying table name
-* `RawSql` now has `@use_brakets` attribute representing if sql statement should be surrounded by brackets
+* `RawSql` now has `@use_brakets` attribute presenting whether sql statement should be surrounded by brackets
 * `Criteria#sql` method now accepts `use_brackets` argument which is passed to `RawSql`
 
 **Migration**

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ dependencies:
 
 ### Requirements
 
-- you need to choose one of existing adapters for your db: [mysql](https://github.com/crystal-lang/crystal-mysql) or [postgres](https://github.com/will/crystal-pg);
-- crystal `>= 0.26.1`
+- you need to choose one of existing drivers for your db: [mysql](https://github.com/crystal-lang/crystal-mysql) or [postgres](https://github.com/will/crystal-pg); sqlite3 adapter automatically installs required driver for itself;
+- crystal `>= 0.26.1`.
 
 ## Usage
 
@@ -123,10 +123,6 @@ Contact.all.group(:gender).group_avg(:age, PG::Numeric)
 ```
 
 Much more about the query DSL can be found on the wiki [page](./docs/query_dsl.md).
-
-### SQLite Support
-
-SQLite3 has many limitations so adding its support isn't a very easy task, but it is still important to Jennifer.
 
 ### Versioning
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -34,8 +34,8 @@ Mapping automatically resolves it to it's definition. At the moment only top lev
 
 For authentication `Crypto::Bcrypt::Password` is used. This mechanism requires you to have a `password_digest`, `password`, `password_confirmation` attributes defined in your mapping. This attribute can be customized - `with_authentication` macro accepts next arguments:
 
-- `password` - represents string based raw password attribute name;
-- `password_digest` - represents string based encrypted password.
+- `password` - presents string based raw password attribute name;
+- `password_digest` - presents string based encrypted password.
 
 > NOTE: `password_confirmation` attribute name is generated based on the `password` value + `_confirmation`.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,13 +10,15 @@ require "jennifer/adapter/postgres" # for postgres
 
 > Be attentive - adapter should be required **after** main staff. From `0.5.0` several adapters could be required at the same time.
 
+[SQLite3](https://github.com/imdrasil/jennifer_sqlite3_adapter) adapter is in a separate shard.
+
 This should be done before you load your application configurations (or at least models). Now configuration could be loaded from yaml file:
 
 ```crystal
 Jennifer::Config.read("./spec/fixtures/database.yml", :development)
 ```
 
-Second argument represents environment and just use it as namespace key grepping values from yml.
+Second argument presents environment and just use it as namespace key grepping values from yml.
 
 ```yaml
 defaults : &defaults

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -28,7 +28,7 @@ create_table(:addresses) do |t|
 end
 ```
 
-There are next methods which represents corresponding types:
+There are next methods which presents corresponding types:
 
 | Method | PostgreSQL | MySql | Crystal type |
 | --- | --- | --- | --- |
@@ -76,7 +76,7 @@ Also if you use postgres array types are available as well: `Array(Int32)`, `Arr
 All those methods accepts additional options:
 
 - `:sql_type` - gets exact (except size) field type;
-- `:null` - represent nullable if field (by default is `false` for all types and field);
+- `:null` - present nullable if field (by default is `false` for all types and field);
 - `:primary` - marks field as primary key field (could be several ones but this provides some bugs with query generation for such model - for now try to avoid this).
 - `:default` - default value for field
 - `:auto_increment` - marks field to use auto increment (properly works only with `Int32` fields, another crystal types have cut functionality for it);

--- a/docs/model_mapping.md
+++ b/docs/model_mapping.md
@@ -142,7 +142,7 @@ If you don't want to define all the table fields - pass `false` as second argume
 | `::field_count`| | number of fields |
 | `::field_names`| | all fields names |
 | `#{{field_name}}` | | getter |
-| `#{{field_name}}_changed?` | | represents if field is changed |
+| `#{{field_name}}_changed?` | | presents whether field is changed |
 | `#{{field_name}}!` | | getter with `not_nil!` if `null: true` was passed |
 | `#{{field_name}}=`| | setter |
 | `::_{{field_name}}` | | helper method for building queries |

--- a/docs/query_dsl.md
+++ b/docs/query_dsl.md
@@ -10,7 +10,7 @@ My favorite part. Jennifer allows you to build lazy evaluated queries with chain
 Contact.all
 ```
 
-Specifying where clause is really flexible. Method accepts block which represents where clause of request (or it's part - you can chain several `#where` and they will be concatenated using `AND`).
+Specifying where clause is really flexible. Method accepts block which presents `WHERE` clause of request (or it's part - you can chain several `#where` and they will be concatenated using `AND`).
 
 To specify field use `#c` method which accepts string as field name. As I've mentioned after declaring model attributes, you can use their names inside of block: `_field_name` if it is for current table and `ModelName._field_name` if for another model. Also there you can specify attribute of some model or table using underscores: `_some_model_or_table_name__field_name` - model/table name is separated from field name by "__". You can specify relation in space of which you want to declare condition using double `_` at the beginning and block. Several examples:
 
@@ -110,7 +110,7 @@ where { _field_name.take(1) }
 
 ### Tips
 
-* all regexp methods accepts string representation of regexp;
+* all regexp methods accepts string presentation of regexp;
 * use parenthesis with binary operators (`&` and `|`);
 * `nil` given to `!=` and `==` will be transformed to `IS NOT NULL` and `IS NULL`;
 * `is` and `not` operator accepts next values: `nil`, `:unknown`, `true` and `false`;

--- a/docs/relations.md
+++ b/docs/relations.md
@@ -58,7 +58,7 @@ Also `mas_many`, `belongs_to` and `has_one` relations have `dependent` parameter
 
 ## Inverse of
 
-`has_many` and `has_one` relations also accepts `inverse_of` option which represents inverse relation name. Specifying this option will automatically load owner object during any relation loading (because of `ModelQuery#includes` or `ModelQuery#eager_load` or even plaint `SomeModel#relation_name` method call).
+`has_many` and `has_one` relations also accepts `inverse_of` option which presents inverse relation name. Specifying this option will automatically load owner object during any relation loading (because of `ModelQuery#includes` or `ModelQuery#eager_load` or even plaint `SomeModel#relation_name` method call).
 
 ## Polymorphic Relations
 

--- a/spec/query_builder/condition_spec.cr
+++ b/spec/query_builder/condition_spec.cr
@@ -6,7 +6,7 @@ describe Jennifer::QueryBuilder::Condition do
   describe "#as_sql" do
     {% for op in [:<, :>, :<=, :>=, :!=] %}
       context "{{op.id}} operator" do
-        it "returns string representation" do
+        it "returns string presentation" do
           Factory.build_criteria.{{op.id}}("asd").as_sql.should eq("tests.f1 {{op.id}} %s")
         end
       end

--- a/spec/query_builder/query_spec.cr
+++ b/spec/query_builder/query_spec.cr
@@ -4,7 +4,7 @@ describe Jennifer::QueryBuilder::Query do
   described_class = Jennifer::QueryBuilder::Query
 
   describe "#as_sql" do
-    it "returns sql representation of condition" do
+    it "returns sql presentation of condition" do
       q = Factory.build_query
       c = Factory.build_criteria
       q.where { c }.as_sql.should eq("SELECT tests.* FROM tests WHERE tests.f1 ")

--- a/src/jennifer/adapter/mysql/schema_processor.cr
+++ b/src/jennifer/adapter/mysql/schema_processor.cr
@@ -37,15 +37,12 @@ module Jennifer
           io << ") "
         end
         if options.has_key?(:null)
-          if options[:null]
-            io << " NULL"
-          else
-            io << " NOT NULL"
-          end
+          io << " NOT" unless options[:null]
+          io << " NULL"
         end
-        io << " PRIMARY KEY" if options[:primary]?
-        io << " DEFAULT #{adapter_class.t(options[:default])}" if options[:default]?
-        io << " AUTO_INCREMENT" if options[:auto_increment]?
+        io << " PRIMARY KEY" if options.has_key?(:primary) && options[:primary]
+        io << " DEFAULT #{adapter_class.t(options[:default])}" if options.has_key?(:default)
+        io << " AUTO_INCREMENT" if options.has_key?(:auto_increment) && options[:auto_increment]
       end
     end
   end

--- a/src/jennifer/adapter/postgres/schema_processor.cr
+++ b/src/jennifer/adapter/postgres/schema_processor.cr
@@ -88,7 +88,7 @@ module Jennifer
             s << opts[:null] ? " DROP" : " SET"
             s << " NOT NULL,"
           end
-          if opts[:default]?
+          if opts.has_key?(:default)
             s << column_name_part
             if opts[:default].is_a?(Symbol) && opts[:default].as(Symbol) == :drop
               s << "DROP DEFAULT "
@@ -110,14 +110,11 @@ module Jennifer
         io << name
         column_type_definition(options, io)
         if options.has_key?(:null)
-          if options[:null]
-            io << " NULL"
-          else
-            io << " NOT NULL"
-          end
+          io << " NOT" unless options[:null]
+          io << " NULL"
         end
-        io << " PRIMARY KEY" if options[:primary]?
-        io << " DEFAULT #{adapter_class.t(options[:default])}" if options[:default]?
+        io << " PRIMARY KEY" if options.has_key?(:primary) && options[:primary]
+        io << " DEFAULT #{adapter_class.t(options[:default])}" if options.has_key?(:default)
       end
 
       private def column_type_definition(options, io)

--- a/src/jennifer/migration/table_builder/base.cr
+++ b/src/jennifer/migration/table_builder/base.cr
@@ -3,7 +3,7 @@ module Jennifer
     module TableBuilder
       abstract class Base
         # Base allowed types for migration DSL option values
-        alias AllowedTypes = String | Int32 | Bool | Float32 | Nil
+        alias AllowedTypes = String | Int32 | Bool | Float32 | Float64 | JSON::Any | Nil
         # Allowed types for migration DSL + Symbol
         alias EAllowedTypes = AllowedTypes | Symbol
         # Allowed types for migration DSL including array
@@ -13,17 +13,11 @@ module Jennifer
 
         delegate schema_processor, table_exists?, index_exists?, column_exists?, to: adapter
 
-        getter adapter : Adapter::Base
-
-        @name : String
+        getter adapter : Adapter::Base, name : String
 
         def initialize(@adapter, name : String | Symbol)
           @name = name.to_s
           @commands = [] of Base
-        end
-
-        def name
-          @name.to_s
         end
 
         abstract def process

--- a/src/jennifer/model/base.cr
+++ b/src/jennifer/model/base.cr
@@ -34,7 +34,8 @@ module Jennifer
         @@has_table
       end
 
-      # Represent actual amount of model's table column amount (is grepped from db).
+      # Returns actual model table column amount (is grepped from db).
+      #
       # If somewhy you define model with custom table name after the place where adapter is used the first time -
       # manually invoke this method anywhere after table name definition.
       def self.actual_table_field_count

--- a/src/jennifer/model/scoping.cr
+++ b/src/jennifer/model/scoping.cr
@@ -3,7 +3,7 @@ module Jennifer
     module Scoping
       # Adds a class method for retrieving and querying objects.
       #
-      # A `.scope` represents a narrowing of a database query, such as
+      # A `.scope` presents a narrowing of a database query, such as
       # `where { _color == "red" }.includes(:washing_instructions)`.
       #
       # ```
@@ -42,7 +42,7 @@ module Jennifer
 
       # Adds a class method for retrieving and querying objects.
       #
-      # A `.scope` represents a narrowing of a database query, such as `where { _color == "red" }.includes(:washing_instructions)`.
+      # A `.scope` presents a narrowing of a database query, such as `where { _color == "red" }.includes(:washing_instructions)`.
       #
       # ```
       # class Shirt < Jennifer::Model::Base

--- a/src/jennifer/model/translation.cr
+++ b/src/jennifer/model/translation.cr
@@ -41,7 +41,7 @@ module Jennifer
           :models
         end
 
-        # Represents key which be used to search any related to current class localization information.
+        # Presents key which be used to search any related to current class localization information.
         def i18n_key
           return @@i18n_key unless @@i18n_key.empty?
           @@i18n_key = Inflector.underscore(Inflector.demodulize(to_s)).downcase

--- a/src/jennifer/query_builder/nested_relation_tree.cr
+++ b/src/jennifer/query_builder/nested_relation_tree.cr
@@ -28,7 +28,7 @@ module Jennifer
 
         # All relations model classes
         models = @bucket.map { |e| e[1].model_class }
-        # Represents found relation primary keys for i-th relation primary key
+        # Presents found relation primary keys for i-th relation primary key
         existence = @bucket.map { |_| {} of DBAny => Set(DBAny) }
         # Stores all found relation records for i-th relation
         repo = @bucket.map { |_| {} of DBAny => Model::Resource }

--- a/src/jennifer/query_builder/relation_tree.cr
+++ b/src/jennifer/query_builder/relation_tree.cr
@@ -4,7 +4,7 @@ require "set"
 module Jennifer
   module QueryBuilder
     abstract class RelationTree
-      # First tuple component represent index of parent context; 0 value represent top level collection, any positive value *i* -
+      # First tuple component present index of parent context; 0 value present top level collection, any positive value *i* -
       # *i*-th relation in ~bucket~ (with 1-based indexing).
       alias Element = Tuple(Int32, Relation::IRelation)
 


### PR DESCRIPTION
# What does this PR do?

- minor fixes in migration logic
- documentation wording fixes

# Release notes

**Adapter**

* `Mysql::SchemaProcessor` now respects `false` as column default value
* `Postgres::SchemaProcessor` now respects `false` as column default value

**Migration**

* `TableBuilder::Base::AllowedTypes` alias includes `Float64` and `JSON::Any`
