### PR TITLE
Revise #none

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,7 +4,7 @@ version: 0.7.0
 authors:
   - Roman Kalnytskyi <moranibaca@gmail.com>
 
-crystal: 0.26.1
+crystal: 0.27.2
 
 license: MIT
 

--- a/spec/query_builder/executables_spec.cr
+++ b/spec/query_builder/executables_spec.cr
@@ -124,17 +124,9 @@ describe Jennifer::QueryBuilder::Executables do
 
     it "returns false if there is no such object with given condition" do
       Factory.create_contact(name: "Anton")
-      described_class.new("contacts").where { _name == "Jhon" }.exists?.should be_false
+      described_class.new("contacts").where { _name == "Abraham" }.exists?.should be_false
     end
   end
-
-  # describe "#modify" do
-  #   it "performs provided operations" do
-  #     c = Factory.create_contact(age: 13)
-  #     Contact.all.modify({:age => {value: 2, operator: :+}})
-  #     c.reload.age.should eq(15)
-  #   end
-  # end
 
   describe "#update" do
     it "updates given fields in all matched rows" do
@@ -397,10 +389,22 @@ describe Jennifer::QueryBuilder::Executables do
       Factory.create_contact
       res = Query["contacts"].find_records_by_sql(query)
       res.size.should eq(1)
-      res[0].id.nil?.should be_false
+      res[0].name.should eq("Deepthi")
     end
 
-    it "respects none method" do
+    it "accepts arguments" do
+      Factory.create_contact(age: 21)
+      Factory.create_contact(age: 20)
+      placeholder = db_specific(postgres: -> { "$1" }, mysql: -> { "?" })
+      res = Query["contacts"].find_records_by_sql(
+        "SELECT * FROM contacts WHERE age > #{placeholder}",
+        [20]
+      )
+      res.size.should eq(1)
+      res[0].age.should eq(21)
+    end
+
+    it "respects #none" do
       Factory.create_contact
       res = Query["contacts"].none.find_records_by_sql(query)
       res.size.should eq(0)

--- a/spec/query_builder/query_spec.cr
+++ b/spec/query_builder/query_spec.cr
@@ -409,4 +409,89 @@ describe Jennifer::QueryBuilder::Query do
     it { clone.as_sql.should match(/UNION/) }
     it { clone._select_fields[0].should_not be_a(Jennifer::QueryBuilder::Star) }
   end
+
+  describe "#none" do
+    context "when is used alongside with #pluck" do
+      it "returns nothing when a single column is plucked" do
+        expect_query_silence do
+          Query["contacts"].none.pluck(:id).should be_empty
+        end
+      end
+
+      it "returns nothing when multiple columns are plucked" do
+        expect_query_silence do
+          Query["contacts"].none.pluck(%i(id name)).should be_empty
+        end
+      end
+    end
+
+    context "when is used alongside with #delete" do
+      it "deletes nothing" do
+        expect_query_silence do
+          Query["contacts"].none.delete
+        end
+      end
+    end
+
+    context "when is used alongside with #exists?" do
+      it "returns false without hitting the db" do
+        expect_query_silence do
+          Query["contacts"].none.exists?.should be_false
+        end
+      end
+    end
+
+    context "when is used alongside with #update" do
+      context "when block is given" do
+        it "updates nothing" do
+          expect_query_silence do
+            block_is_executed = false
+            Query["contacts"].none.update { block_is_executed = true; { :age => _age + 10 } }
+            block_is_executed.should be_true
+          end
+        end
+      end
+
+      context "when arguments is passed as hash" do
+        it "updates nothing" do
+          expect_query_silence do
+            Query["contacts"].none.update({ :age => 40 })
+          end
+        end
+      end
+    end
+
+    context "when is used alongside with #db_results" do
+      it "returns empty array" do
+        expect_query_silence do
+          Query["contacts"].none.db_results.should be_empty
+        end
+      end
+    end
+
+    context "when is used alongside with #results" do
+      it "returns empty array" do
+        expect_query_silence do
+          Query["contacts"].none.results.should be_empty
+        end
+      end
+    end
+
+    context "when is used alongside with #each_result_set" do
+      it do
+        expect_query_silence do
+          Query["contacts"].none.each_result_set do
+          end
+        end
+      end
+    end
+
+    context "when is used alongside with #find_records_by_sql" do
+      it "return empty array" do
+        expect_query_silence do
+          Query["contacts"].none.find_records_by_sql("INVALID SQL").should be_empty
+        end
+      end
+    end
+  end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -22,11 +22,11 @@ require "./support/*"
 Spec.before_each do
   Jennifer::Adapter.adapter.begin_transaction
   set_default_configuration
+  Spec.logger.clear
 end
 
 Spec.after_each do
   Jennifer::Adapter.adapter.rollback_transaction
-  Spec.logger.clear
   Spec.file_system.clean
 end
 

--- a/src/jennifer/query_builder/i_model_query.cr
+++ b/src/jennifer/query_builder/i_model_query.cr
@@ -25,10 +25,35 @@ module Jennifer
         model_class.relation(name.to_s).join_condition(self, type)
       end
 
+      # Yields each batch of records that was found by the specified query.
+      #
+      # ```
+      # Contact.all.where { _age > 21 }.find_in_batches do |batch|
+      #   batch.each do |contact|
+      #     puts contact.id
+      #   end
+      # end
+      # ```
+      #
+      # To get each record one by one use #find_each instead.
+      #
+      # NOTE: any given ordering will be ignored and query will be reordered based on the
+      # *primary_key* and *direction*.
       def find_in_batches(batch_size : Int32 = 1000, start = nil, direction : String | Symbol = "asc", &block)
         super(model_class.primary, batch_size, start, direction) { |records| yield records }
       end
 
+      # Yields each record in batches from #find_in_batches.
+      #
+      # Looping through a collection of records from the database is very inefficient since it will instantiate all the objects
+      # at once. In that case batch processing methods allow you to work with the records
+      # in batches, thereby greatly reducing memory consumption.
+      #
+      # ```
+      # Contact.all.where { _age > 21 }.find_each do |contact|
+      #   puts contact.id
+      # end
+      # ```
       def find_each(batch_size : Int32 = 1000, start = nil, direction : String | Symbol = "asc", &block)
         super(model_class.primary, batch_size, start, direction) { |record| yield record }
       end
@@ -43,6 +68,7 @@ module Jennifer
         find_each(&.update(options))
       end
 
+      # ditto
       def patch(**opts)
         patch(opts)
       end

--- a/src/jennifer/query_builder/model_query.cr
+++ b/src/jennifer/query_builder/model_query.cr
@@ -55,7 +55,7 @@ module Jennifer
       # related records using `#preload` method nad respects `#none`
       def find_by_sql(query : String, args : Array(DBAny) = [] of DBAny)
         results = [] of T
-        return results if @do_nothing
+        return results if do_nothing?
         adapter.query(query, args) do |rs|
           begin
             rs.each do
@@ -71,7 +71,7 @@ module Jennifer
 
       # Executes request and maps result set to objects with loading any requested related objects
       def to_a
-        return [] of T if @do_nothing
+        return [] of T if do_nothing?
         add_aliases if @relation_used
         return to_a_with_relations if @eager_load
         result = [] of T


### PR DESCRIPTION
# What does this PR do?

Make all executable methods respect `Jennifer::QueryBuilder::Query#none`; fix #215.

# Release notes

**QueryBuilder**

* `#pluck`, `#update`, `#db_results`, `#results`. `#each_result_set` and `#find_in_batches`of `Query` respects `#none` (returns empty result if it has being called)
