### PR TITLE
Add query explain

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,12 @@ More details you can find in the documentation.
 Jennifer allows you to query the db using a flexible DSL:
 
 ```crystal
-Contact.all.left_join(Passport) { _contact_id == _contact__id }
-            .order(id: :asc).order(Contact._name.asc.nulls_last)
-            .with_relation(:passport).to_a
+Contact
+  .all
+  .left_join(Passport) { _contact_id == _contact__id }
+  .order(id: :asc).order(Contact._name.asc.nulls_last)
+  .with_relation(:passport)
+  .to_a
 Contact.all.eager_load(:countries).where { __countries { _name.like("%tan%") } }
 Contact.all.group(:gender).group_avg(:age, PG::Numeric)
 ```

--- a/spec/adapter/mysql_spec.cr
+++ b/spec/adapter/mysql_spec.cr
@@ -36,5 +36,22 @@ mysql_only do
         adapter.parse_query("asd %s asd", [2] of Jennifer::DBAny).should eq({"asd ? asd", [2]})
       end
     end
+
+    describe "#explain" do
+      it "has header" do
+        explanation = adapter.explain(Query["contacts"]).split("\n")
+
+        explanation[0].split("|").map(&.strip).should eq(%w(id select_type table partitions type possible_keys key key_len ref rows filtered Extra))
+      end
+
+      it "includes row data" do
+        explanation = adapter.explain(Query["contacts"]).split("\n")
+        cols = explanation[2].split("|").map(&.strip)
+        cols[0..8].should eq(%w(1 SIMPLE contacts NULL ALL NULL NULL NULL NULL))
+        cols[9].should match(/\d*/)
+        cols[10].should eq("100.0")
+        cols[11].should eq("NULL")
+      end
+    end
   end
 end

--- a/spec/adapter/postgres_spec.cr
+++ b/spec/adapter/postgres_spec.cr
@@ -116,5 +116,12 @@ postgres_only do
         end
       end
     end
+
+    describe "#explain" do
+      it do
+        adapter.explain(Query["contacts"])
+          .should match(/Seq Scan on contacts  \(cost=0\.00\.\.\d*\.\d* rows=\d* width=\d*\)/)
+      end
+    end
   end
 end

--- a/spec/query_builder/executables_spec.cr
+++ b/spec/query_builder/executables_spec.cr
@@ -479,4 +479,8 @@ describe Jennifer::QueryBuilder::Executables do
       res.size.should eq(0)
     end
   end
+
+  describe "#explain" do
+    it { Query["contacts"].explain.should_not be_empty }
+  end
 end

--- a/src/jennifer/adapter/base.cr
+++ b/src/jennifer/adapter/base.cr
@@ -326,6 +326,7 @@ module Jennifer
       abstract def table_column_count(table)
       abstract def tables_column_count(tables : Array(String))
       abstract def with_table_lock(table : String, type : String = "default", &block)
+      abstract def explain(q)
 
       def refresh_materialized_view(name)
         raise AbstractMethod.new(:refresh_materialized_view, self.class)

--- a/src/jennifer/adapter/base_sql_generator.cr
+++ b/src/jennifer/adapter/base_sql_generator.cr
@@ -16,6 +16,10 @@ module Jennifer
 
       extend ClassMethods
 
+      def self.explain(query)
+        "EXPLAIN #{self.select(query)}"
+      end
+
       # Generates insert query
       def self.insert(table, hash)
         String.build do |s|

--- a/src/jennifer/adapter/postgres.cr
+++ b/src/jennifer/adapter/postgres.cr
@@ -230,6 +230,19 @@ module Jennifer
       def exists?(query) : Bool
         scalar(*parse_query(sql_generator.exists(query), query.sql_args)).as(Bool)
       end
+
+      def explain(q)
+        body = sql_generator.explain(q)
+        args = q.sql_args
+        plan = ""
+        query(*parse_query(body, args)) do |rs|
+          rs.each do
+            plan = rs.read(String)
+          end
+        end
+
+        plan
+      end
     end
   end
 end

--- a/src/jennifer/query_builder/executables.cr
+++ b/src/jennifer/query_builder/executables.cr
@@ -430,6 +430,17 @@ module Jennifer
         end
         results
       end
+
+      # Returns query execution explanation.
+      #
+      # Format depends on used database adapter.
+      #
+      # ```
+      # Jennifer::Query["contacts"].explain # => "Seq Scan on contacts  (cost=0.00..13.40 rows=340 width=206)"
+      # ```
+      def explain : String
+        adapter.explain(self)
+      end
     end
   end
 end


### PR DESCRIPTION
# What does this PR do?

Add `#explain` method to the query which returns formatted output of `EXPLAIN` sql.

# Release notes

**QueryBuilder**

* add `Executables#explain`

**Adapter**

* add `Base#explain` abstract method and implementations for `Mysql` and `Postgres`

**SqlGenerator**

* add `.explain`