### PR TITLE
Add Int64 to Jennifer::Migration::TableBuilder::Base::AllowedTypes alias

### DIFF
--- a/src/jennifer/migration/table_builder/base.cr
+++ b/src/jennifer/migration/table_builder/base.cr
@@ -3,7 +3,7 @@ module Jennifer
     module TableBuilder
       abstract class Base
         # Base allowed types for migration DSL option values
-        alias AllowedTypes = String | Int32 | Bool | Float32 | Float64 | JSON::Any | Nil
+        alias AllowedTypes = String | Int32 | Int64 | Bool | Float32 | Float64 | JSON::Any | Nil
         # Allowed types for migration DSL + Symbol
         alias EAllowedTypes = AllowedTypes | Symbol
         # Allowed types for migration DSL including array


### PR DESCRIPTION
# What does this PR do?

Extends `Jennifer::Migration::TableBuilder::Base::AllowedTypes` alias with `Int64` type.

# Release notes

**Migration**

* extend `Jennifer::Migration::TableBuilder::Base::AllowedTypes` alias with `Int64` type.