### PR TITLE
Fix odd and even options of numericality validator

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -32,6 +32,12 @@ end
 
 # Helper methods ================
 
+macro validated_by_record(type, value, field = :age, allow_blank = true)
+  Factory.build_contact.tap do |record|
+    described_class.instance.validate(record, {{field}}, {{value}}, {{allow_blank}}, **{{type}})
+  end
+end
+
 def clean_db
   postgres_only do
     Jennifer::Adapter.adapter.as(Jennifer::Postgres::Adapter).refresh_materialized_view(FemaleContact.table_name)
@@ -110,38 +116,4 @@ def db_specific(mysql, postgres)
   else
     raise "Unknown adapter type"
   end
-end
-
-# Matchers ======================
-
-def match_array(expect, target)
-  (expect - target).size.should eq(0)
-  (target - expect).size.should eq(0)
-rescue e
-  puts "Actual array: #{expect}"
-  puts "Expected: #{target}"
-  raise e
-end
-
-def match_each(source, target)
-  source.size.should eq(target.size)
-  source.each do |e|
-    target.includes?(e).should be_true
-  end
-rescue e
-  puts "Actual array: #{source}"
-  puts "Expected: #{target}"
-  raise e
-end
-
-macro match_fields(object, fields)
-  {% for field, value in fields %}
-    {{object}}.{{field.id}}.should eq({{value}})
-  {% end %}
-end
-
-macro match_fields(object, **fields)
-  {% for field, value in fields %}
-    {{object}}.{{field.id}}.should eq({{value}})
-  {% end %}
 end

--- a/spec/support/matchers.cr
+++ b/spec/support/matchers.cr
@@ -1,3 +1,35 @@
+def match_array(expect, target)
+  (expect - target).size.should eq(0)
+  (target - expect).size.should eq(0)
+rescue e
+  puts "Actual array: #{expect}"
+  puts "Expected: #{target}"
+  raise e
+end
+
+def match_each(source, target)
+  source.size.should eq(target.size)
+  source.each do |e|
+    target.includes?(e).should be_true
+  end
+rescue e
+  puts "Actual array: #{source}"
+  puts "Expected: #{target}"
+  raise e
+end
+
+macro match_fields(object, fields)
+  {% for field, value in fields %}
+    {{object}}.{{field.id}}.should eq({{value}})
+  {% end %}
+end
+
+macro match_fields(object, **fields)
+  {% for field, value in fields %}
+    {{object}}.{{field.id}}.should eq({{value}})
+  {% end %}
+end
+
 module Spec
   module Methods
     # The following construction
@@ -39,6 +71,20 @@ module Spec
 
     def negative_failure_message(object)
       "Expected: #{object.inspect} not to be valid"
+    end
+  end
+
+  struct BeInvalidExpectation
+    def match(object)
+      object.invalid?
+    end
+
+    def failure_message(object)
+      "Expected: #{object.inspect} to be invalid"
+    end
+
+    def negative_failure_message(object)
+      "Expected: #{object.inspect} be valid but got errors: #{object.errors.full_messages.inspect}"
     end
   end
 
@@ -131,6 +177,10 @@ module Spec
 
     def be_valid
       BeValidExpectation.new
+    end
+
+    def be_invalid
+      BeInvalidExpectation.new
     end
 
     def validate(attr)

--- a/spec/validations/absence_spec.cr
+++ b/spec/validations/absence_spec.cr
@@ -1,0 +1,8 @@
+require "../spec_helper"
+
+describe Jennifer::Validations::Absence do
+  described_class = Jennifer::Validations::Inclusion
+
+  pending "add #validate"
+  pending "test allow_blank"
+end

--- a/spec/validations/acceptance_spec.cr
+++ b/spec/validations/acceptance_spec.cr
@@ -1,0 +1,8 @@
+require "../spec_helper"
+
+describe Jennifer::Validations::Acceptance do
+  described_class = Jennifer::Validations::Acceptance
+
+  pending "add #validate"
+  pending "test allow_blank"
+end

--- a/spec/validations/confirmation_spec.cr
+++ b/spec/validations/confirmation_spec.cr
@@ -1,0 +1,8 @@
+require "../spec_helper"
+
+describe Jennifer::Validations::Confirmation do
+  described_class = Jennifer::Validations::Confirmation
+
+  pending "add #validate"
+  pending "test allow_blank"
+end

