### PR TITLE
Allow custom field names for mapped columns

### DIFF
--- a/examples/migrations/20181017202211501_create_column_alias_models.cr
+++ b/examples/migrations/20181017202211501_create_column_alias_models.cr
@@ -1,0 +1,42 @@
+class AddColumnAliasModels20181017202211501 < Jennifer::Migration::Base
+  def up
+    create_table :authors do |t|
+      t.string  :first_name,  { :null => false }
+      t.string  :last_name,   { :null => false }
+    end
+
+    {% if env("DB") == "postgres" || env("DB") == nil %}
+      create_enum(:publication_type_enum, ["Book", "Article", "BlogPost"])
+
+      create_table :publications do |t|
+        t.string  :title,       { :null => false }
+        t.integer :version,     { :null => false }
+        t.integer :pages
+        t.string  :url
+        t.string  :publisher
+        t.field   :type,        :publication_type_enum
+      end
+    {% else %}
+      create_table :publications do |t|
+        t.string  :title,       { :null => false }
+        t.integer :version,     { :null => false }
+        t.integer :pages
+        t.string  :url
+        t.string  :publisher
+        t.enum    :type,        ["Book", "Article", "BlogPost"]
+      end
+    {% end %}
+
+    create_join_table(:authors, :publications)
+
+    create_view(:print_publications, Jennifer::Query["publications"].where { sql("type IN ('Book', 'Article')") })
+  end
+
+  def down
+    drop_view       :print_publications
+    drop_join_table :authors, :publications
+    drop_table      :publications
+    drop_enum       :publication_type_enum
+    drop_table      :authors
+  end
+end

--- a/spec/factories.cr
+++ b/spec/factories.cr
@@ -107,11 +107,6 @@ class CityFactory < Factory::Jennifer::Base
   attr :country_id, -> { Factory.create_country.id }, Int32
 end
 
-class DistrictFactory < Factory::Jennifer::Base
-  attr :code, "2357"
-  attr :country_id, -> { Factory.create_country.id }, Int32
-end
-
 class ProfileFactory < Factory::Jennifer::Base
   attr :login, "some_login"
   attr :type, Profile.to_s

--- a/spec/model/base_spec.cr
+++ b/spec/model/base_spec.cr
@@ -176,6 +176,21 @@ describe Jennifer::Model::Base do
         model.name.should eq("some name")
       end
     end
+
+    context "model has column aliases" do
+      it "correctly maps column aliases" do
+        a = Author.create(
+          name1: "Samply",
+          name2: "Examplary"
+        )
+
+        Author
+          .where { _first_name == "Samply" }
+          .first!
+          .id
+          .should eq(a.id)
+      end
+    end
   end
 
   describe "::create!" do

--- a/spec/model/sti_mapping_spec.cr
+++ b/spec/model/sti_mapping_spec.cr
@@ -26,6 +26,13 @@ describe Jennifer::Model::STIMapping do
         id[:type].should eq(Int32)
         id[:parsed_type].should eq("Int32?")
       end
+
+      it "copies column aliases fro superclass" do
+        name = Book::COLUMNS_METADATA[:name]
+        name.is_a?(NamedTuple).should be_true
+        name[:type].should eq(String)
+        name[:column].should eq("title")
+      end
     end
 
     describe "::columns_tuple" do
@@ -35,6 +42,14 @@ describe Jennifer::Model::STIMapping do
         metadata[:uid].is_a?(NamedTuple).should be_true
         metadata[:uid][:type].should eq(String?)
         metadata[:uid][:parsed_type].should eq("::Union(String, ::Nil)")
+      end
+
+      it "returns named tuple that also contains column aliases configs" do
+        metadata = Article.columns_tuple
+        metadata.is_a?(NamedTuple).should be_true
+        metadata[:size].is_a?(NamedTuple).should be_true
+        metadata[:size][:type].should eq(Int32?)
+        metadata[:size][:column].should eq("pages")
       end
     end
 
@@ -81,6 +96,30 @@ describe Jennifer::Model::STIMapping do
         res.uid.should eq("1111")
         res.login.should eq("my_login")
       end
+
+      it "properly maps aliased columns in superclass" do
+        b = Book.create(
+          name:       "HowToMapDbStuff?",
+          version:    1,
+          publisher:  "DbStuffMapper",
+          pages:      19_000
+        )
+        b = Book.find!(b.id)
+        b.name.should eq "HowToMapDbStuff?"
+        b.pages.should eq 19_000
+      end
+
+      it "properly maps aliased columns in subclass" do
+        a = Article.create(
+          name:       "100DatabaseTypesYouDidNotKnowAbout",
+          version:    3,
+          publisher:  "DbStuffMapper",
+          size:       12
+        )
+        a = Article.find!(a.id)
+        a.name.should eq "100DatabaseTypesYouDidNotKnowAbout"
+        a.size.should eq 12
+      end
     end
 
     context "hash" do
