### PR TITLE
Fix sql data type mapping and some api

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -42,11 +42,11 @@ There are next methods which presents corresponding types:
 | `#decimal` | `DECIMAL` | `DECIMAL` | `PG::Numeric` (pg); `Float64` (mysql) |
 | `#string` | `varchar(254)` | `varchar(254)` | `String` |
 | `#char` | `char` | - | `String` |
-| `#var_string` / `#varchar` | `varchar(254)` | `varstring` | `String` |
 | `#text` | `TEXT` | `TEXT` | `String` |
 | `#bool` | `boolean` | `bool` | `Bool` |
 | `#timestamp` | `timestamp` | `datetime` | `Time` |
-| `#date_time` | `datetime` | `datetime` | `Time` |
+| `#date_time` | `timestamp` | `datetime` | `Time` |
+| `#date` | `date` | `date` | `Time` |
 | `#blob` | `blob` | `blob` | `Bytes` |
 | `#json` | `json` | `json` | `JSON::Any` |
 | `#enum` | - | `ENUM` | `String` |

--- a/docs/time.md
+++ b/docs/time.md
@@ -10,15 +10,3 @@ Jennifer::Config.config do |conf|
   conf.local_time_zone_name = "Etc/GMT+1"
 end
 ```
-
-Jennifer use own default time zone, so `Time.zone.now` still uses it's own default zone. If you need same time zone for this case as well - just assign it as well or make assignment of default TimeZone zone instead of setting it to the Jennifer itself:
-
-```crystal
-TimeZone::Zone.default = "Etc/GMT+1"
-
-Jennifer::Config.config do |conf|
-  # ...
-  # this isn't needed now
-  # conf.local_time_zone_name = "Etc/GMT+1"
-end
-```

--- a/examples/migrations/20191019010424611_add_all_type_model.cr
+++ b/examples/migrations/20191019010424611_add_all_type_model.cr
@@ -1,0 +1,43 @@
+# Includes all field types except enums and arrays
+class AddAllTypeModel < Jennifer::Migration::Base
+  def up
+    create_table :all_types do |t|
+      t.bool :bool_f
+      t.bigint :bigint_f
+      t.integer :integer_f
+      t.short :short_f
+      t.float :float_f
+      t.double :double_f
+      t.decimal :decimal_f
+      t.string :string_f
+      t.varchar :varchar_f
+      t.text :text_f
+      t.timestamp :timestamp_f
+      t.date_time :date_time_f
+      t.date :date_f
+      t.json :json_f
+
+      {% if env("DB") == "postgres" || env("DB") == nil %}
+        t.oid :oid_f
+        t.char :char_f
+        t.uuid :uuid_f
+        t.timestamptz :timestamptz_f
+        t.bytea :bytea_f
+        t.jsonb :jsonb_f
+        t.xml :xml_f
+        t.point :point_f
+        t.lseg :lseg_f
+        t.path :path_f
+        t.box :box_f
+      {% else %}
+        # t.enum
+        t.blob :blob_f
+        t.tinyint :tinyint_f
+      {% end %}
+    end
+  end
+
+  def down
+    drop_table :all_types
+  end
+end

--- a/spec/migration/table_builder/create_table_spec.cr
+++ b/spec/migration/table_builder/create_table_spec.cr
@@ -67,30 +67,45 @@ describe Jennifer::Migration::TableBuilder::CreateTable do
         command.type.should eq(:uniq)
         command.lengths.empty?.should be_true
         command.orders[:uuid].should eq(:asc)
+        command.index_name.should eq("nodes_uuid_index")
+      end
+    end
+
+    context "with index name" do
+      it do
+        table = create_table_expr
+        table.index(:uuid, :uniq, "nodes_uuid_index", length: 10, order: :asc)
+        command = table.@commands[0].as(Jennifer::Migration::TableBuilder::CreateIndex)
+        command.fields.should eq([:uuid])
+        command.type.should eq(:uniq)
+        command.lengths[:uuid].should eq(10)
+        command.orders[:uuid].should eq(:asc)
+        command.index_name.should eq("nodes_uuid_index")
       end
     end
 
     context "with plain arguments and specified length" do
       it do
         table = create_table_expr
-        table.index("nodes_uuid_index", :uuid, :uniq, 10, :asc)
+        table.index(:uuid, :uniq, length: 10)
         command = table.@commands[0].as(Jennifer::Migration::TableBuilder::CreateIndex)
         command.fields.should eq([:uuid])
         command.type.should eq(:uniq)
         command.lengths[:uuid].should eq(10)
-        command.orders[:uuid].should eq(:asc)
+        command.index_name.should eq("test_table_uuid_idx")
       end
     end
 
     context "with multiple fields" do
       it do
         table = create_table_expr
-        table.index("nodes_uuid_index", [:uuid, :name], :uniq, orders: { :uuid => :asc, :name => :desc })
+        table.index([:uuid, :name], :uniq, orders: { :uuid => :asc, :name => :desc })
         command = table.@commands[0].as(Jennifer::Migration::TableBuilder::CreateIndex)
         command.fields.should eq([:uuid, :name])
         command.type.should eq(:uniq)
         command.lengths.empty?.should be_true
         command.orders.should eq({ :uuid => :asc, :name => :desc })
+        command.index_name.should eq("test_table_uuid_name_idx")
       end
     end
   end

--- a/spec/models.cr
+++ b/spec/models.cr
@@ -327,6 +327,56 @@ class OneFieldModel < Jennifer::Model::Base
   )
 end
 
+class AllTypeModel < ApplicationRecord
+  module SpecificMapping
+    include Jennifer::Model::Mapping
+
+    {% if env("DB") == "postgres" || env("DB") == nil %}
+      mapping(
+        decimal_f: PG::Numeric?,
+        oid_f: UInt32?,
+        char_f: String?,
+        uuid_f: String?,
+        timestamptz_f: Time?,
+        bytea_f: Bytes?,
+        jsonb_f: JSON::Any?,
+        xml_f: String?,
+        point_f: PG::Geo::Point?,
+        lseg_f: PG::Geo::LineSegment?,
+        path_f: PG::Geo::Path?,
+        box_f: PG::Geo::Box?
+      )
+    {% else %}
+      mapping(
+        tinyint_f: Int8?,
+        decimal_f: Float64?,
+        blob_f: Bytes?
+      )
+    {% end %}
+  end
+
+  include SpecificMapping
+
+  table_name "all_types"
+
+  mapping(
+    id: Primary32,
+    bool_f: Bool?,
+    bigint_f: Int64?,
+    integer_f: Int32?,
+    short_f: Int16?,
+    float_f: Float32?,
+    double_f: Float64?,
+    string_f: String?,
+    varchar_f: String?,
+    text_f: String?,
+    timestamp_f: Time?,
+    date_time_f: Time?,
+    date_f: Time?,
+    json_f: JSON::Any?
+  )
+end
+
 # ===================
 # synthetic models
 # ===================

--- a/src/jennifer/adapter.cr
+++ b/src/jennifer/adapter.cr
@@ -14,9 +14,9 @@ module Jennifer
       float double
       numeric decimal
       bool
-      string char text var_string varchar blchar
+      string char text varchar blchar
       uuid
-      timestamp timestamptz date_time
+      timestamp timestamptz date_time date
       blob bytea
       json jsonb xml
       point lseg path box polygon line circle

--- a/src/jennifer/adapter/mysql.cr
+++ b/src/jennifer/adapter/mysql.cr
@@ -27,10 +27,10 @@ module Jennifer
         :string     => "varchar",
         :varchar    => "varchar",
         :text       => "text",
-        :var_string => "varstring",
 
         :timestamp => "datetime", # "timestamp",
         :date_time => "datetime",
+        :date => "date",
 
         :blob => "blob",
         :json => "json",
@@ -38,6 +38,7 @@ module Jennifer
 
       DEFAULT_SIZES = {
         :string => 254,
+        :varchar => 254
       }
 
       # NOTE: ATM is not used

--- a/src/jennifer/adapter/postgres.cr
+++ b/src/jennifer/adapter/postgres.cr
@@ -29,26 +29,25 @@ module Jennifer
         :decimal => "decimal", # PG::Numeric - alias for numeric
 
         :string     => "varchar",
-        :char       => "char",
+        :char       => "char", # String
         :text       => "text",
-        :var_string => "varchar",
         :varchar    => "varchar",
         :blchar     => "blchar", # String
 
         :uuid => "uuid", # String
 
-        :timestamp   => "timestamp",
-        :timestamptz => "timestamptz", # Time
-        :date_time   => "datetime",
+        :timestamp   => "timestamp", # Time
+        :timestamptz => "timestamptz",
+        :date_time   => "timestamp",
+        :date        => "date",
 
-        :blob  => "blob",
-        :bytea => "bytea",
+        :bytea => "bytea", # Bytes
 
         :json  => "json",  # JSON
         :jsonb => "jsonb", # JSON
         :xml   => "xml",   # String
 
-        :point   => "point",
+        :point   => "point", # PG::Geo::Point
         :lseg    => "lseg",
         :path    => "path",
         :box     => "box",
@@ -58,8 +57,7 @@ module Jennifer
       }
 
       DEFAULT_SIZES = {
-        :string     => 254,
-        :var_string => 254,
+        :string     => 254
       }
 
       TABLE_LOCK_TYPES = {

--- a/src/jennifer/migration/table_builder/change_table.cr
+++ b/src/jennifer/migration/table_builder/change_table.cr
@@ -61,7 +61,7 @@ module Jennifer
         # Defines new column *name* of *type* with given *options*.
         #
         # The *type* argument should be one of the following supported data types: `integer`, `short`, `bigint`,
-        # `float`, `double`, `decimal`, `bool`, `string`, `char`, `text`, `var_string`, `varchar`, `timestamp`,
+        # `float`, `double`, `decimal`, `bool`, `string`, `char`, `text`, `varchar`, `timestamp`,
         # `date_time`, `blob`, `json`; PostgreSQL specific: `oid`, `numeric`, `char`, `blchar`, `uuid`, `timestamptz`,
         # `bytea`, `jsonb`, `xml`, `point`, `lseg`, `path`, `box`, `polygon`, `line`, `circle`; MySQL specific: `emum`,
         # `tinyint`.

--- a/src/jennifer/migration/table_builder/create_index.cr
+++ b/src/jennifer/migration/table_builder/create_index.cr
@@ -11,23 +11,23 @@ module Jennifer
         end
 
         def process
-          schema_processor.add_index(@name, @index_name, fields, @type, orders, @lengths)
+          schema_processor.add_index(name, index_name, fields, type, orders, lengths)
         end
 
         def explain
           String.build do |io|
-            io << "add_foreign_key :" <<
-              @name <<
+            io << "add_index :" <<
+              name <<
               ", " <<
-              @fields.inspect <<
+              fields.inspect <<
               ", " <<
-              @type.inspect <<
+              type.inspect <<
               ", " <<
-              @index_name.inspect <<
+              index_name.inspect <<
               ", " <<
-              @lengths.inspect <<
+              lengths.inspect <<
               ", " <<
-              @orders.inspect
+              orders.inspect
           end
         end
 

--- a/src/jennifer/migration/table_builder/create_table.cr
+++ b/src/jennifer/migration/table_builder/create_table.cr
@@ -117,23 +117,37 @@ module Jennifer
 
         # Adds index.
         #
+        # This is deprecated signature - please use one with the filed name at the beginning and optional index name.
+        #
         # For more details see `Migration::Base#add_index`.
         def index(name : String, fields : Array(Symbol), type : Symbol? = nil,
+                  lengths : Hash(Symbol, Int32) = {} of Symbol => Int32,
+                  orders : Hash(Symbol, Symbol) = {} of Symbol => Symbol)
+          index(fields, type, name, lengths, orders)
+        end
+
+        # ditto
+        def index(name : String, field : Symbol, type : Symbol? = nil, length : Int32? = nil, order : Symbol? = nil)
+          index(field, type, name, length, order)
+        end
+
+        # Adds index.
+        #
+        # For more details see `Migration::Base#add_index`.
+        def index(fields : Array(Symbol), type : Symbol? = nil, name : String? = nil,
                   lengths : Hash(Symbol, Int32) = {} of Symbol => Int32,
                   orders : Hash(Symbol, Symbol) = {} of Symbol => Symbol)
           @commands << CreateIndex.new(@adapter, @name, name, fields, type, lengths, orders)
           self
         end
 
