### PR TITLE
Add model mapping inheritance

### DIFF
--- a/docs/model_mapping.md
+++ b/docs/model_mapping.md
@@ -102,7 +102,11 @@ end
 
 ## Mapping definition
 
-`%mapping(options, strict = true)` macros stands for defining all model attributes. If field has no extra parameter, you can just specify name and type (type in case of crystal language): `field_name: :Type`. Named tuple can be used instead of type. Next keys are supported:
+You should define all fields that you'd like to grep from the particular table, other words - define model's mapping.
+
+`%mapping(options, strict = true)` macro stands for defining all model attributes. If field has no extra parameter,
+you can just specify name and type (type in case of crystal language): `field_name: :Type`. Named tuple can be used
+instead of type. Next keys are supported:
 
 | argument | description |
 | --- | --- |
@@ -110,6 +114,7 @@ end
 | `:primary` | mark field as primary key (default is `false`) |
 | `:null` | allows field to be `nil` (default is `false` for all fields except primary key |
 | `:default` | default value which will be set during creating **new** object |
+| `:column` | database column name associated with this attribute (default is attribute name) |
 | `:getter` | if getter should be created (default - `true`) |
 | `:setter` | if setter should be created (default - `true`) |
 | `:virtual` | mark field as virtual - will not be stored and retrieved from db |

--- a/docs/timestamps.md
+++ b/docs/timestamps.md
@@ -1,14 +1,17 @@
 # Timestamps
 
-`with_timestamps` macros adds callbacks for `created_at` and `updated_at` fields update. But now they still should be mentioned in mapping manually:
+`with_timestamps` macros adds callbacks for `created_at` and `updated_at` fields update. But now they still should be defined in the mapping manually:
 
 ```crystal
 class MyModel < Jennifer::Model::Base
   with_timestamps
+
   mapping(
     id: { type: Int32, primary: true },
-    created_at:  {type: Time, null: true},
-    updated_at:  {type: Time, null: true}
+    created_at: { type: Time, null: true },
+    updated_at: { type: Time, null: true }
   )
 end
 ```
+
+`created_at` field is populated with current time when corresponding record is stored to the database. `updated_at` - whenever record is updated (the way that callbacks are invoked).

--- a/spec/models.cr
+++ b/spec/models.cr
@@ -73,40 +73,41 @@ class User < ApplicationRecord
 end
 
 class Contact < ApplicationRecord
-  with_timestamps
-
   module Mapping
-    macro included
-      {% if env("DB") == "postgres" || env("DB") == nil %}
-        mapping(
-          id:          Primary32,
-          name:        String,
-          ballance:    PG::Numeric?,
-          age:         {type: Int32, default: 10},
-          gender:      {type: String?, default: "male"},
-          description: String?,
-          created_at:  Time?,
-          updated_at:  Time?,
-          user_id:     Int32?,
-          tags:        { type: Array(Int32)? }
-        )
-      {% else %}
-        mapping(
-          id:          Primary32,
-          name:        String,
-          ballance:    Float64?,
-          age:         {type: Int32, default: 10},
-          gender:      {type: String?, default: "male"},
-          description: String?,
-          created_at:  Time?,
-          updated_at:  Time?,
-          user_id:     Int32?
-        )
-      {% end %}
-    end
+    include Jennifer::Model::Mapping
+
+    {% if env("DB") == "postgres" || env("DB") == nil %}
+      mapping(
+        id:          Primary32,
+        name:        String,
+        ballance:    PG::Numeric?,
+        age:         {type: Int32, default: 10},
+        gender:      {type: String?, default: "male"},
+        description: String?,
+        created_at:  Time?,
+        updated_at:  Time?,
+        user_id:     Int32?,
+        tags:        { type: Array(Int32)? }
+      )
+    {% else %}
+      mapping(
+        id:          Primary32,
+        name:        String,
+        ballance:    Float64?,
+        age:         {type: Int32, default: 10},
+        gender:      {type: String?, default: "male"},
+        description: String?,
+        created_at:  Time?,
+        updated_at:  Time?,
+        user_id:     Int32?
+      )
+    {% end %}
   end
 
   include Mapping
+
+  with_timestamps
+  mapping
 
   has_many :addresses, Address, inverse_of: :contact
   has_many :facebook_profiles, FacebookProfile, inverse_of: :contact
@@ -577,7 +578,7 @@ class Author < Jennifer::Model::Base
   })
 end
 