@@ -90,6 +129,28 @@ describe Jennifer::Model::STIMapping do
         f.login.should eq("asd")
         f.uid.should eq("uid")
       end
+
+      it "properly loads aliased columns in superclass" do
+        b = Book.build({
+          :name       => "HowToMapDbStuff?",
+          :version    => 2,
+          :publisher  => "DbStuffMapper",
+          :pages      => 19_000
+        })
+        b.name.should eq "HowToMapDbStuff?"
+        b.pages.should eq 19_000
+      end
+
+      it "properly maps aliased columns in subclass" do
+        a = Article.build({
+          :name       => "101DatabaseTypesYouDidNotKnowAbout",
+          :version    => 1,
+          :publisher  => "DbStuffMapper",
+          :size       => 14
+        })
+        a.name.should eq "101DatabaseTypesYouDidNotKnowAbout"
+        a.size.should eq 14
+      end
     end
   end
 
@@ -98,6 +159,16 @@ describe Jennifer::Model::STIMapping do
       names = FacebookProfile.field_names
       match_array(names, %w(login uid type contact_id id virtual_child_field virtual_parent_field))
     end
+
+    it "does not return aliased columns of the superclass" do
+      names = BlogPost.field_names
+      match_array(names, %w(id name version publisher type url created_at))
+    end
+
+    it "does not return aliased columns of the subclass" do
+      names = Article.field_names
+      match_array(names, %w(id name version publisher type size))
+    end
   end
 
   describe "::all" do
@@ -105,6 +176,12 @@ describe Jennifer::Model::STIMapping do
       q = FacebookProfile.all
       q.as_sql.should match(/profiles\.type = %s/)
       q.sql_args.should eq(db_array("FacebookProfile"))
+    end
+
+    it "generates correct queries for tables with column aliases" do
+      q = Article.all
+      q.as_sql.should match /publications\.type = %s/
+      q.sql_args.should eq db_array("Article")
     end
   end
 
@@ -116,6 +193,36 @@ describe Jennifer::Model::STIMapping do
       r[:type].should eq("FacebookProfile")
       r[:uid].should eq("1111")
     end
+
+    it "sets fields with column aliases in superclasses" do
+      b = BlogPost.build(
+        name:       "ASimpleDbMappingTutorial",
+        version:    1,
+        publisher:  "ATutorialPage",
+        url:        "an.url.com"
+      ).to_h
+
+      b.keys.should eq(%i(id name version publisher type url))
+      b[:name].should eq "ASimpleDbMappingTutorial"
+      b[:version].should eq 1
+      b[:type].should eq "BlogPost"
+      b[:url].should eq "an.url.com"
+    end
+
+    it "sets fields with column aliases in subclasses" do
+      a = Article.build(
+        name:       "AMeasureOnHowMuchDbMappingStuffThereIs",
+        version:    1,
+        publisher:  "MeasuringAllDay",
+        size:       19
+      ).to_h
+
+      a.keys.should eq(%i(id name version publisher type size))
+      a[:name].should eq "AMeasureOnHowMuchDbMappingStuffThereIs"
+      a[:version].should eq 1
+      a[:type].should eq "Article"
+      a[:size].should eq 19
+    end
   end
 
   describe "#to_str_h" do
@@ -126,6 +233,32 @@ describe Jennifer::Model::STIMapping do
       r["type"].should eq("FacebookProfile")
       r["uid"].should eq("1111")
     end
+
+    it "sets fields with column aliases in superclasses" do
+      b = BlogPost.build(
+        name:       "AGuideForSpecTesting",
+        version:    99,
+        publisher:  "SpecTestingersLegion",
+        url:        "spec.tests.com"
+      ).to_str_h
+      b.keys.should eq(%w(id name version publisher type url))
+      b["name"].should eq "AGuideForSpecTesting"
+      b["type"].should eq "BlogPost"
+      b["url"].should eq "spec.tests.com"
+    end
+
+    it "sets fields with column aliases in subclasses" do
+      b = Article.build(
+        name:       "DealingWithSpecsInORMapping",
+        version:    99,
+        publisher:  "SpecTestingersLegion",
+        size:       3
+      ).to_str_h
+      b.keys.should eq(%w(id name version publisher type size))
+      b["name"].should eq "DealingWithSpecsInORMapping"
+      b["type"].should eq "Article"
+      b["size"].should eq 3
+    end
   end
 
   describe "#update_column" do
