### PR TITLE
Add option to disable automatic transaction wrapping of migration methods

### DIFF
--- a/examples/migrations/20180909200027509_create_notes.cr
+++ b/examples/migrations/20180909200027509_create_notes.cr
@@ -1,4 +1,6 @@
-class CreateNote < Jennifer::Migration::Base
+class CreateNotes < Jennifer::Migration::Base
+  with_transaction false
+
   def up
     create_table :notes do |t|
       t.string :text

--- a/spec/migration/base_spec.cr
+++ b/spec/migration/base_spec.cr
@@ -1,20 +1,24 @@
 require "../spec_helper"
-require "../../examples/migrations/20170119011451314_create_contacts"
 
 describe Jennifer::Migration::Base do
   described_class = Jennifer::Migration::Base
   migration = CreateContacts.new
 
   describe ".versions" do
-    it { described_class.versions.should eq(["20170119011451314"]) }
+    it { described_class.versions.should eq(["20170119011451314", "20180909200027509"]) }
   end
 
   describe ".migrations" do
-    it { described_class.migrations.should eq({ "20170119011451314" => CreateContacts }) }
+    it { described_class.migrations.should eq({ "20170119011451314" => CreateContacts, "20180909200027509" => CreateNotes }) }
   end
 
   describe ".version" do
     it { CreateContacts.version.should eq("20170119011451314") }
+  end
+
+  describe ".with_transaction?" do
+    it { CreateContacts.with_transaction?.should be_true }
+    it { CreateNotes.with_transaction?.should be_false }
   end
 
   # TODO: add aka transactional schema tests for MySQL

--- a/spec/migration/runnser_spec.cr
+++ b/spec/migration/runnser_spec.cr
@@ -1,5 +1,4 @@
 require "../spec_helper"
-require "../../examples/migrations/20170119011451314_create_contacts"
 
 module Jennifer::Migration::Runner
   def self.reset_pending_versions

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -17,6 +17,9 @@ require "./models"
 require "./factories"
 require "./support/*"
 
+require "../examples/migrations/20170119011451314_create_contacts"
+require "../examples/migrations/20180909200027509_create_notes"
+
 # Callbacks =======================
 
 Spec.before_each do


### PR DESCRIPTION
# What does this PR do?

Add an option to disable automatic transaction wrapping of migration methods

# Release notes

**Migration**

* add `Base.with_transaction` method to disable automatic transaction wrapping around migration methods
* add `Base.with_transaction?` to check whether migration is run under a transaction