--- a/spec/validations/exclusion_spec.cr
+++ b/spec/validations/exclusion_spec.cr
@@ -1,0 +1,27 @@
+require "../spec_helper"
+
+describe Jennifer::Validations::Exclusion do
+  described_class = Jennifer::Validations::Exclusion
+
+  describe "#validate" do
+    describe "String" do
+      it { validated_by_record({collection: ["Sam"]}, "John", :name).should_not be_invalid }
+      it { validated_by_record({collection: ["Sam"]}, "Sam", :name).should be_invalid }
+      it { validated_by_record({collection: ["Sam"]}, nil, :name).should_not be_invalid }
+    end
+
+    describe "Float32" do
+      it { validated_by_record({collection: [1.2]}, 2.5, :name).should_not be_invalid }
+      it { validated_by_record({collection: [1.2]}, 1.2, :name).should be_invalid }
+      it { validated_by_record({collection: [1.2]}, nil, :name).should_not be_invalid }
+    end
+
+    describe "Int32" do
+      it { validated_by_record({collection: [1]}, 2, :name).should_not be_invalid }
+      it { validated_by_record({collection: [1]}, 1, :name).should be_invalid }
+      it { validated_by_record({collection: [1]}, nil, :name).should_not be_invalid }
+    end
+  end
+
+  pending "test allow_blank"
+end

--- a/spec/validations/format_spec.cr
+++ b/spec/validations/format_spec.cr
@@ -1,0 +1,8 @@
+require "../spec_helper"
+
+describe Jennifer::Validations::Format do
+  described_class = Jennifer::Validations::Format
+
+  pending "add #validate"
+  pending "test allow_blank"
+end

--- a/spec/validations/inclusion_spec.cr
+++ b/spec/validations/inclusion_spec.cr
@@ -3,17 +3,25 @@ require "../spec_helper"
 describe Jennifer::Validations::Inclusion do
   described_class = Jennifer::Validations::Inclusion
 
-  describe ".validate" do
-    it do
-      c = Factory.build_contact
-      described_class.instance.validate(c, :name, "John", false, ["Sam"])
-      c.should be_valid
+  describe "#validate" do
+    describe "String" do
+      it { validated_by_record({collection: ["Sam"]}, "John", :name).should be_invalid }
+      it { validated_by_record({collection: ["Sam"]}, "Sam", :name).should_not be_invalid }
+      it { validated_by_record({collection: ["Sam"]}, nil, :name).should_not be_invalid }
     end
 
-    it do
-      instance = Factory.build_contact
-      described_class.instance.validate(instance, :name, nil, true, [1.2])
-      instance.should be_valid
+    describe "Float32" do
+      it { validated_by_record({collection: [1.2]}, 2.5, :name).should be_invalid }
+      it { validated_by_record({collection: [1.2]}, 1.2, :name).should_not be_invalid }
+      it { validated_by_record({collection: [1.2]}, nil, :name).should_not be_invalid }
+    end
+
+    describe "Int32" do
+      it { validated_by_record({collection: [1]}, 2, :name).should be_invalid }
+      it { validated_by_record({collection: [1]}, 1, :name).should_not be_invalid }
+      it { validated_by_record({collection: [1]}, nil, :name).should_not be_invalid }
     end
   end
+
+  pending "test allow_blank"
 end