@@ -134,6 +267,18 @@ describe Jennifer::Model::STIMapping do
       p.update_column(:uid, "2222")
       p.uid.should eq("2222")
       p.reload.uid.should eq("2222")
+    end
+
+    it "properly updates and maps column aliases" do
+      b = BlogPost.create(
+        name:       "NotAnotherBlogPost",
+        version:    3,
+        publisher:  "NoMoreBlogPosts",
+        url:        "www.blogpost.ing"
+      )
+      b.update_column(:title, "YesAnotherBlogPost")
+      b.name.should eq("YesAnotherBlogPost")
+      b.reload.name.should eq("YesAnotherBlogPost")
     end
   end
 
@@ -145,6 +290,18 @@ describe Jennifer::Model::STIMapping do
         p.uid.should eq("2222")
         p.reload.uid.should eq("2222")
       end
+
+      it "propertly maps column aliases" do
+        a = Article.create(
+          name:       "NotAnotherArticle",
+          version:    99,
+          publisher:  "NoMoreArticles",
+          size:       13
+        )
+        a.update_column(:pages, 14)
+        a.size.should eq 14
+        a.reload.size.should eq 14
+      end
     end
 
     context "updating attributes described in parent model" do
@@ -153,6 +310,18 @@ describe Jennifer::Model::STIMapping do
         p.update_columns({:login => "222"})
         p.login.should eq("222")
         p.reload.login.should eq("222")
+      end
+
+      it "propertly maps column aliases" do
+        b = Book.create(
+          name:       "BooksAreSuperiorToArticles",
+          version:    3,
+          publisher:  "UnionOfBookEnthusiasts",
+          pages:      290
+        )
+        b.update_column(:title, "BooksAreSuperiorToArticlesAndBlogPosts")
+        b.name.should eq "BooksAreSuperiorToArticlesAndBlogPosts"
+        b.reload.name.should eq "BooksAreSuperiorToArticlesAndBlogPosts"
       end
     end
 
@@ -166,12 +335,50 @@ describe Jennifer::Model::STIMapping do
         p.login.should eq("222")
         p.uid.should eq("3333")
       end
+
+      it "propertly maps column aliases" do
+        a = Article.create(
+          name:       "HowAboutStoppingThisMess?",
+          version:    4,
+          publisher:  "FedUpFederation",
+          size:       2
+        )
+        a.update_columns({:title => "HowAboutNeverStoppingThisMess?", :pages => 3})
+        a.name.should eq "HowAboutNeverStoppingThisMess?"
+        a.size.should eq 3
+        a.reload
+        a.name.should eq "HowAboutNeverStoppingThisMess?"
+        a.size.should eq 3
+      end
     end
 
     it "raises exception if any given attribute is not exists" do
       p = Factory.create_facebook_profile(login: "111")
       expect_raises(Jennifer::BaseException) do
         p.update_columns({:asd => "222"})
+      end
+    end
+
+    it "allows access via maped columns" do
+      b = Book.create(
+        name:       "Necronomicon",
+        version:    13,
+        publisher:  "SomePublisher",
+        pages:      1299
+      )
+      b.update_columns({:title => "Necronnnnomicon"})
+      b.name.should eq "Necronnnnomicon"
+    end
+
+    it "raises an exception when mapped columns of the subclass are accessed" do
+      a = Article.create(
+        name:       "TheHorrorAtRedHook",
+        version:    2,
+        publisher:  "SomePublisher",
+        size:      14
+      )
+      expect_raises(Jennifer::BaseException) do
+        a.update_columns({:size => 17})
       end
     end
   end
@@ -181,6 +388,18 @@ describe Jennifer::Model::STIMapping do
       f = Factory.build_facebook_profile(uid: "111", login: "my_login")
       f.virtual_child_field = 2
       f.attribute(:virtual_child_field).should eq(2)
+    end
+
+    it "should ignore column mappings of virtual fields" do
+      b = BlogPost.build(
+        name:       "AWebVersionOfInTheHillsTheCities",
+        version:    5,
+        publisher:  "RandomBlogger",
+        url:        "www.random-blog.blog"
+      )
+      timestamp = Time.utc_now
+      b.created_at = timestamp
+      b.attribute(:created_at).should eq timestamp
     end
 
     it "returns own attribute" do