-abstract class Publication < Jennifer::Model::Base
+class Publication < Jennifer::Model::Base
   mapping({
     id:         Primary32,
     name:       { type: String, column: :title },

--- a/spec/query_builder/function_spec.cr
+++ b/spec/query_builder/function_spec.cr
@@ -129,7 +129,8 @@ describe Jennifer::QueryBuilder::Function do
 
     it do
       Factory.create_contact
-      Jennifer::Query["contacts"].select { [current_date.alias("current_d")] }.first!.current_d(Time).should eq(Time.unix(Time.now.to_unix).date)
+      Jennifer::Query["contacts"].select { [current_date.alias("current_d")] }.first!.current_d(Time).date
+        .should eq(Time.unix(Time.now.to_unix).date)
     end
   end
 

--- a/spec/relation/polymorphic_belongs_to_spec.cr
+++ b/spec/relation/polymorphic_belongs_to_spec.cr
@@ -10,6 +10,8 @@ module Spec
   class Contact < ApplicationRecord
     include ::Contact::Mapping
 
+    mapping
+
     has_one :note, Note, inverse_of: :notable, polymorphic: true, dependent: :nullify
   end
 end

--- a/src/jennifer/adapter/postgres/converters.cr
+++ b/src/jennifer/adapter/postgres/converters.cr
@@ -1,5 +1,8 @@
 module Jennifer
   module Model
+    # Type converter for Postgre numeric field.
+    #
+    # Converts `PG::Numeric` to `Float64` and back.
     class NumericToFloat64Converter
       def self.from_db(pull, nillable)
         if nillable

--- a/src/jennifer/macros.cr
+++ b/src/jennifer/macros.cr
@@ -10,13 +10,13 @@ module Jennifer
     # :nodoc:
     AUTOINCREMENTABLE_STR_TYPES = %w(Int32 Int64)
 
-    # Primary key type (Int32).
+    # Mapping type for `Int32` primary key.
     Primary32 = {
       type: Int32,
       primary: true
     }
 
-    # Primary key type (Int64).
+    # Mapping type for `Int64` primary key.
     Primary64 = {
       type: Int64,
       primary: true

--- a/src/jennifer/model/callback.cr
+++ b/src/jennifer/model/callback.cr
@@ -1,7 +1,7 @@
 module Jennifer
   module Model
     # Callbacks are hooks into the life cycle of a model object that allow you to trigger logic before
-    #  or after an alteration of the object state.
+    # or after an alteration of the object state.
     module Callback
       protected def __before_save_callback
         true
@@ -83,18 +83,24 @@ module Jennifer
       #
       # Note that these callbacks are already wrapped in the transaction around save.
       macro before_save(*names)
-        {% for name in names %}
-          {% CALLBACKS[:save][:before] << name.id.stringify %}
-        {% end %}
+        {%
+          names.reduce(CALLBACKS[:save][:before]) do |array, name|
+            array << name.id.stringify
+            array
+          end
+        %}
       end
 
       # Defines callbacks which are called after `Base.save` (regardless of whether it's a `create` or `update` save).
       #
       # Note that these callbacks are still wrapped in the transaction around save.
       macro after_save(*names)
-        {% for name in names %}
-          {% CALLBACKS[:save][:after] << name.id.stringify %}
-        {% end %}
+        {%
+          names.reduce(CALLBACKS[:save][:after]) do |array, name|
+            array << name.id.stringify
+            array
+          end
+        %}
       end
 
       # Defines callbacks which are called before `Base.save` on new objects that haven’t been saved yet
@@ -102,9 +108,12 @@ module Jennifer
       #
       # Note that these callbacks are already wrapped in the transaction around save.
       macro before_create(*names)
-        {% for name in names %}
-          {% CALLBACKS[:create][:before] << name.id.stringify %}
-        {% end %}
+        {%
+          names.reduce(CALLBACKS[:create][:before]) do |array, name|
+            array << name.id.stringify
+            array
+          end
+        %}
       end
 
       # Defines callbacks which are called after `Base.save` on new objects that haven’t been saved yet
@@ -112,67 +121,92 @@ module Jennifer
       #
       # Note that these callbacks is still wrapped in the transaction around save.
       macro after_create(*names)
-        {% for name in names %}
-          {% CALLBACKS[:create][:after] << name.id.stringify %}
-        {% end %}
+        {%
+          names.reduce(CALLBACKS[:create][:after]) do |array, name|
+            array << name.id.stringify
+            array
+          end
+        %}
       end
 
       # Defines callbacks which are called before `Base.save` on existing objects that have a record.
       #
       # Note that these callbacks are already wrapped in the transaction around save.
       macro before_update(*names)
-        {% for name in names %}
-          {% CALLBACKS[:update][:before] << name.id.stringify %}
-        {% end %}
+        {%
+          names.reduce(CALLBACKS[:update][:before]) do |array, name|
+            array << name.id.stringify
+            array
+          end
+        %}
       end
 
       # Defines callbacks which are called after `Base.save` on existing objects that have a record.
       #
       # Note that these callbacks are still wrapped in the transaction around save.
       macro after_update(*names)
-        {% for name in names %}
-          {% CALLBACKS[:update][:after] << name.id.stringify %}
-        {% end %}
+        {%
+          names.reduce(CALLBACKS[:update][:after]) do |array, name|
+            array << name.id.stringify
+            array
+          end
+        %}
       end
 
       # Defines callbacks which are called after `Base.build` call.
       macro after_initialize(*names)
-        {% for name in names %}
-          {% CALLBACKS[:initialize][:after] << name.id.stringify %}
-        {% end %}
+        {%
+          names.reduce(CALLBACKS[:initialize][:after]) do |array, name|
+            array << name.id.stringify
+            array
+          end
+        %}
       end
 
       # Defines callbacks which are called before `Base.destroy`
       macro before_destroy(*names)
-        {% for name in names %}
-          {% CALLBACKS[:destroy][:before] << name.id.stringify %}
-        {% end %}
+        {%
+          names.reduce(CALLBACKS[:destroy][:before]) do |array, name|
+            array << name.id.stringify
+            array
+          end
+        %}
       end
 
       # Defines callbacks which are called after `Base.destroy`.
       macro after_destroy(*names)
-        {% for name in names %}
-          {% CALLBACKS[:destroy][:after] << name.id.stringify %}
-        {% end %}
+        {%
+          names.reduce(CALLBACKS[:destroy][:after]) do |array, name|
+            array << name.id.stringify
+            array
+          end
+        %}
       end
 
       # Defines callbacks which are called before `Base.validate!` (which is part of the `Base.save` call).
       macro before_validation(*names)
-        {% for name in names %}
-          {% CALLBACKS[:validation][:before] << name.id.stringify %}
-        {% end %}
+        {%
+          names.reduce(CALLBACKS[:validation][:before]) do |array, name|
+            array << name.id.stringify
+            array
+          end
+        %}
       end
 
       # Defines callbacks which are called after `Base.validate!` (which is part of the `Base.save` call).
       macro after_validation(*names)
-        {% for name in names %}
-          {% CALLBACKS[:validation][:after] << name.id.stringify %}
-        {% end %}
+        {%
+          names.reduce(CALLBACKS[:validation][:after]) do |array, name|
+            array << name.id.stringify
+            array
+          end
+        %}
       end
 
       # Defines callbacks which are called after a record has been created, updated, or destroyed.
       #
       # You can specify that the callback should only be fired by a certain action with the :on option:
+      #
       # ```
       # after_commit :var, on: :save
       # after_commit :foo, on: :create
@@ -180,24 +214,34 @@ module Jennifer
       # after_commit :baz, on: :destroy
       # ```
       macro after_commit(*names, on)
-        {% unless [:create, :save, :destroy, :update].includes?(on) %}
-          {% raise "#{on} is invalid action for %after_commit callback." %}
-        {% end %}
-        {% for name in names %}
-          {% CALLBACKS[on][:commit] << name %}
-        {% end %}
+        {%
+          unless %i(create save destroy update).includes?(on)
+            raise "#{on} is invalid action for 'after_commit' callback."
+          end
+        %}
+        {%
+          names.reduce(CALLBACKS[on][:commit]) do |array, name|
+            array << name.id.stringify
+            array
+          end
+        %}
       end
 
       # Defines callbacks which are called after a create, update, or destroy are rolled back.
       #
       # Please check the documentation of `after_commit` macro for options.
       macro after_rollback(*names, on)
-        {% unless [:create, :save, :destroy, :update].includes?(on) %}
-          {% raise "#{on} is invalid action for %after_rollback callback." %}
-        {% end %}
-        {% for name in names %}
-          {% CALLBACKS[on][:rollback] << name %}
-        {% end %}
+        {%
+          unless %i(create save destroy update).includes?(on)
+            raise "#{on} is invalid action for 'after_rollback' callback."
+          end
+        %}
+        {%
+          names.reduce(CALLBACKS[on][:rollback]) do |array, name|
+            array << name.id.stringify
+            array
+          end
+        %}
       end
 
       # :nodoc:
@@ -242,7 +286,7 @@ module Jennifer
       macro finished_hook
         {% verbatim do %}
           {% for type in [:before, :after] %}
-            {% for action in [:save, :create, :destroy, :validation, :update] %}
+            {% for action in %i(save create destroy validation update) %}
               {% if !CALLBACKS[action][type].empty? %}
                 protected def __{{type.id}}_{{action.id}}_callback
                   return false unless super
@@ -255,7 +299,7 @@ module Jennifer
             {% end %}
           {% end %}
 
-          {% for action in ["save", "create", "destroy", "update"] %}
+          {% for action in %i(save create destroy update) %}
             {% for type in ["commit", "rollback"] %}
               {% constant_name = "HAS_#{action.upcase.id}_#{type.upcase.id}_CALLBACK" %}
               {% if !CALLBACKS[action][type].empty? %}

--- a/src/jennifer/model/common_mapping.cr
+++ b/src/jennifer/model/common_mapping.cr
@@ -1,0 +1,159 @@
+module Jennifer::Model
+  # :nodoc:
+  module CommonMapping
+    # :nodoc:
+    macro common_mapping(strict)
+      {%
+        primary = COLUMNS_METADATA.keys.find { |field| COLUMNS_METADATA[field][:primary] }
+        primary_auto_incrementable = primary && AUTOINCREMENTABLE_STR_TYPES.includes?(COLUMNS_METADATA[primary][:type].stringify)
+        properties = COLUMNS_METADATA
+        nonvirtual_attrs = properties.keys.select { |attr| !properties[attr][:virtual] }
+        raise "Model #{@type} has no defined primary field. For now model without primary field is not allowed" if primary == nil
+      %}
+
+      __field_declaration({{properties}}, {{primary_auto_incrementable}})
+
+      # :nodoc:
+      def self.field_count
+        {{properties.size}}
+      end
+
+      # :nodoc:
+      FIELD_NAMES = [{{properties.keys.map { |e| "#{e.id.stringify}" }.join(", ").id}}]
+
+      # :nodoc:
+      def self.field_names
+        FIELD_NAMES
+      end
+
+      # :nodoc:
+      def self.columns_tuple
+        COLUMNS_METADATA
+      end
+
+      @[JSON::Field(ignore: true)]
+      @new_record = true
+      @[JSON::Field(ignore: true)]
+      @destroyed = false
+
+      # Creates object from `DB::ResultSet`
+      def initialize(%pull : DB::ResultSet)
+        @new_record = false
+        {{properties.keys.map { |key| "@#{key.id}" }.join(", ").id}} = _extract_attributes(%pull)
+      end
+
+      # :nodoc:
+      def self.new(pull : DB::ResultSet)
+        {% verbatim do %}
+        {% begin %}
+          {% klasses = @type.all_subclasses.select { |s| s.constant("STI") == true } %}
+          {% if !klasses.empty? %}
+            hash = adapter.result_to_hash(pull)
+            case hash["type"]
+            when "", nil, "{{@type}}"
+              new(hash, false)
+            {% for klass in klasses %}
+            when "{{klass}}"
+              {{klass}}.new(hash, false)
+            {% end %}
+            else
+              raise ::Jennifer::UnknownSTIType.new(self, hash["type"])
+            end
+          {% else %}
+            instance = allocate
+            instance.initialize(pull)
+            instance.__after_initialize_callback
+            instance
+          {% end %}
+        {% end %}
+        {% end %}
+      end
+
+      # Accepts symbol hash or named tuple, stringify it and calls constructor with string-based keys hash.
+      def initialize(values : Hash(Symbol, ::Jennifer::DBAny) | NamedTuple)
+        initialize(Ifrit.stringify_hash(values, Jennifer::DBAny))
+      end
+
+      # :nodoc:
+      def self.new(values : Hash(Symbol, ::Jennifer::DBAny) | NamedTuple)
+        instance = allocate
+        instance.initialize(values)
+        instance.__after_initialize_callback
+        instance
+      end
+
+      def initialize(values : Hash(String, ::Jennifer::DBAny))
+        {{properties.keys.map { |key| "@#{key.id}" }.join(", ").id}} = _extract_attributes(values)
+      end
+
+      # :nodoc:
+      def self.new(values : Hash(String, ::Jennifer::DBAny))
+        instance = allocate
+        instance.initialize(values)
+        instance.__after_initialize_callback
+        instance
+      end
+
+      # :nodoc:
+      def initialize(values : Hash | NamedTuple, @new_record)
+        initialize(values)
+      end
+
+      # :nodoc:
+      def self.new(values : Hash | NamedTuple, new_record : Bool)
+        instance = allocate
+        instance.initialize(values, new_record)
+        instance.__after_initialize_callback
+        instance
+      end
+
+      # :nodoc:
+      def to_h
+        {
+          {% for key in nonvirtual_attrs %}
+            :{{key.id}} => {{key.id}},
+          {% end %}
+        } of Symbol => ::Jennifer::DBAny
+      end
+
+      # :nodoc:
+      def to_str_h
+        {
+          {% for key in nonvirtual_attrs %}
+            {{key.stringify}} => {{key.id}},
+          {% end %}
+        } of String => ::Jennifer::DBAny
+      end
+
+      # :nodoc:
+      def attribute(name : String | Symbol, raise_exception : Bool = true)
+        case name.to_s
+        {% for attr in properties.keys %}
+        when "{{attr.id}}"
+          @{{attr.id}}
+        {% end %}
+        else
+          raise ::Jennifer::BaseException.new("Unknown model attribute - #{name}") if raise_exception
+        end
+      end
+
+      private def init_attributes(values : Hash)
+        {{properties.keys.map { |key| "@#{key.id}" }.join(", ").id}} = _extract_attributes(values)
+      end
+
+      private def init_attributes(values : DB::ResultSet)
+        {{properties.keys.map { |key| "@#{key.id}" }.join(", ").id}} = _extract_attributes(values)
+      end
+
+      private def inspect_attributes(io) : Nil
+        io << ' '
+        {% for var, i in properties.keys %}
+          {% if i > 0 %} io << ", " {% end %}
+          io << "{{var.id}}: "
+          @{{var.id}}.inspect(io)
+        {% end %}
+        nil
+      end
+    end
+  end
+end

--- a/src/jennifer/model/converters.cr
+++ b/src/jennifer/model/converters.cr
@@ -1,5 +1,8 @@
 module Jennifer
   module Model
+    # Default converter for `JSON::Any` fields.
+    #
+    # Converts json string to `JSON::Any` and back.
     class JSONConverter
       def self.from_db(pull, nillable)
         nillable ? pull.read(JSON::Any?) : pull.read(JSON::Any)

--- a/src/jennifer/model/field_declaration.cr
+++ b/src/jennifer/model/field_declaration.cr
@@ -1,0 +1,101 @@
+module Jennifer::Model
+  module FieldDeclaration
+    # :nodoc:
+    macro __bool_convert(value, type)
+      {% if type.stringify == "Bool" %}
+        ({{value.id}}.is_a?(Int8) ? {{value.id}} == 1i8 : {{value.id}}.as({{type}}))
+      {% else %}
+        {{value}}.as({{type}})
+      {% end %}
+    end
+
+    # TODO: remove .primary_field_type method as it isn't used anywhere
+
+    # :nodoc:
+    macro __field_declaration(properties, primary_auto_incrementable)
+      {% for key, value in properties %}
+        @{{key.id}} : {{value[:parsed_type].id}}
+        @[JSON::Field(ignore: true)]
+        @{{key.id}}_changed = false
+
+        {% if value[:setter] != false %}
+          def {{key.id}}=(_{{key.id}} : {{value[:parsed_type].id}})
+            {% if !value[:virtual] %}
+              @{{key.id}}_changed = true if _{{key.id}} != @{{key.id}}
+            {% end %}
+            @{{key.id}} = _{{key.id}}
+          end
+
+          def {{key.id}}=(_{{key.id}} : ::Jennifer::DBAny)
+            {% if !value[:virtual] %}
+              @{{key.id}}_changed = true if _{{key.id}} != @{{key.id}}
+            {% end %}
+            @{{key.id}} = _{{key.id}}.as({{value[:parsed_type].id}})
+          end
+        {% end %}
+
+        {% if value[:getter] != false %}
+          def {{key.id}}
+            @{{key.id}}
+          end
+
+          {% if value[:null] != false %}
+            def {{key.id}}!
+              @{{key.id}}.not_nil!
+            end
+          {% end %}
+
+          {% resolved_type = value[:type].resolve %}
+          {% if resolved_type == Bool || (resolved_type.union? && resolved_type.union_types[0] == Bool) %}
+            def {{key.id}}?
+              {{key.id}} == true
+            end
+          {% end %}
+        {% end %}
+
+        {% if !value[:virtual] %}
+          def {{key.id}}_changed?
+            @{{key.id}}_changed
+          end
+
+          def self._{{key}}
+            c({{value[:column]}})
+          end
+
+          {% if value[:primary] %}
+            # :nodoc:
+            def primary
+              @{{key.id}}
+            end
+
+            # :nodoc:
+            def self.primary
+              c({{value[:column]}})
+            end
+
+            # :nodoc:
+            def self.primary_field_name
+              "{{key.id}}"
+            end
+
+            # :nodoc:
+            def self.primary_field_type
+              {{value[:parsed_type].id}}
+            end
+
+            # :nodoc:
+            def init_primary_field(value : Int)
+              {% if primary_auto_incrementable %}
+                raise ::Jennifer::AlreadyInitialized.new(@{{key.id}}, value) if @{{key.id}}
+                @{{key.id}} = value{% if value[:parsed_type] =~ /32/ %}.to_i{% else %}.to_i64{% end %}
+              {% end %}
+            end
+
+            # :nodoc:
+            def init_primary_field(value); end
+          {% end %}
+        {% end %}
+      {% end %}
+    end
+  end
+end

--- a/src/jennifer/model/resource.cr
+++ b/src/jennifer/model/resource.cr
@@ -109,6 +109,12 @@ module Jennifer
       @@has_table : Bool?
       @@table_name : String?
 
+      # Returns a string containing a human-readable representation of object.
+      #
+      # ```
+      # Address.new.inspect
+      # # => "#<Address:0x7f532bdd5340 id: nil, street: "Ant st. 69", contact_id: nil, created_at: nil, updated_at: nil>"
+      # ```
       def inspect(io) : Nil
         io << "#<" << {{@type.name.id.stringify}} << ":0x"
         object_id.to_s(16, io)
@@ -156,6 +162,7 @@ module Jennifer
         Adapter.adapter
       end
 
+      # Returns `QueryBuilder::ExpressionBuilder` object of this resource's table.
       def self.context
         @@expression_builder ||= QueryBuilder::ExpressionBuilder.new(table_name)
       end
@@ -176,26 +183,38 @@ module Jennifer
       end
 
       # Starts database transaction.
+      #
+      # For more details see `Jennifer::Adapter::Transactions`.
       def self.transaction
         adapter.transaction do |t|
           yield(t)
         end
       end
 
+      # Returns criterion for column *name* of resource's table.
+      #
+      # ```
+      # User.c(:email) # => users.email
+      # ```
       def self.c(name : String | Symbol)
         context.c(name.to_s)
       end
 
       def self.c(name : String | Symbol, relation)
-        ::Jennifer::QueryBuilder::Criteria.new(name.to_s, table_name, relation)
+        QueryBuilder::Criteria.new(name.to_s, table_name, relation)
       end
 
+      # Returns star field statement for current resource's table.
+      #
+      # ```
+      # User.star # => users.*
+      # ```
       def self.star
         context.star
       end
 
       def self.relation(name)
-        raise Jennifer::UnknownRelation.new(self, name)
+        raise UnknownRelation.new(self, name)
       end
 
       def append_relation(name : String, hash)


### PR DESCRIPTION
# What does this PR do?

Allows defining reusable column mapping in modules and abstract classes.

# Any background context you want to provide?

Requested here #229 this functionality allows to make some common mapping (like id definition, `created_at`, `updated_at` columns) and reuse it across application.

# Release notes

**Model**

* `Mapping` module now can be included by another module with mapping definition
* `STIMapping` now doesn't convert result set to hash and use same logic as `Mapping`

**View**

* mapping shares same functionality as `Model`
