### PR TITLE
Fix wrong casting of any Int8 field to Bool when reading result set to hash in MySQL

### DIFF
--- a/spec/adapter/result_parsers_spec.cr
+++ b/spec/adapter/result_parsers_spec.cr
@@ -2,10 +2,6 @@ require "../spec_helper"
 
 describe Jennifer::Adapter::ResultParsers do
   adapter = Jennifer::Adapter.default_adapter
-  contact_fields = db_specific(
-    postgres: -> { %w(id name age tags ballance gender created_at updated_at description user_id) },
-    mysql: -> { %w(id name age ballance gender created_at updated_at description user_id) }
-  )
 
   describe "#result_to_hash" do
     describe "data types" do

--- a/spec/adapter/result_parsers_spec.cr
+++ b/spec/adapter/result_parsers_spec.cr
@@ -8,34 +8,192 @@ describe Jennifer::Adapter::ResultParsers do
   )
 
   describe "#result_to_hash" do
-    it "converts result set to hash with string keys" do
-      Factory.create_contact
-      executed = false
-      Contact.all.each_result_set do |rs|
-        executed = true
-        hash = adapter.result_to_hash(rs)
-        hash.keys.should eq(contact_fields)
-        hash["id"].should_not be_nil
-        hash["name"].should eq("Deepthi")
-        hash["age"].should eq(28)
+    describe "data types" do
+      describe "BOOLEAN" do
+        it do
+          AllTypeModel.create(bool_f: false)
+          executed = false
+          AllTypeModel.all.each_result_set do |rs|
+            executed = true
+            value = adapter.result_to_hash(rs)["bool_f"]
+            value.is_a?(Bool).should be_true
+            value.should be_false
+          end
+          executed.should be_true
+        end
       end
-      executed.should be_true
-    end
-  end
 
-  describe "#result_to_array" do
-    it "converts result set to array" do
-      Factory.create_contact
-      executed = false
-      Contact.all.each_result_set do |rs|
-        executed = true
-        array = adapter.result_to_array(rs)
-        array.size.should eq(contact_fields.size)
-        array[0].should_not be_nil
-        array[1].should eq("Deepthi")
-        array[2].should eq(28)
+      describe "TIMESTAMP" do
+        it "correctly saves and loads" do
+          AllTypeModel.create!(timestamp_f: Time.utc(2016, 2, 15, 10, 20, 30))
+          executed = false
+          AllTypeModel.all.each_result_set do |rs|
+            executed = true
+            value = adapter.result_to_hash(rs)["timestamp_f"]
+            value.is_a?(Time).should be_true
+          end
+          executed.should be_true
+        end
       end