@@ -197,6 +416,17 @@ describe Jennifer::Model::STIMapping do
   describe "#arguments_to_save" do
     it "returns named tuple with correct keys" do
       r = Factory.build_twitter_profile.arguments_to_save
+      r.is_a?(NamedTuple).should be_true
+      r.keys.should eq({:args, :fields})
+    end
+
+    it "correctly maps column aliases" do
+      r = Article.build(
+        name:       "ADiscussionOfDagon",
+        version:    3,
+        publisher:  "DiscussionsAndOtherStuff",
+        size:       21
+      ).arguments_to_save
       r.is_a?(NamedTuple).should be_true
       r.keys.should eq({:args, :fields})
     end
@@ -222,6 +452,34 @@ describe Jennifer::Model::STIMapping do
       r[:args].should eq(db_array("some new email"))
       r[:fields].should eq(db_array("email"))
     end
+
+    it "returns tuple with mapped and changed parent arguments" do
+      b = Book.build(
+        name:       "ABigLeatherBoundBook",
+        version:    1,
+        publisher:  "AndRichMahogany",
+        pages:      5099
+      )
+
+      b.name = "BigLeatherBoundBooks"
+      r = b.arguments_to_save
+      r[:args].should eq db_array("BigLeatherBoundBooks")
+      r[:fields].should eq db_array("title")
+    end
+
+    it "returns tuple with mapped and changed child arguments" do
+      a = Article.build(
+        name:       "TunasWithBreathingApparatuses",
+        version:    4,
+        publisher:  "LikeToEatLions",
+        size:       3
+      )
+
+      a.size = 5
+      r = a.arguments_to_save
+      r[:args].should eq db_array(5)
+      r[:fields].should eq db_array("pages")
+    end
   end
 
   describe "#arguments_to_insert" do
@@ -239,6 +497,20 @@ describe Jennifer::Model::STIMapping do
     it "returns tuple with all values" do
       r = Factory.build_twitter_profile.arguments_to_insert
       match_array(r[:args], db_array("some_login", nil, "TwitterProfile", "some_email@example.com"))
+    end
+
+    it "maps columns aliases" do
+      r = Article.build(
+        name:       "MyNameIsDonnieSmith",
+        version:    5,
+        publisher:  "PTA",
+        size:       1
+      ).arguments_to_insert
+      r.is_a?(NamedTuple).should be_true
+      r.keys.should eq({:args, :fields})
+
+      match_array(r[:fields], %w(title version publisher type pages))
+      match_array(r[:args], db_array("MyNameIsDonnieSmith", 5, "PTA", "Article", 1))
     end
   end
 

--- a/spec/models.cr
+++ b/spec/models.cr
@@ -565,3 +565,39 @@ class AddressWithNilableBool < Jennifer::Model::Base
     main: Bool?
   }, false)
 end
+class Author < Jennifer::Model::Base
+  mapping({
+    id:         Primary32,
+    name1:      { type: String, column: :first_name },
+    name2:      { type: String, column: :last_name }
+  })
+end
+
+abstract class Publication < Jennifer::Model::Base
+  mapping({
+    id:         Primary32,
+    name:       { type: String, column: :title },
+    version:    Int32,
+    publisher:  String,
+    type:       String
+  })
+end
+
+class Book < Publication
+  mapping({
+    pages:      Int32?
+  })
+end
+
+class Article < Publication
+  mapping({
+    size:       { type: Int32?, column: :pages }
+  })
+end
+
+class BlogPost < Publication
+  mapping({
+    url:        String?,
+    created_at:    {type: Time?, virtual: true, column: :created}
+  })
+end

--- a/spec/views.cr
+++ b/spec/views.cr
@@ -76,3 +76,15 @@ class MaleContactWithDescription < Jennifer::View::Base
     description: String,
   }, false)
 end
+
+class PrintPublication < Jennifer::View::Base
+  mapping({
+    id:         Primary32,
+    title:      String,
+    v:          {type: Int32, column: :version},
+    publisher:  String,
+    pages:      Int32?,
+    url:        String?,
+    type:       String
+  })
+end

--- a/src/jennifer/model/sti_mapping.cr
+++ b/src/jennifer/model/sti_mapping.cr
@@ -58,13 +58,21 @@ module Jennifer
           {% end %}
 
           {% for key, value in properties %}
-            {% column = (value[:column_name] || key).id.stringify %}
-            if values.has_key?({{column}})
+            {% column1 = key.id.stringify %}
+            {% column2 = value[:column] %}
+            if values.has_key?({{column1}})
               %var{key.id} =
                 {% if value[:converter] %}
