### PR TITLE
Add Postgre ENUM converter to String

### DIFF
--- a/docs/model_mapping.md
+++ b/docs/model_mapping.md
@@ -127,10 +127,11 @@ To define field converter create a class which implements next methods:
 - `.to_db(SomeType)` - converts field to the db format;
 - `.from_hash(Hash(String, Jennifer::DBAny), String)` - converts field from the given hash (second argument is a field name).
 
-There are 2 predefined converters:
+There are 3 predefined converters:
 
-- `Jennifer::Model::JSONConverter` - default converter for `JSON::Any`;
-- `Jennifer::Model::NumericToFloat64Converter` - converts Postgres `PG::Numeric` to `Float64`.
+- `Jennifer::Model::JSONConverter` - default converter for `JSON::Any` (it is applied automatically for `JSON::Any` fields);
+- `Jennifer::Model::NumericToFloat64Converter` - converts Postgre `PG::Numeric` to `Float64`;
+- `Jennifer::Model::EnumConverter` - converts Postgre `ENUM` value to `String`.
 
 To make some field nillable tou can use any of the next options:
 

--- a/shard.yml
+++ b/shard.yml
@@ -4,17 +4,17 @@ version: 0.8.0
 authors:
   - Roman Kalnytskyi <moranibaca@gmail.com>
 
-crystal: 0.29.0
+crystal: 0.30.0
 
 license: MIT
 
 development_dependencies:
   mysql:
     github: crystal-lang/crystal-mysql
-    version: "~> 0.5"
+    version: "~> 0.8"
   pg:
     github: will/crystal-pg
-    version: "~> 0.15.0"
+    version: "~> 0.18.0"
   factory:
     github: imdrasil/factory
     version: "~> 0.1.4"

--- a/spec/model/sti_mapping_spec.cr
+++ b/spec/model/sti_mapping_spec.cr
@@ -510,7 +510,12 @@ describe Jennifer::Model::STIMapping do
       r.keys.should eq({:args, :fields})
 
       match_array(r[:fields], %w(title version publisher type pages))
-      match_array(r[:args], db_array("MyNameIsDonnieSmith", 5, "PTA", "Article", 1))
+      expected =
+        db_specific(
+          mysql: -> { db_array("MyNameIsDonnieSmith", 5, "PTA",  "Article", 1) },
+          postgres: -> { db_array("MyNameIsDonnieSmith", 5, "PTA",  Bytes[65, 114, 116, 105, 99, 108, 101], 1) }
+        )
+      match_array(r[:args], expected)
     end
   end
 

--- a/spec/models.cr
+++ b/spec/models.cr
@@ -82,7 +82,7 @@ class Contact < ApplicationRecord
         name:        String,
         ballance:    PG::Numeric?,
         age:         {type: Int32, default: 10},
-        gender:      {type: String?, default: "male"},
+        gender:      {type: String?, default: "male", converter: Jennifer::Model::EnumConverter},
         description: String?,
         created_at:  Time?,
         updated_at:  Time?,
@@ -429,13 +429,23 @@ end
 class ContactWithDependencies < Jennifer::Model::Base
   table_name "contacts"
 
-  mapping({
-    id:          Primary32,
-    name:        String?,
-    description: String?,
-    age:         {type: Int32, default: 10},
-    gender:      {type: String?, default: "male"},
-  }, false)
+  {% if env("DB") == "postgres" || env("DB") == nil %}
+    mapping({
+      id:          Primary32,
+      name:        String?,
+      description: String?,
+      age:         {type: Int32, default: 10},
+      gender:      {type: String?, default: "male", converter: Jennifer::Model::EnumConverter},
+    }, false)
+  {% else %}
+    mapping({
+      id:          Primary32,
+      name:        String?,
+      description: String?,
+      age:         {type: Int32, default: 10},
+      gender:      {type: String?, default: "male"},
+    }, false)
+  {% end %}
 
   has_many :addresses, Address, dependent: :delete, foreign: :contact_id
   has_many :facebook_profiles, FacebookProfile, dependent: :nullify, foreign: :contact_id
@@ -592,13 +602,23 @@ class Author < Jennifer::Model::Base
 end
 
 class Publication < Jennifer::Model::Base
-  mapping({
-    id:         Primary32,
-    name:       { type: String, column: :title },
-    version:    Int32,
-    publisher:  String,
-    type:       String
-  })
+  {% if env("DB") == "postgres" || env("DB") == nil %}
+    mapping(
+      id:         Primary32,
+      name:       { type: String, column: :title },
+      version:    Int32,
+      publisher:  String,
+      type:       { type: String, converter: Jennifer::Model::EnumConverter }
+    )
+  {% else %}
+    mapping(
+      id:         Primary32,
+      name:       { type: String, column: :title },
+      version:    Int32,
+      publisher:  String,
+      type:       String
+    )
+  {% end %}
 end
 
 class Book < Publication