-      executed.should be_true
+
+      describe "DATE" do
+        it "correctly saves and loads" do
+          AllTypeModel.create!(date_f: Time.utc(2016, 2, 15, 10, 20, 30))
+          executed = false
+          AllTypeModel.all.each_result_set do |rs|
+            executed = true
+            value = adapter.result_to_hash(rs)["date_f"]
+            value.is_a?(Time).should be_true
+            value.as(Time).in(UTC).should eq(Time.utc(2016, 2, 15, 0, 0, 0))
+          end
+          executed.should be_true
+        end
+      end
+
+      describe "JSON" do
+        it "correctly loads json field" do
+          AllTypeModel.create!(json_f: {:a => 2}.to_json)
+          executed = false
+          AllTypeModel.all.each_result_set do |rs|
+            executed = true
+            value = adapter.result_to_hash(rs)["json_f"]
+            value.is_a?(JSON::Any).should be_true
+            value.should eq(JSON.parse(%({"a": 2})))
+          end
+          executed.should be_true
+        end
+      end
+
+      mysql_only do
+        describe "TINYINT" do
+          it do
+            AllTypeModel.create(tinyint_f: 1i8)
+            executed = false
+            AllTypeModel.all.each_result_set do |rs|
+              executed = true
+              value = adapter.result_to_hash(rs)["tinyint_f"]
+              value.is_a?(Int8).should be_true
+              value.should eq(1i8)
+            end
+            executed.should be_true
+          end
+        end
+      end
+
+      postgres_only do
+        describe "DECIMAL" do
+          it "correctly saves and loads" do
+            AllTypeModel.create!(decimal_f: PG::Numeric.new(1i16, 0i16, 0i16, 0i16, [1i16]))
+            executed = false
+            AllTypeModel.all.each_result_set do |rs|
+              executed = true
+              value = adapter.result_to_hash(rs)["decimal_f"]
+              value.is_a?(PG::Numeric).should be_true
+              value.should eq(PG::Numeric.new(1i16, 0i16, 0i16, 0i16, [1i16]))
+            end
+            executed.should be_true
+          end
+        end
+
+        describe "OID" do
+          it "correctly saves and loads" do
+            AllTypeModel.create!(oid_f: 2147483648_u32)
+            executed = false
+            AllTypeModel.all.each_result_set do |rs|
+              executed = true
+              value = adapter.result_to_hash(rs)["oid_f"]
+              value.is_a?(UInt32).should be_true
+              value.should eq(2147483648_u32)
+            end
+            executed.should be_true
+          end
+        end
+
+        describe "CHAR" do
+          it "correctly saves and loads" do
+            AllTypeModel.create!(char_f: "a")
+            executed = false
+            AllTypeModel.all.each_result_set do |rs|
+              executed = true
+              value = adapter.result_to_hash(rs)["char_f"]
+              value.is_a?(String).should be_true
+              value.should eq("a")
+            end
+            executed.should be_true
+          end
+        end
+
+        describe "UUID" do
+          it "correctly saves and loads" do
+            AllTypeModel.create!(uuid_f: "7d61d548-124c-4b38-bc05-cfbb88cfd1d1")
+            executed = false
+            AllTypeModel.all.each_result_set do |rs|
+              executed = true
+              value = adapter.result_to_hash(rs)["uuid_f"]
+              value.is_a?(String).should be_true
+              value.should eq("7d61d548-124c-4b38-bc05-cfbb88cfd1d1")
+            end
+            executed.should be_true
+          end
+        end
+
+        describe "BYTEA" do
+          it "correctly saves and loads" do
+            AllTypeModel.create!(bytea_f: Bytes[65, 114, 116, 105, 99, 108, 101])
+            executed = false
+            AllTypeModel.all.each_result_set do |rs|
+              executed = true
+              value = adapter.result_to_hash(rs)["bytea_f"]
+              value.is_a?(Bytes).should be_true
+              value.should eq(Bytes[65, 114, 116, 105, 99, 108, 101])
+            end
+            executed.should be_true
+          end
+        end
+
+        describe "JSONB" do
+          it "correctly saves and loads" do
+            AllTypeModel.create!(jsonb_f: JSON.parse(%(["a", "b", 1])))
+            executed = false
+            AllTypeModel.all.each_result_set do |rs|
+              executed = true
+              value = adapter.result_to_hash(rs)["jsonb_f"]
+              value.is_a?(JSON::Any).should be_true
+              value.should eq(JSON.parse(%(["a", "b", 1])))
+            end
+            executed.should be_true
+          end
+        end
+
+        describe "POINT" do
+          it "correctly saves and loads" do
+            AllTypeModel.create!(point_f: PG::Geo::Point.new(1.2, 3.4))
+            executed = false
+            AllTypeModel.all.each_result_set do |rs|
+              executed = true
+              value = adapter.result_to_hash(rs)["point_f"]
+              value.is_a?(PG::Geo::Point).should be_true
+              value.should eq(PG::Geo::Point.new(1.2, 3.4))
+            end
+            executed.should be_true
+          end
+        end
+
+        describe "PATH" do
+          it "correctly saves and loads" do
+            path = PG::Geo::Path.new([PG::Geo::Point.new(1.0, 2.0), PG::Geo::Point.new(3.0, 4.0)], closed: true)
+            AllTypeModel.create!(path_f: path)
+            executed = false
+            AllTypeModel.all.each_result_set do |rs|
+              executed = true
+              value = adapter.result_to_hash(rs)["path_f"]
+              value.is_a?(PG::Geo::Path).should be_true
+              value.should eq(path)
+            end
+            executed.should be_true
+          end
+        end
+      end
     end
   end
 

--- a/spec/model/mapping_spec.cr
+++ b/spec/model/mapping_spec.cr
@@ -50,9 +50,6 @@ class UserWithModuleMapping < Jennifer::Model::Base
   )
 end
 
-UTC = Time::Location.load("UTC")
-BERLIN = Time::Location.load("Europe/Berlin")
-
 describe Jennifer::Model::Mapping do
   select_regexp = /[\S\s]*SELECT contacts\.\*/i
 

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -35,6 +35,9 @@ end
 
 # Helper methods ================
 
