### PR TITLE
Restrict result type of Executables#exists? to Bool

### DIFF
--- a/src/jennifer/adapter/base.cr
+++ b/src/jennifer/adapter/base.cr
@@ -93,7 +93,7 @@ module Jennifer
         exec(*parse_query(sql_generator.delete(query), query.sql_args))
       end
 
-      def exists?(query : QueryBuilder::Query)
+      def exists?(query : QueryBuilder::Query) : Bool
         scalar(*parse_query(sql_generator.exists(query), query.sql_args)) == 1
       end
 

--- a/src/jennifer/adapter/postgres.cr
+++ b/src/jennifer/adapter/postgres.cr
@@ -209,8 +209,8 @@ module Jennifer
         ExecResult.new(id, affected)
       end
 
-      def exists?(query)
-        scalar(*parse_query(sql_generator.exists(query), query.sql_args))
+      def exists?(query) : Bool
+        scalar(*parse_query(sql_generator.exists(query), query.sql_args)).as(Bool)
       end
     end
   end

--- a/src/jennifer/query_builder/executables.cr
+++ b/src/jennifer/query_builder/executables.cr
@@ -79,7 +79,7 @@ module Jennifer
       end
 
       # Returns whether any record satisfying given conditions exists.
-      def exists?
+      def exists? : Bool
         return false if do_nothing?
         adapter.exists?(self)
       end


### PR DESCRIPTION
# What does this PR do?
This pull request restricts the APIs of `Executables#exists?`, `Jennifer::Adapter::Base#exists?` and `Jennifer::Adapter::Postgres#exists?` to always return results of type `Bool`.

Related issue: #241

# Release notes

**QueryBuilder**
- Fix result type of `Executables#exists?` query method to `Bool`

**Adapter**
- Fix result type of `#exists?` query method to `Bool` for `Base` and `Postgres` adapters