--- a/spec/query_builder/aggregations_spec.cr
+++ b/spec/query_builder/aggregations_spec.cr
@@ -91,11 +91,8 @@ describe Jennifer::QueryBuilder::Aggregations do
       Factory.create_contact(name: "BBB", gender: "female", age: 19)
       Factory.create_contact(name: "Asd", gender: "male", age: 20)
       Factory.create_contact(name: "BBB", gender: "female", age: 21)
-      {% if env("DB") == "mysql" %}
-        match_each([19, 20], described_class.new("contacts").group(:gender).group_avg(:age, Float64))
-      {% else %}
-        match_each([19, 20], described_class.new("contacts").group(:gender).group_avg(:age, PG::Numeric))
-      {% end %}
+      klass = {% if env("DB") == "mysql" %} Float64 {% else %} PG::Numeric {% end %}
+      match_array([19.0, 20.0], described_class.new("contacts").group(:gender).group_avg(:age, klass).map(&.to_f))
     end
   end
 
@@ -104,7 +101,7 @@ describe Jennifer::QueryBuilder::Aggregations do
       Factory.create_contact(name: "Asd", gender: "male", age: 18)
       Factory.create_contact(name: "BBB", gender: "female", age: 18)
       Factory.create_contact(name: "Asd", gender: "male", age: 20)
-      match_each([2, 1], described_class.new("contacts").group(:age).group_count(:age))
+      match_array([2, 1], described_class.new("contacts").group(:age).group_count(:age))
     end
   end
 end

--- a/spec/support/matchers.cr
+++ b/spec/support/matchers.cr
@@ -1,37 +1,23 @@
-def match_array(expect, target)
-  (expect - target).size.should eq(0)
-  (target - expect).size.should eq(0)
-rescue e
-  puts "Actual array: #{expect}"
-  puts "Expected: #{target}"
-  raise e
-end
-
-def match_each(source, target)
-  source.size.should eq(target.size)
-  source.each do |e|
-    target.includes?(e).should be_true
-  end
-rescue e
-  puts "Actual array: #{source}"
-  puts "Expected: #{target}"
-  raise e
-end
-
-macro match_fields(object, fields)
-  {% for field, value in fields %}
-    {{object}}.{{field.id}}.should eq({{value}})
-  {% end %}
-end
-
-macro match_fields(object, **fields)
-  {% for field, value in fields %}
-    {{object}}.{{field.id}}.should eq({{value}})
-  {% end %}
-end
-
 module Spec
   module Methods
+    def match_array(expect, target)
+      missing = expect - target
+      extra = target - expect
+      fail("Actual array: #{expect}; Expected: #{target}") unless missing.empty? && extra.empty?
+    end
+
+    macro match_fields(object, fields)
+      {% for field, value in fields %}
+        {{object}}.{{field.id}}.should eq({{value}})
+      {% end %}
+    end
+
+    macro match_fields(object, **fields)
+      {% for field, value in fields %}
+        {{object}}.{{field.id}}.should eq({{value}})
+      {% end %}
+    end
+
     # The following construction
     #
     # ```

--- a/spec/views.cr
+++ b/spec/views.cr
@@ -15,13 +15,23 @@ class FemaleContact < BaseView
 end
 
 class MaleContact < Jennifer::View::Base
-  mapping({
-    id:         Primary32,
-    name:       String,
-    gender:     String,
-    age:        Int32,
-    created_at: Time?,
-  }, false)
+  {% if env("DB") == "postgres" || env("DB") == nil %}
+    mapping({
+      id:         Primary32,
+      name:       String,
+      gender:     { type: String, converter: Jennifer::Model::EnumConverter },
+      age:        Int32,
+      created_at: Time?,
+    }, false)
+  {% else %}
+    mapping({
+      id:         Primary32,
+      name:       String,
+      gender:     String,
+      age:        Int32,
+      created_at: Time?,
+    }, false)
+  {% end %}
 
   scope :main { where { _age < 50 } }
   scope :older { |age| where { _age >= age } }
@@ -35,13 +45,23 @@ end
 class FakeFemaleContact < Jennifer::View::Base
   view_name "female_contacs"
 