-                  {{value[:converter]}}.from_hash(values, {{column}})
+                  {{value[:converter]}}.from_hash(values, {{column1}})
                 {% else %}
-                  values[{{column}}]
+                  values[{{column1}}]
+                {% end %}
+            elsif values.has_key?({{column2}})
+              %var{key.id} =
+                {% if value[:converter] %}
+                  {{value[:converter]}}.from_hash(values, {{column2}})
+                {% else %}
+                  values[{{column2}}]
                 {% end %}
             else
               %found{key.id} = false
@@ -187,7 +195,7 @@ module Jennifer
             case name.to_s
             {% for key, value in properties %}
               {% if !value[:virtual] %}
-                when "{{key.id}}"
+                when {{value[:column]}}
                   if value.is_a?({{value[:parsed_type].id}})
                     local = value.as({{value[:parsed_type].id}})
                     @{{key.id}} = local
@@ -244,7 +252,7 @@ module Jennifer
               if @{{attr.id}}_changed
                 args <<
                   {% if options[:converter] %} {{options[:converter]}}.to_db(@{{attr.id}}) {% else %} @{{attr.id}} {% end %}
-                fields << "{{attr.id}}"
+                fields << {{options[:column]}}
               end
             {% end %}
           {% end %}
@@ -260,7 +268,7 @@ module Jennifer
             {% unless options[:virtual] %}
               args <<
                 {% if options[:converter] %} {{options[:converter]}}.to_db(@{{attr.id}}) {% else %} @{{attr.id}} {% end %}
-              fields << "{{attr.id}}"
+              fields << {{options[:column]}}
             {% end %}
           {% end %}
           named_tuple

--- a/src/jennifer/validations/macros.cr
+++ b/src/jennifer/validations/macros.cr
@@ -75,7 +75,6 @@ module Jennifer
       #
       # Because this check is performed outside the database there is still a chance that duplicate values will be
       # inserted in two parallel transactions. To guarantee against this you should create a unique index on the field.
-      # TODO: add scope
       macro validates_uniqueness(*fields, allow_blank allow_blank_value = false, if if_value = nil)
         # raise a compile time error if a uniqueness validator is specified
         # that does not define any properties
@@ -88,7 +87,7 @@ module Jennifer
         # (e.g. ... WHERE id = <id> AND name = <name> AND config = <config> ...)
         {% normalized_fields = fields.map(&.id) %}
 
-        {% fields_condition = normalized_fields.map { |field| ".where { _#{field} == #{field} }" }.join("") %}
+        {% fields_condition = normalized_fields.map { |field| ".where { self.class._#{field} == #{field} }" }.join("") %}
 
         # builds a unique identifier for this set of properties
         # (e.g. for uniqueness properties `:a`, `:b` this results in `:a_b`)


### PR DESCRIPTION
# What does this PR do?
Hi,

this should be some sort of proof-of-concept for #218.
In order to overcome some issues with an existing database / domain model, we require some way to get an abstraction layer between the field names and the underlying columns.
This feature adds a new mapping option `column` to define custom column names for fields.
A mapping for a class like
```
class A < Jennifer::Model::Base
  mapping({
    id: Primary64,
    b: {type: String, colum: :c}
  })
end
```
would therefore map to a table `A(id INTEGER, c TEXT)` (ignoring the actual types in this example) while still allowing access to property `b`.

This is done by manually gathering the column mappings via macros and then replacing any access to the column name with this mapping (e.g. `fields << {{COLUMN_MAPPINGS[attr.id]}}` i/o `fields << {{attr.id}}` in `arguments_to_insert`).
Unfortunately I could not find a way to allow the original fields in the query builder as the query is resolved via `method_missing` hooks and therefore does not have access to the type specific constant.
This results in queries that have to use the actual column names - e.g. `A.where { _c == "foo" }`.

Another limitation of this approach is that at the moment views cannot access the mapped field names. Therefore the initialisation of a view by a hash with mapped fields does not work / would require the inclusion of both mapped fields and columns in the `#to_h` method (this issue is on display in [`experimental_mapping_spec.cr`](https://github.com/skloibi/jennifer.cr/blob/feature/property_aliases/spec/view/experimental_mapping_spec.cr#L391-L405)).

# Release notes

**Model**
* Allow mapping option `column` that defines a custom column name that is mapped to this field
* Add constant `COLUMN_MAPPINGS` that saves all fields and their corresponding column mappings for a specific model class

**Validation**
* Change `Validations::Uniqueness` to consider field mappings when validating properties

**View**
* Allow specification of property aliases via `column` option (cf. Model)