--- a/spec/validations/length_spec.cr
+++ b/spec/validations/length_spec.cr
@@ -1,0 +1,69 @@
+require "../spec_helper"
+
+describe Jennifer::Validations::Length do
+  described_class = Jennifer::Validations::Length
+
+  describe "#validate" do
+    describe "in" do
+      describe "String" do
+        it { validated_by_record({in: 2..3}, "Joh", :name).should_not be_invalid }
+        it { validated_by_record({in: 2..3}, "Jo", :name).should_not be_invalid }
+        it { validated_by_record({in: 2...3}, "Sam", :name).should be_invalid }
+        it { validated_by_record({in: 2...3}, "S", :name).should be_invalid }
+      end
+
+      describe "Array" do
+        it { validated_by_record({in: 2..3}, [1, 2, 3], :name).should_not be_invalid }
+        it { validated_by_record({in: 2..3}, [1, 2], :name).should_not be_invalid }
+        it { validated_by_record({in: 2...3}, [1, 2, 3], :name).should be_invalid }
+        it { validated_by_record({in: 2...3}, [1], :name).should be_invalid }
+      end
+
+      it { validated_by_record({in: 2..3}, nil, :name).should_not be_invalid }
+    end
+
+    describe "is" do
+      describe "String" do
+        it { validated_by_record({is: 3}, "Joh", :name).should_not be_invalid }
+        it { validated_by_record({is: 3}, "Jo", :name).should be_invalid }
+      end
+
+      describe "Array" do
+        it { validated_by_record({is: 3}, [1, 2, 3], :name).should_not be_invalid }
+        it { validated_by_record({is: 3}, [1, 2], :name).should be_invalid }
+      end
+
+      it { validated_by_record({is: 3}, nil, :name).should_not be_invalid }
+    end
+
+    describe "minimum" do
+      describe "String" do
+        it { validated_by_record({minimum: 3}, "Joh", :name).should_not be_invalid }
+        it { validated_by_record({minimum: 3}, "Jo", :name).should be_invalid }
+      end
+
+      describe "Array" do
+        it { validated_by_record({minimum: 3}, [1, 2, 3], :name).should_not be_invalid }
+        it { validated_by_record({minimum: 3}, [1, 2], :name).should be_invalid }
+      end
+
+      it { validated_by_record({minimum: 3}, nil, :name).should_not be_invalid }
+    end
+
+    describe "maximum" do
+      describe "String" do
+        it { validated_by_record({maximum: 3}, "Joh", :name).should_not be_invalid }
+        it { validated_by_record({maximum: 3}, "John", :name).should be_invalid }
+      end
+
+      describe "Array" do
+        it { validated_by_record({maximum: 3}, [1, 2, 3], :name).should_not be_invalid }
+        it { validated_by_record({maximum: 3}, [1, 2, 3, 4], :name).should be_invalid }
+      end
+
+      it { validated_by_record({maximum: 3}, nil, :name).should_not be_invalid }
+    end
+  end
+
+  pending "test allow_blank"
+end