-        # ditto
-        def index(name : String, field : Symbol, type : Symbol? = nil, length : Int32? = nil, order : Symbol? = nil)
-          index(
-            name,
-            [field],
-            type: type,
-            orders: (order ? {field => order.not_nil!} : {} of Symbol => Symbol),
-            lengths: (length ? {field => length.not_nil!} : {} of Symbol => Int32)
-          )
+        # Adds index.
+        #
+        # For more details see `Migration::Base#add_index`.
+        def index(field : Symbol, type : Symbol? = nil, name : String? = nil, length : Int32? = nil, order : Symbol? = nil)
+          orders = order ? {field => order.not_nil!} : {} of Symbol => Symbol
+          lengths = length ? {field => length.not_nil!} : {} of Symbol => Int32
+          index([field],type, name, lengths, orders)
         end
 
         # Creates a foreign key constraint to `to_table` table.

--- a/src/jennifer/model/common_mapping.cr
+++ b/src/jennifer/model/common_mapping.cr
@@ -8,7 +8,6 @@ module Jennifer::Model
         primary_auto_incrementable = primary && AUTOINCREMENTABLE_STR_TYPES.includes?(COLUMNS_METADATA[primary][:type].stringify)
         properties = COLUMNS_METADATA
         nonvirtual_attrs = properties.keys.select { |attr| !properties[attr][:virtual] }