+UTC = Time::Location.load("UTC")
+BERLIN = Time::Location.load("Europe/Berlin")
+
 macro validated_by_record(type, value, field = :age, allow_blank = true)
   Factory.build_contact.tap do |record|
     described_class.instance.validate(record, {{field}}, {{value}}, {{allow_blank}}, **{{type}})

--- a/src/jennifer/adapter/mysql.cr
+++ b/src/jennifer/adapter/mysql.cr
@@ -146,20 +146,6 @@ module Jennifer
         format_explain_query(plan)
       end
 
-      def result_to_hash(rs)
-        result = {} of String => DBAny
-        rs.columns.each do |column|
-          column_name = column.name
-          result[column_name] =
-            if column.column_type == MySql::Type::Tiny && column.column_length == 1u32
-              (rs.read.as(DBAny) == 1i8).as(Bool)
-            else
-              rs.read.as(DBAny)
-            end
-        end
-        result
-      end
-
       def self.command_interface
         @@command_interface ||= CommandInterface.new(Config.instance)
       end
@@ -187,6 +173,14 @@ module Jennifer
           SQL
           Config.db
         end == 1
+      end
+
+      def read_column(rs, column : MySql::ColumnSpec)
+        if column.column_type == MySql::Type::Tiny && column.column_length == 1u32
+          (rs.read.as(DBAny) == 1i8).as(Bool)
+        else
+          rs.read.as(DBAny)
+        end
       end
 
       private def format_explain_query(plan : Array)

--- a/src/jennifer/adapter/result_parsers.cr
+++ b/src/jennifer/adapter/result_parsers.cr
@@ -5,12 +5,10 @@ module Jennifer
         buf = {} of String => DBAny
         names.each { |name| buf[name] = nil }
         count = names.size
-        rs.each_column do |column|
-          if buf.has_key?(column)
-            buf[column] = rs.read.as(DBAny)
-            if buf[column].is_a?(Int8)
-              buf[column] = (buf[column] == 1i8).as(Bool)
-            end
+        rs.columns.each do |column|
+          column_name = column.name
+          if buf.has_key?(column_name)
+            buf[column_name] = read_column(rs, column)
             count -= 1
           else
             rs.read
@@ -24,8 +22,17 @@ module Jennifer
       # Converts single ResultSet to hash
       def result_to_hash(rs)
         result = {} of String => DBAny
-        rs.each_column { |column| result[column] = rs.read.as(DBAny) }
+        rs.columns.each do |column|
+          result[column.name] = read_column(rs, column)
+        end
         result
+      end
+
+      # Reads *column*'s value from given result set.
+      abstract def read_column(rs, column)
+
+      def read_column(rs, column)
+        rs.read.as(DBAny)
       end
     end
   end

--- a/src/jennifer/adapter/result_parsers.cr
+++ b/src/jennifer/adapter/result_parsers.cr
@@ -1,19 +1,9 @@
 module Jennifer
   module Adapter
     module ResultParsers
-      def result_to_array(rs)
-        a = [] of DBAny
-        rs.each_column do
-          temp = rs.read(DBAny)
-          temp = (temp == 1i8).as(Bool) if temp.is_a?(Int8)
-          a << temp
-        end
-        a
-      end
-
-      def result_to_array_by_names(rs, names : Array)
+      def result_to_array_by_names(rs, names : Array(String))
         buf = {} of String => DBAny
-        names.each { |n| buf[n] = nil }
+        names.each { |name| buf[name] = nil }
         count = names.size
         rs.each_column do |column|
           if buf.has_key?(column)
@@ -31,16 +21,11 @@ module Jennifer
         buf.values
       end
 
-      # converts single ResultSet to hash
+      # Converts single ResultSet to hash
       def result_to_hash(rs)
-        h = {} of String => DBAny
-        rs.each_column do |column|
-          h[column] = rs.read.as(DBAny)
-          if h[column].is_a?(Int8)
-            h[column] = (h[column] == 1i8).as(Bool)
-          end
-        end
-        h
+        result = {} of String => DBAny
+        rs.each_column { |column| result[column] = rs.read.as(DBAny) }
+        result
       end
     end
   end

--- a/src/jennifer/model/field_declaration.cr
+++ b/src/jennifer/model/field_declaration.cr
@@ -1,15 +1,6 @@
 module Jennifer::Model
   # :nodoc:
   module FieldDeclaration