-  mapping({
-    id:         Primary32,
-    name:       String,
-    gender:     String,
-    age:        Int32,
-    created_at: Time?,
-  }, false)
+  {% if env("DB") == "postgres" || env("DB") == nil %}
+    mapping({
+      id:         Primary32,
+      name:       String,
+      gender:     { type: String, converter: Jennifer::Model::EnumConverter },
+      age:        Int32,
+      created_at: Time?,
+    }, false)
+  {% else %}
+    mapping({
+      id:         Primary32,
+      name:       String,
+      gender:     String,
+      age:        Int32,
+      created_at: Time?,
+    }, false)
+  {% end %}
 end
 
 class FakeContactView < Jennifer::View::Base
@@ -78,13 +98,25 @@ class MaleContactWithDescription < Jennifer::View::Base
 end
 
 class PrintPublication < Jennifer::View::Base
-  mapping({
-    id:         Primary32,
-    title:      String,
-    v:          {type: Int32, column: :version},
-    publisher:  String,
-    pages:      Int32?,
-    url:        String?,
-    type:       String
-  })
+  {% if env("DB") == "postgres" || env("DB") == nil %}
+    mapping(
+      id:         Primary32,
+      title:      String,
+      v:          {type: Int32, column: :version},
+      publisher:  String,
+      pages:      Int32?,
+      url:        String?,
+      type:       { type: String, converter: Jennifer::Model::EnumConverter }
+    )
+  {% else %}
+    mapping(
+      id:         Primary32,
+      title:      String,
+      v:          {type: Int32, column: :version},
+      publisher:  String,
+      pages:      Int32?,
+      url:        String?,
+      type:       String
+    )
+  {% end %}
 end

--- a/src/jennifer/adapter/postgres.cr
+++ b/src/jennifer/adapter/postgres.cr
@@ -86,21 +86,6 @@ module Jennifer
         @schema_processor ||= SchemaProcessor.new(self)
       end
 
-      def prepare
-        _query = <<-SQL
-          SELECT e.enumtypid
-          FROM pg_type t, pg_enum e
-          WHERE t.oid = e.enumtypid
-        SQL
-
-        query(_query) do |rs|
-          rs.each do
-            PG::Decoders.register_decoder PG::Decoders::StringDecoder.new, rs.read(UInt32).to_i
-          end
-        end
-        super
-      end
-
       def translate_type(name)
         TYPE_TRANSLATIONS[name]
       rescue e : KeyError

--- a/src/jennifer/adapter/postgres/converters.cr
+++ b/src/jennifer/adapter/postgres/converters.cr
@@ -3,6 +3,15 @@ module Jennifer
     # Type converter for Postgre numeric field.
     #
     # Converts `PG::Numeric` to `Float64` and back.
+    #
+    # ```
+    # class Order < Jennifer::Model::Base
+    #   mapping(
+    #     id: Primary32,
+    #     total: { type: Float64?, converter: Jennifer::Model::NumericToFloat64Converter }
+    #   )
+    # end
+    # ```
     class NumericToFloat64Converter
       def self.from_db(pull, nillable)
         if nillable
@@ -21,6 +30,50 @@ module Jennifer
         case value
         when PG::Numeric
           value.to_f64
+        else
+          value
+        end
+      end
+    end
+
+    # Type converter for Postgre ENUM field.
+    #
+    # Postgre custom data types (to which ENUM belongs) may have different OID on different databases.
+    # Therefore PG driver treats value of ENUM type as `Bytes`. To bring dynamic convert to string value and back
+    # use this converter
+    #
+    # ```
+    # class Order < Jennifer::Model::Base
+    #   mapping(
+    #     id: Primary32,
+    #     title: String,
+    #     status: { type: String?, default: "draft", converter: Jennifer::Model::EnumConverter }
+    #   )
+    # end
+    # ```
+    class EnumConverter
+      def self.from_db(pull, nillable)
+        if nillable
+          value = pull.read(Bytes?)
+          value && String.new(value)
+        else
+          String.new(pull.read(Bytes))
+        end
+      end
+
+      def self.to_db(value : String)
+        value.to_slice
+      end
+
+      def self.to_db(value : Nil)
+        value
+      end
+
+      def self.from_hash(hash : Hash, column)
+        value = hash[column]
+        case value
+        when Bytes
+          String.new(value)
         else
           value
         end


### PR DESCRIPTION
# What does this PR do?

Fixes #258 . As a result all string-based fields mapping to Postrge `ENUM` should take `Jennifer::Model::EnumConverter` converter.

# Release notes

**General**

* add `crystal-pg` 0.18.0 support

**Model**

* Add `EnumConverter` converter for Postgre `ENUM` field convert
* (pg only) field presenting `ENUM` field should explicitly specify `converter: Jennifer::Model::EnumConverter`

**Adapter**

* `Postgre` adapter now doesn't register decoders for each ENUM type in `#prepare`