--- a/spec/validations/numericality_spec.cr
+++ b/spec/validations/numericality_spec.cr
@@ -1,0 +1,255 @@
+require "../spec_helper"
+
+describe Jennifer::Validations::Numericality do
+  described_class = Jennifer::Validations::Numericality
+
+  describe "#validate" do
+    describe "greater_than" do
+      definition = {greater_than: 12}
+
+      describe "Int32" do
+        it { validated_by_record(definition, 13).should_not be_invalid }
+        it { validated_by_record(definition, 12).should be_invalid }
+      end
+
+      describe "Int16" do
+        it { validated_by_record(definition, 13i64).should_not be_invalid }
+        it { validated_by_record(definition, 12i64).should be_invalid }
+      end
+
+      describe "Float64" do
+        it { validated_by_record(definition, 13.0).should_not be_invalid }
+        it { validated_by_record(definition, 12.0).should be_invalid }
+      end
+
+      describe "Float32" do
+        it { validated_by_record(definition, 13.0f32).should_not be_invalid }
+        it { validated_by_record(definition, 12.0f32).should be_invalid }
+      end
+
+      describe "Nil" do
+        it { validated_by_record(definition, nil).should_not be_invalid }
+      end
+    end
+
+    describe "greater_than_or_equal_to" do
+      definition = {greater_than_or_equal_to: 12}
+
+      describe "Int32" do
+        it { validated_by_record(definition, 12).should_not be_invalid }
+        it { validated_by_record(definition, 11).should be_invalid }
+      end
+
+      describe "Int16" do
+        it { validated_by_record(definition, 12i64).should_not be_invalid }
+        it { validated_by_record(definition, 11i64).should be_invalid }
+      end
+
+      describe "Float64" do
+        it { validated_by_record(definition, 12.0).should_not be_invalid }
+        it { validated_by_record(definition, 11.0).should be_invalid }
+      end
+
+      describe "Float32" do
+        it { validated_by_record(definition, 12.0f32).should_not be_invalid }
+        it { validated_by_record(definition, 11.0f32).should be_invalid }
+      end
+
+      describe "Nil" do
+        it { validated_by_record(definition, nil).should_not be_invalid }
+      end
+    end
+
+    describe "equal_to" do
+      definition = {equal_to: 12}
+
+      describe "Int32" do
+        it { validated_by_record(definition, 12).should_not be_invalid }
+        it { validated_by_record(definition, 11).should be_invalid }
+        it { validated_by_record(definition, 13).should be_invalid }
+      end
+
+      describe "Int16" do
+        it { validated_by_record(definition, 12i64).should_not be_invalid }
+        it { validated_by_record(definition, 11i64).should be_invalid }
+        it { validated_by_record(definition, 13i64).should be_invalid }
+      end
+
+      describe "Float64" do
+        it { validated_by_record(definition, 12.0).should_not be_invalid }
+        it { validated_by_record(definition, 11.0).should be_invalid }
+        it { validated_by_record(definition, 13.0).should be_invalid }
+      end
+
+      describe "Float32" do
+        it { validated_by_record(definition, 12.0f32).should_not be_invalid }
+        it { validated_by_record(definition, 11.0f32).should be_invalid }
+        it { validated_by_record(definition, 13.0f32).should be_invalid }
+      end
+
+      describe "Nil" do
+        it { validated_by_record(definition, nil).should_not be_invalid }
+      end
+    end
+
+    describe "other_than" do
+      definition = {other_than: 12}
+
+      describe "Int32" do
+        it { validated_by_record(definition, 12).should be_invalid }
+        it { validated_by_record(definition, 11).should_not be_invalid }
+        it { validated_by_record(definition, 13).should_not be_invalid }
+      end
+
+      describe "Int16" do
+        it { validated_by_record(definition, 12i64).should be_invalid }
+        it { validated_by_record(definition, 11i64).should_not be_invalid }
+        it { validated_by_record(definition, 13i64).should_not be_invalid }
+      end
+
+      describe "Float64" do
+        it { validated_by_record(definition, 12.0).should be_invalid }
+        it { validated_by_record(definition, 11.0).should_not be_invalid }
+        it { validated_by_record(definition, 13.0).should_not be_invalid }
+      end
+
+      describe "Float32" do
+        it { validated_by_record(definition, 12.0f32).should be_invalid }
+        it { validated_by_record(definition, 11.0f32).should_not be_invalid }
+        it { validated_by_record(definition, 13.0f32).should_not be_invalid }
+      end
+
+      describe "Nil" do
+        it { validated_by_record(definition, nil).should_not be_invalid }
+      end
+    end
+
+    describe "less_than" do
+      definition = {less_than: 12}
+
+      describe "Int32" do
+        it { validated_by_record(definition, 11).should_not be_invalid }
+        it { validated_by_record(definition, 12).should be_invalid }
+      end
+
+      describe "Int16" do
+        it { validated_by_record(definition, 11i64).should_not be_invalid }
+        it { validated_by_record(definition, 12i64).should be_invalid }
+      end
+
+      describe "Float64" do
+        it { validated_by_record(definition, 11.0).should_not be_invalid }
+        it { validated_by_record(definition, 12.0).should be_invalid }
+      end
+
+      describe "Float32" do
+        it { validated_by_record(definition, 11.0f32).should_not be_invalid }
+        it { validated_by_record(definition, 12.0f32).should be_invalid }
+      end
+
+      describe "Nil" do
+        it { validated_by_record(definition, nil).should_not be_invalid }
+      end
+    end
+
+    describe "less_than_or_equal_to" do
+      definition = {less_than_or_equal_to: 12}
+
+      describe "Int32" do
+        it { validated_by_record(definition, 12).should_not be_invalid }
+        it { validated_by_record(definition, 13).should be_invalid }
+      end
+
+      describe "Int16" do
+        it { validated_by_record(definition, 12i64).should_not be_invalid }
+        it { validated_by_record(definition, 13i64).should be_invalid }
+      end
+
+      describe "Float64" do
+        it { validated_by_record(definition, 12.0).should_not be_invalid }
+        it { validated_by_record(definition, 13.0).should be_invalid }
+      end
+
+      describe "Float32" do
+        it { validated_by_record(definition, 12.0f32).should_not be_invalid }
+        it { validated_by_record(definition, 13.0f32).should be_invalid }
+      end
+
+      describe "Nil" do
+        it { validated_by_record(definition, nil).should_not be_invalid }
+      end
+    end
+
+    describe "odd" do
+      definition = {odd: true}
+
+      describe "Int32" do
+        it { validated_by_record(definition, 13).should_not be_invalid }
+        it { validated_by_record(definition, 14).should be_invalid }
+      end
+
+      describe "Int16" do
+        it { validated_by_record(definition, 13i64).should_not be_invalid }
+        it { validated_by_record(definition, 14i64).should be_invalid }
+      end
+
+      describe "Float64" do
+        it { validated_by_record(definition, 13.0).should_not be_invalid }
+        it { validated_by_record(definition, 14.0).should be_invalid }
+      end
+
+      describe "Float32" do
+        it { validated_by_record(definition, 13.0f32).should_not be_invalid }
+        it { validated_by_record(definition, 14.0f32).should be_invalid }
+      end
+
+      describe "String" do
+        it do
+          expect_raises(ArgumentError) do
+            validated_by_record(definition, "13").should_not be_invalid
+          end
+        end
+      end
+
+      describe "Nil" do
+        it { validated_by_record(definition, nil).should_not be_invalid }
+      end
+    end
+
+    describe "even" do
+      describe "Int32" do
+        it { validated_by_record({even: true}, 14).should_not be_invalid }
+        it { validated_by_record({even: true}, 13).should be_invalid }
+      end
+
+      describe "Int16" do
+        it { validated_by_record({even: true}, 14i64).should_not be_invalid }
+        it { validated_by_record({even: true}, 13i64).should be_invalid }
+      end
+
+      describe "Float64" do
+        it { validated_by_record({even: true}, 14.0).should_not be_invalid }
+        it { validated_by_record({even: true}, 13.0).should be_invalid }
+      end
+
+      describe "Float32" do
+        it { validated_by_record({even: true}, 14.0f32).should_not be_invalid }
+        it { validated_by_record({even: true}, 13.0f32).should be_invalid }
+      end
+
+      describe "String" do
+        it do
+          expect_raises(ArgumentError) do
+            validated_by_record({even: true}, "14").should_not be_invalid
+          end
+        end
+      end
+
+      describe "Nil" do
+        it { validated_by_record({even: true}, nil).should_not be_invalid }
+      end
+    end
+
+    pending "test allow_blank"
+  end
+end