-    # :nodoc:
-    macro __bool_convert(value, type)
-      {% if type.stringify == "Bool" %}
-        ({{value.id}}.is_a?(Int8) ? {{value.id}} == 1i8 : {{value.id}}.as({{type}}))
-      {% else %}
-        {{value}}.as({{type}})
-      {% end %}
-    end
-
     # TODO: remove .primary_field_type method as it isn't used anywhere
 
     # :nodoc:

--- a/src/jennifer/model/mapping.cr
+++ b/src/jennifer/model/mapping.cr
@@ -461,9 +461,9 @@ module Jennifer
             begin
               %casted_var{key.id} =
                 {% if value[:default] != nil %}
-                  %found{key.id} ? __bool_convert(%var{key.id}, {{value[:parsed_type].id}}) : {{value[:default]}}
+                  %found{key.id} ? %var{key.id}.as({{value[:parsed_type].id}}) : {{value[:default]}}
                 {% else %}
-                  __bool_convert(%var{key.id}, {{value[:parsed_type].id}})
+                  %var{key.id}.as({{value[:parsed_type].id}})
                 {% end %}
               %casted_var{key.id} = %casted_var{key.id}.in(::Jennifer::Config.local_time_zone) if %casted_var{key.id}.is_a?(Time)
             rescue e : Exception

--- a/src/jennifer/model/sti_mapping.cr
+++ b/src/jennifer/model/sti_mapping.cr
@@ -143,9 +143,9 @@ module Jennifer
             begin
               %casted_var{key.id} =
                 {% if value[:default] != nil %}
-                  %found{key.id} ? __bool_convert(%var{key.id}, {{value[:parsed_type].id}}) : {{value[:default]}}
+                  %found{key.id} ? %var{key.id}.as({{value[:parsed_type].id}}) : {{value[:default]}}
                 {% else %}
-                  __bool_convert(%var{key.id}, {{value[:parsed_type].id}})
+                  %var{key.id}.as({{value[:parsed_type].id}})
                 {% end %}
               %casted_var{key.id} = %casted_var{key.id}.in(::Jennifer::Config.local_time_zone) if %casted_var{key.id}.is_a?(Time)
             rescue e : Exception

--- a/src/jennifer/query_builder/i_model_query.cr
+++ b/src/jennifer/query_builder/i_model_query.cr
@@ -79,7 +79,7 @@ module Jennifer
       # As a result all callbacks and validations are invoked.
       #
       # ```
-      # Contact.all.where { _name == "Ohn" }.path({ name: "John" })
+      # Contact.all.where { _name == "Ohn" }.patch({ name: "John" })
       # ```
       def patch(options : Hash | NamedTuple)
         find_each(&.update(options))
@@ -96,7 +96,7 @@ module Jennifer
       # it will stop all following operations.
       #
       # ```
-      # Contact.all.where { _name == "Ohn" }.path!({ name: "John" })
+      # Contact.all.where { _name == "Ohn" }.patch!({ name: "John" })
       # ```
       def patch!(options : Hash | NamedTuple)
         find_each(&.update!(options))

--- a/src/jennifer/query_builder/relation_tree.cr
+++ b/src/jennifer/query_builder/relation_tree.cr
@@ -14,6 +14,10 @@ module Jennifer
         @bucket = [] of Element
       end
 
+      def adapter
+        @klass.adapter
+      end
+
       def clone
         clone = {{@type}}.allocate
         clone.initialize_copy(self)

--- a/src/jennifer/view/mapping.cr
+++ b/src/jennifer/view/mapping.cr
@@ -172,9 +172,9 @@ module Jennifer
             begin
               %casted_var{key.id} =
                 {% if value[:default] != nil %}
-                  %found{key.id} ? __bool_convert(%var{key.id}, {{value[:parsed_type].id}}) : {{value[:default]}}
+                  %found{key.id} ? %var{key.id}.as({{value[:parsed_type].id}}) : {{value[:default]}}
                 {% else %}
-                  __bool_convert(%var{key.id}, {{value[:parsed_type].id}})
+                  %var{key.id}.as({{value[:parsed_type].id}})
                 {% end %}
               %casted_var{key.id} = %casted_var{key.id}.in(::Jennifer::Config.local_time_zone) if %casted_var{key.id}.is_a?(Time)
             rescue e : Exception


### PR DESCRIPTION
# What does this PR do?

Fix #279 

# Release notes

**QueryBuilder**

* use adapter's `#read_column` in `NestedRelationTree`
* add `RelationTree#adapter`

**Adapter**

* fix issue with treating `tinyint` mysql field as `boolean`
* remove `ResultParser#result_to_array`
* add `Mysql#read_column` 