### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ To create the databases:
 $ make sam db:setup
 
 # Mysql
-$ DB=mysql make same db:setup
+$ DB=mysql make sam db:setup
 ```
 
 ### Running tests


### PR DESCRIPTION
# What does this PR do?
Fixes a typo in the *README* section `Development`
