### PR TITLE
fixing validates_uniqueness typo in the documentation

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -298,7 +298,7 @@ class Country < Jennifer::Model::Base
     code: String
   )
 
-  validate_uniqueness :code
+  validates_uniqueness :code
 end
 ```
 


### PR DESCRIPTION
This is just fixing a small typo in the documentation for validates_uniqueness, the corresponding method has an "s".