### PR TITLE
Doesn't fail on db:create when database already exists

### DIFF
--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -23,7 +23,9 @@ Creates database described in the configuration.
 $ crystal sam.cr -- db:create
 ```
 
-> Will create only **one** database. This means that for test environment this command should be invoked separately. This is common for all commands in this section.
+> Will create only **one** database. This means that for test environment (and for any extra environment you want) this command should be invoked separately. This is common for all commands in this section.
+
+If database is already exists - successfully finishes (returns code 0).
 
 ### db:drop
 

--- a/spec/integration/sam_test.cr
+++ b/spec/integration/sam_test.cr
@@ -11,6 +11,15 @@ describe "Blank application" do
         execute("crystal spec/integration/sam/blank_application.cr", ["db:create"]).should succeed
       end
     end
+
+    context "when database already exists" do
+      it do
+        clean do
+          execute("crystal spec/integration/sam/blank_application.cr", ["db:create"]).should succeed
+          execute("crystal spec/integration/sam/blank_application.cr", ["db:create"]).should succeed
+        end
+      end
+    end
   end
 
   describe "db:drop" do

--- a/src/jennifer/adapter/base.cr
+++ b/src/jennifer/adapter/base.cr
@@ -192,6 +192,10 @@ module Jennifer
         command_interface.drop_database
       end
 
+      def self.database_exists?
+        command_interface.database_exists?
+      end
+
       # Yields to block connection to the database main schema.
       def self.db_connection
         DB.open(connection_string) do |db|

--- a/src/jennifer/adapter/command_shell/i_command_shell.cr
+++ b/src/jennifer/adapter/command_shell/i_command_shell.cr
@@ -17,7 +17,7 @@ module Jennifer
         io = IO::Memory.new
         result = Process.run(command_string, options, shell: true, output: io, error: io)
         raise Command::Failed.new(result.exit_code, io) if result.exit_code != 0
-        result
+        {status: result, output: io}
       end
     end
   end

--- a/src/jennifer/adapter/db_command_interface.cr
+++ b/src/jennifer/adapter/db_command_interface.cr
@@ -18,6 +18,7 @@ module Jennifer
       abstract def create_database
       abstract def generate_schema
       abstract def load_schema
+      abstract def database_exists?
 
       def execute(command)
         shell.execute(command)

--- a/src/jennifer/adapter/mysql.cr
+++ b/src/jennifer/adapter/mysql.cr
@@ -142,6 +142,19 @@ module Jennifer
           db.exec "DROP DATABASE #{Config.db}"
         end
       end
+
+      def self.database_exists? : Bool
+        db_connection do |db|
+          db.scalar <<-SQL,
+            SELECT EXISTS(
+              SELECT 1
+              FROM INFORMATION_SCHEMA.SCHEMATA
+              WHERE SCHEMA_NAME = ?
+            )
+          SQL
+          Config.db
+        end == 1
+      end
     end
   end
 end

--- a/src/jennifer/adapter/mysql/command_interface.cr
+++ b/src/jennifer/adapter/mysql/command_interface.cr
@@ -11,6 +11,10 @@ module Jennifer
         raise AbstractMethod.new("drop_database", self)
       end
 
+      def database_exists?
+        raise AbstractMethod.new("database_exists?", self)
+      end
+
       def generate_schema
         options = ["-u", config.user, "--no-data", "-h", config.host, "--skip-lock-tables", config.db]
         options += ["--password=#{config.password}"] if !config.password.empty?

--- a/src/jennifer/adapter/postgres/command_interface.cr
+++ b/src/jennifer/adapter/postgres/command_interface.cr
@@ -23,6 +23,16 @@ module Jennifer
         execute(command)
       end
 
+      def database_exists?
+        options = ["-U", config.user, "-l"] of Command::Option
+        command = Command.new(
+          executable: "psql",
+          options: options,
+          inline_vars: default_env_variables
+        )
+        execute(command)[:output].to_s.split("\n")[2..-1].any?(&.[](/([^|]*)? |/).strip.==(config.db))
+      end
+
       def generate_schema
         options = ["-U", config.user, "-d", config.db, "-h", config.host, "-s"] of Command::Option
         command = Command.new(

--- a/src/jennifer/migration/runner.cr
+++ b/src/jennifer/migration/runner.cr
@@ -33,15 +33,19 @@ module Jennifer
       # Creates database.
       def self.create
         # TODO: allow to specify adapter
-        r = default_adapter_class.create_database
-        puts "DB is created!"
+        if default_adapter_class.database_exists?
+          puts "#{Config.db} is already exists"
+        else
+          default_adapter_class.create_database
+          puts "#{Config.db} is created!"
+        end
       end
 
       # Drops database.
       def self.drop
         # TODO: allow to specify adapter
         r = default_adapter_class.drop_database
-        puts "DB is dropped!"
+        puts "#{Config.db} is dropped!"
       end
 
       # Rollbacks migrations.


### PR DESCRIPTION
# What does this PR do?

Allow to invoke `sam db:create` when database already exists without getting any error

# Any background context you want to provide?

This simplifies deployment process.

# Release notes

**General**

* `db:create` command doesn't fail if database already exists