--- a/spec/validations/presence_spec.cr
+++ b/spec/validations/presence_spec.cr
@@ -1,0 +1,8 @@
+require "../spec_helper"
+
+describe Jennifer::Validations::Presence do
+  described_class = Jennifer::Validations::Presence
+
+  pending "add #validate"
+  pending "test allow_blank"
+end

--- a/spec/validations/uniqueness_spec.cr
+++ b/spec/validations/uniqueness_spec.cr
@@ -1,0 +1,8 @@
+require "../spec_helper"
+
+describe Jennifer::Validations::Uniqueness do
+  described_class = Jennifer::Validations::Uniqueness
+
+  pending "add #validate"
+  pending "test allow_blank"
+end

--- a/src/jennifer/validations/numericality.cr
+++ b/src/jennifer/validations/numericality.cr
@@ -23,10 +23,40 @@ module Jennifer
 
           errors.add(field, :other_than, { :value => other_than }) if other_than.try(&.== value)
 
-          errors.add(field, :odd) if odd && value.even?
+          errors.add(field, :odd) if odd && even?(value)
 
-          errors.add(field, :even) if even && value.odd?
+          errors.add(field, :even) if even && odd?(value)
         end
+      end
+
+      private def odd?(value : Int)
+        value.odd?
+      end
+
+      private def even?(value : Int | Float)
+        !odd?(value)
+      end
+
+      private def odd?(value : Float64)
+        odd?(value.to_i64)
+      end
+
+      private def odd?(value : Float32)
+        odd?(value.to_i)
+      end
+
+      private def odd?(value : Nil)
+      end
+
+      private def even?(value : Nil)
+      end
+
+      private def odd?(value)
+        raise ArgumentError.new("'#{value.inspect}' doesn't support :even validation")
+      end
+
+      private def even?(value)
+        raise ArgumentError.new("'#{value.inspect}' doesn't support :odd validation")
       end
     end
   end


### PR DESCRIPTION
# What does this PR do?

Fix `odd` and `even` numeric validator options for non integer arguments (fix #224 )

# Release notes

**Validation**

* fix `odd` and `even` numeric validator options for non integer arguments