-        raise "Model #{@type} has no defined primary field. For now model without primary field is not allowed" if primary == nil
       %}
 
       __field_declaration({{properties}}, {{primary_auto_incrementable}})

--- a/src/jennifer/model/mapping.cr
+++ b/src/jennifer/model/mapping.cr
@@ -230,6 +230,7 @@ module Jennifer
           end
           properties = COLUMNS_METADATA
           nonvirtual_attrs = properties.keys.select { |attr| !properties[attr][:virtual] }
+          raise "Model #{@type} has no defined primary field. For now a model without a primary field is not supported" if !primary
         %}
 
         # :nodoc:

--- a/src/jennifer/view/mapping.cr
+++ b/src/jennifer/view/mapping.cr
@@ -68,6 +68,11 @@ module Jennifer
       macro base_mapping(strict = true)
         common_mapping({{strict}})
 
+        {%
+          primary = COLUMNS_METADATA.keys.find { |field| COLUMNS_METADATA[field][:primary] }
+          raise "View #{@type} has no defined primary field. For now a view without a primary field is not supported" if !primary
+        %}
+
         # Extracts arguments due to mapping from *pull* and returns tuple for fields assignment.
         # It stands on that fact result set has all defined fields in a raw
         # TODO: think about moving it to class scope


### PR DESCRIPTION
# What does this PR do?

Fix #275 and several minor tweaks.

# Release notes

**Model**

* fix bug with primary field presence assertion

**View**

* fix bug with primary field presence assertion

**Adapter**

* add `date` SQL data type
* `date_time` field type maps to `timestamp` SQL data type (postgres only)

**Migration**

* remove `var_string` field type
* remove `blob` field type for postgres
* fix wrong explanation message for `TableBuilder::CreateIndex`
* add new `TableBuilder::CreateTable#index` signatures (old ones are deprecated):
  * `#index(fields : Array(Symbol), type : Symbol | ::Nil = nil, name : String | ::Nil = nil, lengths : Hash(Symbol, Int32) = {} of Symbol => Int32, orders : Hash(Symbol, Symbol) = {} of Symbol => Symbol)`
  * `#index(field : Symbol, type : Symbol | ::Nil = nil, name : String | ::Nil = nil, length : Int32 | ::Nil = nil, order : Symbol | ::Nil = nil)`
* make default `varchar` length `254` (mysql only)