### PR TITLE
Bump to 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 ## Future release (__-__-2019)
 
+## 0.7.1 (09-02-2019)
+
+**QueryBuilder**
+
+* `#pluck`, `#update`, `#db_results`, `#results`. `#each_result_set` and `#find_in_batches`of `Query` respects `#none` (returns empty result if it has being called)
+* remove deprecated `QueryObject` constructor accepting array of options and `#params`
+
+**Model**
+
+* fix mapping issue when all `Generic`s are assumed as unions (#208)
+
+**Validation**
+
+* allow passing multiple fields to `.validates_uniqueness` to validate combination uniqueness
+
+**Adapter**
+
+* `Mysql::SchemaProcessor` now respects `false` as column default value
+* `Postgres::SchemaProcessor` now respects `false` as column default value
+
+**Config**
+
+* introduce new configuration `pool_size` which sets `max_idle_pool_size = max_pool_size = initial_pool_size` to the given value; getter `#pool_size` returns `#max_pool_size`
+* `postgres` is no more default adapter
+
+**Migration**
+
+* `TableBuilder::Base::AllowedTypes` alias includes `Float64` and `JSON::Any`
+
 ## 0.7.0 (08-01-2019)
 
 **General**

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add this to your application's `shard.yml`:
 dependencies:
   jennifer:
     github: imdrasil/jennifer.cr
-    version: "~> 0.7.0"
+    version: "~> 0.7.1"
 ```
 
 ### Requirements

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: jennifer
-version: 0.7.0
+version: 0.7.1
 
 authors:
   - Roman Kalnytskyi <moranibaca@gmail.com>

--- a/src/jennifer.cr
+++ b/src/jennifer.cr
@@ -21,7 +21,7 @@ require "./jennifer/view/base"
 require "./jennifer/migration/*"
 
 module Jennifer
-  VERSION = "0.7.0"
+  VERSION = "0.7.1"
 
   {% if Jennifer.constant("AFTER_LOAD_SCRIPT") == nil %}
     # :nodoc:

--- a/src/jennifer/query_builder/query_object.cr
+++ b/src/jennifer/query_builder/query_object.cr
@@ -19,9 +19,7 @@ module Jennifer
     #   end
     #
     #   private def article_order
-    #     article_order = Article.c(params["field"].as(String))
-    #     article_order.direction = params["order"].as(String)
-    #     article_order
+    #     Article.c(field).tap { |article_order| article_order.direction = order }
     #   end
     # end
     #
@@ -29,19 +27,13 @@ module Jennifer
     #   # ...
     #   scope :ordered, OrderedArticlesQuery
     # end
+    #
+    # Article.all.ordered("by_date", "desc")
     # ```
     abstract class QueryObject
-      getter relation : ::Jennifer::QueryBuilder::IModelQuery, params : Array(Jennifer::DBAny)
+      getter relation : ::Jennifer::QueryBuilder::IModelQuery
 
       def initialize(@relation)
-        @params = [] of Jennifer::DBAny
-      end
-
-      # Creates QueryObject based on given *relation* and *options*.
-      #
-      # NOTE: deprecated - will be removed in 0.7.0.
-      def initialize(@relation, *options)
-        @params = Ifrit.typed_array_cast(options, Jennifer::DBAny)
       end
 
       abstract def call


### PR DESCRIPTION
# What does this PR do?

Bump version to `0.7.1`.

# Release notes

**QueryBuilder**

* remove deprecated `QueryObject` constructor accepting array of options and `#params`
