### PR TITLE
remove redundant require of ifrit

### DIFF
--- a/spec/query_builder/function_spec.cr
+++ b/spec/query_builder/function_spec.cr
@@ -115,7 +115,7 @@ describe Jennifer::QueryBuilder::Function do
 
     it do
       Factory.create_contact
-      Jennifer::Query["contacts"].select { [current_date.alias("current_d")] }.first!.current_d(Time).should eq(Time.unix(Time.now.to_unix).date)
+      Jennifer::Query["contacts"].select { [current_date.alias("current_d")] }.first!.current_d(Time).should eq(Time.unix(Time.now.to_unix).at_beginning_of_day)
     end
   end
 

--- a/src/jennifer/adapter/base.cr
+++ b/src/jennifer/adapter/base.cr
@@ -1,5 +1,4 @@
 require "db"
-require "ifrit"
 require "./shared/*"
 require "./transactions"
 require "./result_parsers"


### PR DESCRIPTION
Hi.

It's not necessary here :)

In "ifrit" you have the class called `HashWithIndifferentAccess`, which triggers a Crystal bug, it unable to compile jennifer.cr with raven.cr - https://github.com/Sija/raven.cr/issues/49.

I guess `HashWithIndifferentAccess` not used in this shard.