### PR TITLE
Add model primary key autoincrementation configuration

### DIFF
--- a/docs/model_mapping.md
+++ b/docs/model_mapping.md
@@ -119,6 +119,7 @@ instead of type. Next keys are supported:
 | `:setter` | if setter should be created (default - `true`) |
 | `:virtual` | mark field as virtual - will not be stored and retrieved from db |
 | `:converter` | class be used to serialize/deserialize value |
+| `:auto` | indicate whether primary field is autoincrementable (by default `true` for `Int32` and `Int64`) |
 
 To define field converter create a class which implements next methods:
 

--- a/spec/model/base_spec.cr
+++ b/spec/model/base_spec.cr
@@ -191,6 +191,13 @@ describe Jennifer::Model::Base do
           .should eq(a.id)
       end
     end
+
+    context "with non-auto primary key" do
+      it do
+        NoteWithManualId.create(id: 1)
+        NoteWithManualId.all.where { _id == 1 }.exists?.should be_true
+      end
+    end
   end
 
   describe "::create!" do

--- a/spec/model/mapping_spec.cr
+++ b/spec/model/mapping_spec.cr
@@ -151,14 +151,6 @@ describe Jennifer::Model::Mapping do
       end
     end
 
-    it "define default constructor if all fields are nillable or have default values" do
-      Passport::WITH_DEFAULT_CONSTRUCTOR.should be_true
-    end
-
-    it "defines no defulat constructor if at least one field is not nillable and has no default" do
-      Contact::WITH_DEFAULT_CONSTRUCTOR.should be_false
-    end
-
     describe ".new" do
       context "loading STI objects from request" do
         it "creates proper objects" do
@@ -716,6 +708,12 @@ describe Jennifer::Model::Mapping do
         match_array(r[:args], db_array("Prob", "AblyTheLast"))
         match_array(r[:fields], %w(first_name last_name))
       end
+
+      it "includes non autoincrementable primary field" do
+        r = NoteWithManualId.new({ id: 12, text: "test" }).arguments_to_insert
+        match_array(r[:args], db_array(12, "test", nil, nil))
+        match_array(r[:fields], %w(id text created_at updated_at))
+      end
     end
 
     describe "#to_h" do
@@ -742,6 +740,11 @@ describe Jennifer::Model::Mapping do
         hash = Author.build(name1: "NoIt", name2: "SNot").to_str_h
         hash.keys.should eq(%w(id name1 name2))
       end
+    end
+
+    describe ".primary_auto_incrementable?" do
+      it { Note.primary_auto_incrementable?.should be_true }
+      it { NoteWithManualId.primary_auto_incrementable?.should be_false }
     end
   end
 

--- a/spec/models.cr
+++ b/spec/models.cr
@@ -570,6 +570,19 @@ class AddressWithNilableBool < Jennifer::Model::Base
     main: Bool?
   }, false)
 end
+
+class NoteWithManualId < Jennifer::Model::Base
+  table_name "notes"
+  with_timestamps
+
+  mapping(
+    id: { type: Primary32, auto: false },
+    text: { type: String? },
+    created_at: Time?,
+    updated_at: Time?
+  )
+end
+
 class Author < Jennifer::Model::Base
   mapping({
     id:         Primary32,


### PR DESCRIPTION
# What does this PR do?

Add `:auto` key to model mapping to mark integer primary key as not autoincrementable.

# Release notes

**Model**

* add `:auto` mapping option to specify whether primary key is autoincrementable