### PR TITLE
Add query upsert command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
   - postgresql
   - mysql
 addons:
-  postgresql: 9.4
+  postgresql: 9.5
 env:
   - DB=mysql DB_USER=root DB_PASSWORD=""
   - DB=postgres DB_USER=postgres DB_PASSWORD=""

--- a/src/jennifer/adapter/base_sql_generator.cr
+++ b/src/jennifer/adapter/base_sql_generator.cr
@@ -8,6 +8,10 @@ module Jennifer
         # Generates query for inserting new record to db
         abstract def insert(obj : Model::Base)
         abstract def json_path(path : QueryBuilder::JSONSelector)
+        abstract def insert_on_duplicate(table, fields, values, unique_fields, on_conflict)
+
+        # Generates SQL for VALUES reference in `INSERT ... ON DUPLICATE` query.
+        abstract def values_expression(field)
       end
 
       extend ClassMethods

--- a/src/jennifer/adapter/postgres/criteria.cr
+++ b/src/jennifer/adapter/postgres/criteria.cr
@@ -1,11 +1,10 @@
 class Jennifer::QueryBuilder::Criteria
   {% for op in [:overlap, :contain, :contained] %}
+    # Presents {{op}} operator.
+    #
+    # PostgreSQL specific.
     def {{op.id}}(value : Rightable)
       Condition.new(self, {{op}}, value)
     end
   {% end %}
-
-  def similar(value : String)
-    Condition.new(self, :similar, value)
-  end
 end

--- a/src/jennifer/model/base.cr
+++ b/src/jennifer/model/base.cr
@@ -393,6 +393,15 @@ module Jennifer
       end
 
       # Performs bulk import of given collection.
+      #
+      # Any callback is ignored.
+      #
+      # ```
+      # User.import([
+      #   User.new({ name: "John" }),
+      #   User.new({ name: "Fahad" })
+      # ])
+      # ```
       def self.import(collection : Array(self))
         adapter.bulk_insert(collection)
       end

--- a/src/jennifer/query_builder/aggregations.cr
+++ b/src/jennifer/query_builder/aggregations.cr
@@ -26,42 +26,42 @@ module Jennifer
       end
 
       def group_max(field, klass : T.class) : Array(T) forall T
-        _select = @raw_select
+        old_select = @raw_select
         @raw_select = "MAX(#{field}) as m"
         result = to_a.map(&.["m"])
-        @raw_select = _select
+        @raw_select = old_select
         Ifrit.typed_array_cast(result, T)
       end
 
       def group_min(field, klass : T.class) : Array(T) forall T
-        _select = @raw_select
+        old_select = @raw_select
         @raw_select = "MIN(#{field}) as m"
         result = to_a.map(&.["m"])
-        @raw_select = _select
+        @raw_select = old_select
         Ifrit.typed_array_cast(result, T)
       end
 
       def group_sum(field, klass : T.class) : Array(T) forall T
-        _select = @raw_select
-        @raw_select = "SUM(#{field}) as m"
-        result = to_a.map(&.["m"])
-        @raw_select = _select
+        old_select = @raw_select
+        @raw_select = "SUM(#{field}) as s"
+        result = to_a.map(&.["s"])
+        @raw_select = old_select
         Ifrit.typed_array_cast(result, T)
       end
 
       def group_avg(field, klass : T.class) : Array(T) forall T
-        _select = @raw_select
-        @raw_select = "AVG(#{field}) as m"
-        result = to_a.map(&.["m"])
-        @raw_select = _select
+        old_select = @raw_select
+        @raw_select = "AVG(#{field}) as a"
+        result = to_a.map(&.["a"])
+        @raw_select = old_select
         Ifrit.typed_array_cast(result, T)
       end
 
       def group_count(field)
-        _select = @raw_select
-        @raw_select = "COUNT(#{field}) as m"
-        result = to_a.map(&.["m"])
-        @raw_select = _select
+        old_select = @raw_select
+        @raw_select = "COUNT(#{field}) as c"
+        result = to_a.map(&.["c"])
+        @raw_select = old_select
         result
       end
     end

--- a/src/jennifer/query_builder/expression_builder.cr
+++ b/src/jennifer/query_builder/expression_builder.cr
@@ -75,6 +75,10 @@ module Jennifer
         Star.new(table)
       end
 
+      def values(field : String | Symbol)
+        Values.new(field)
+      end
+
       # Combines given *first_condition*, *second_condition* and all other *conditions* by `AND` operator.
       #
       # All given conditions will be wrapped in `Grouping`.

--- a/src/jennifer/query_builder/values.cr
+++ b/src/jennifer/query_builder/values.cr
@@ -1,0 +1,27 @@
+module Jennifer::QueryBuilder
+  # Present reference to the `VALUES` related to the row with duplicate key during upsert.
+  class Values < SQLNode
+    def initialize(@field : Symbol)
+    end
+
+    def_clone
+
+    {% for op in %i(+ - * /) %}
+      def {{op.id}}(value : SQLNode | DBAny)
+        Condition.new(self, {{op}}, value)
+      end
+    {% end %}
+
+    def as_sql(sql_generator)
+      sql_generator.values_expression(@field)
+    end
+
+    def sql_args
+      [] of DBAny
+    end
+
+    def filterable?
+      false
+    end
+  end
+end


### PR DESCRIPTION
# What does this PR do?

Adds upsert command support mentioned in #139 .

# Release notes

**QueryBuilder**

* remove redundant `Criteria#similar` which is loaded with `postgres` adapter
* add `Query#insert`
* add `Query#upsert`
* add `ExpressionBuilder#values` and `Values` to reference to `VALUES` statement in upsert

**Adapter**

* remove `Base::ArgType` alias
* add `Base#upsert`

**SqlGenerator**

* add `.insert_on_duplicate` and `.values_expression` to `BaseSQLGenerator` as abstract methods and implementations to `Postgres` and `Mysql`