### PR TITLE
Add quoting for huge bulk inserts instead of prepared statement usage

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -80,6 +80,7 @@ Take into account - some configs can't be initialized using URI string or yaml f
 | `command_shell_sudo` | ✔ | ❌ |
 | `migration_failure_handler_method` | ✔ | ❌ |
 | `allow_outdated_pending_migration` | ✔ | ❌ |
+| `max_bind_vars_count` | ✔ | ❌ |
 
 ## Supported configuration options
 
@@ -110,6 +111,7 @@ Take into account - some configs can't be initialized using URI string or yaml f
 * `verbose_migrations` - outputs basic invoked migration information if set to `true`; default: `true`
 * `model_files_path` - path to the models locations; is used by model and migration generators; default: `"./src/models"`
 * `structure_folder` - path to the database structure file location; if set to empty string - parent folder of `migration_files_path` is used; default: `""`
+* `max_bind_vars_count` - maximum allowed count of bind variables; if nothing specified - used adapter's default value; default: `nil`
 
 From `0.5.1` `Jennifer::Config` has started working under singleton pattern instead of using class as a container for all configuration properties.
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -107,7 +107,7 @@ I18n.init
 To be able to use CLI install [sam](https://github.com/imdrasil/sam.cr) task manager and modify `sam.cr` file in you application root folder with following content:
 
 ```crystal
-# here load jennifer and all required configurations
+require "./your_configuration_folder/*" # here load jennifer and all required configurations
 require "./db/migrations/*"
 require "sam"
 load_dependencies "jennifer"

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -152,7 +152,7 @@ end
 Also plain SQL could be executed as well:
 
 ```crystal
-execute("ALTER TABLE addresses CHANGE street st VARCHAR(20)")
+exec("ALTER TABLE addresses CHANGE street st VARCHAR(20)")
 ```
 
 All changes are executed one by one so you also could add data changes here (in `#up` and/or `#down`).

--- a/examples/migrations/20170119011451314_create_contacts.cr
+++ b/examples/migrations/20170119011451314_create_contacts.cr
@@ -12,7 +12,6 @@ class CreateContacts < Jennifer::Migration::Base
       end
       change_enum(:gender_enum, {:add_values => ["unknown"]})
       change_enum(:gender_enum, {:rename_values => ["unknown", "other"]})
-      change_enum(:gender_enum, {:remove_values => ["other"]})
     {% else %}
       create_table(:contacts) do |t|
         t.string :name, {:size => 30}

--- a/examples/migrations/20170119011460000_remove_enum_value.cr
+++ b/examples/migrations/20170119011460000_remove_enum_value.cr
@@ -1,0 +1,13 @@
+class RemoveEnumValue < Jennifer::Migration::Base
+  def up
+    {% if env("DB") == "postgres" || env("DB") == nil %}
+      change_enum(:gender_enum, {:remove_values => ["other"]})
+    {% end %}
+  end
+
+  def down
+    {% if env("DB") == "postgres" || env("DB") == nil %}
+      change_enum(:gender_enum, {:add_values => ["other"]})
+    {% end %}
+  end
+end

--- a/spec/adapter/postgres/sql_generator_spec.cr
+++ b/spec/adapter/postgres/sql_generator_spec.cr
@@ -1,11 +1,26 @@
 require "../../spec_helper"
 
+private macro quote_example(value, type_cast)
+  it do
+    executed = false
+    value = {{value}}
+    adapter.query("SELECT #{described_class.quote(value)}::{{type_cast.id}}") do |rs|
+      rs.each do
+        result = rs.read
+        result.should eq(value)
+        executed = true
+      end
+    end
+    executed.should be_true
+  end
+end
+
 postgres_only do
   describe Jennifer::Postgres::SQLGenerator do
     described_class = Jennifer::Adapter.adapter.sql_generator
+    adapter = Jennifer::Adapter.adapter
 
     describe "::lock_clause" do
-
       it "render custom query part if specified" do
         query = Contact.all.lock("FOR NO KEY UPDATE")
         sb { |s| described_class.lock_clause(s, query) }.should match(/FOR NO KEY UPDATE/)
@@ -60,6 +75,37 @@ postgres_only do
           Factory.build_criteria.desc.nulls_last.as_sql.should eq("tests.f1 DESC NULLS LAST")
         end
       end
+    end
+
+    describe "#quote" do
+      quote_example(PG::Geo::Box.new(1, 2, 3, 4), :box)
+      quote_example(PG::Geo::Circle.new(1, 2, 3), :circle)
+      quote_example(PG::Geo::Line.new(1, 2, 3), :line)
+      quote_example(PG::Geo::LineSegment.new(1, 2, 3, 4), :lseg)
+      quote_example(PG::Geo::Path.new([PG::Geo::Point.new(1, 2), PG::Geo::Point.new(3, 4)], false), :path)
+      quote_example(PG::Geo::Point.new(1, 2), :point)
+      quote_example(PG::Geo::Polygon.new([PG::Geo::Point.new(1, 2), PG::Geo::Point.new(3, 4)]), :polygon)
+      quote_example(PG::Numeric.new(1i16, 0i16, 0i16, 0i16, [1i16]), :numeric)
+      quote_example([1, 2], "int[]")
+      quote_example([1.0, 2.0], "float[]")
+      quote_example([1.0, 2.0], "double precision[]")
+      quote_example([%(this has a \\), "a"], "text[]")
+      quote_example(JSON::Any.from_json({ "asd" => { "asd" => [1, 2, 3], "b" => ["asd"]}}.to_json), "json")
+      quote_example(JSON::Any.from_json({ "asd" => { "asd" => [1, 2, 3], "b" => ["asd"]}}.to_json), "jsonb")
+      quote_example(JSON::Any.from_json({ %(this has a \\) => { "b" => [%(what's your "name")]}}.to_json), "json")
+      quote_example(Bytes[1, 123, 123, 34, 54], "bytea")
+      quote_example(Time.utc(2010, 10, 10, 12, 34, 56), "timestamp")
+      quote_example(Time.utc(2010, 10, 10, 0, 0, 0), "date")
+      quote_example(nil, "unknown")
+      quote_example(true, "boolean")
+      quote_example(false, "boolean")
+      # quote_example('c', "char")
+      quote_example(%(foo), "text")
+      quote_example(%(this has a \\), "text")
+      quote_example(%(what's your "name"), "text")
+      quote_example(1, "int")
+      quote_example(1.0, "float")
+      quote_example(1.0, "double precision")
     end
   end
 end

--- a/spec/generators/migration_spec.cr
+++ b/spec/generators/migration_spec.cr
@@ -4,7 +4,6 @@ describe Jennifer::Generators::Migration do
   described_class = Jennifer::Generators::Migration
 
   describe "#render" do
-    timestamp = Time.local.to_s("%Y%m%d%H%M%S%L")[0...-5]
     args = Sam::Args.new({} of String => String, %w(CreateArticles))
 
     it "creates migration" do
@@ -13,7 +12,7 @@ describe Jennifer::Generators::Migration do
       migration_path = Dir["./examples/migrations/*.cr"].sort.last
 
       migration_path.should match(/\d{16}_create_articles\.cr/)
-      File.basename(migration_path).starts_with?(timestamp).should be_true
+      Time.parse(File.basename(migration_path), "%Y%m%d%H%M%S%L", Time::Location.local).should be_close(Time.local, 1.seconds)
       File.read(migration_path).should eq(expected_content)
     end
   end

--- a/spec/generators/model_spec.cr
+++ b/spec/generators/model_spec.cr
@@ -4,8 +4,6 @@ describe Jennifer::Generators::Model do
   described_class = Jennifer::Generators::Model
 
   describe "#render" do
-    timestamp = Time.local.to_s("%Y%m%d%H%M%S%L")[0...-5]
-
     context "with common fields only" do
       args = Sam::Args.new({} of String => String, %w(Article title:string text:text?))
 
@@ -23,7 +21,7 @@ describe Jennifer::Generators::Model do
         migration_path = Dir["./examples/migrations/*.cr"].sort.last
 
         migration_path.should match(/\d{16}_create_articles\.cr/)
-        File.basename(migration_path).starts_with?(timestamp).should be_true
+        Time.parse(File.basename(migration_path), "%Y%m%d%H%M%S%L", Time::Location.local).should be_close(Time.local, 1.seconds)
         File.read(migration_path).should eq(expected_content)
       end
     end
@@ -45,7 +43,7 @@ describe Jennifer::Generators::Model do
         migration_path = Dir["./examples/migrations/*.cr"].sort.last
 
         migration_path.ends_with?("_create_articles.cr").should be_true
-        File.basename(migration_path).starts_with?(timestamp).should be_true
+        Time.parse(File.basename(migration_path), "%Y%m%d%H%M%S%L", Time::Location.local).should be_close(Time.local, 1.seconds)
 
         File.read(migration_path).should eq(expected_content)
       end

--- a/spec/migration/base_spec.cr
+++ b/spec/migration/base_spec.cr
@@ -144,10 +144,16 @@ describe Jennifer::Migration::Base do
 
     describe "#change_enum" do
       it do
-        migration.create_enum(:gender, %w(unspecified female male))
-        migration.change_enum(:gender, { :add_values => ["other"] })
+        void_transaction do
+          begin
+            migration.create_enum(:gender, %w(unspecified female male))
+            migration.change_enum(:gender, { :add_values => ["other"] })
 
-        adapter.enum_values(:gender).should eq(%w(unspecified female male other))
+            adapter.enum_values(:gender).should eq(%w(unspecified female male other))
+          ensure
+            migration.drop_enum(:gender)
+          end
+        end
       end
     end
 

--- a/src/jennifer/adapter/json_encoder.cr
+++ b/src/jennifer/adapter/json_encoder.cr
@@ -1,0 +1,39 @@
+module Jennifer
+  module Adapter
+    module JSONEncoder
+      def self.encode(value : JSON::Any, sql_generator) : String
+        jsonify(value, sql_generator).to_json
+      end
+
+      def self.jsonify(value : JSON::Any, sql_generator)
+        if value.as_s?
+          to_json(value.as_s, sql_generator)
+        elsif value.as_h?
+          to_json(value.as_h, sql_generator)
+        elsif value.as_a?
+          to_json(value.as_a, sql_generator)
+        else
+          value
+        end
+      end
+
+      def self.to_json(value : String, sql_generator)
+        JSON::Any.new(sql_generator.quote_json_string(value))
+      end
+
+      def self.to_json(value : Hash, sql_generator)
+        result = {} of String => JSON::Any
+        value.each do |key, key_value|
+          result[sql_generator.quote_json_string(key)] = jsonify(key_value, sql_generator)
+        end
+        JSON::Any.new(result)
+      end
+
+      def self.to_json(value : Array, sql_generator)
+        result = [] of JSON::Any
+        value.each { |element| result << jsonify(element, sql_generator) }
+        JSON::Any.new(result)
+      end
+    end
+  end
+end

--- a/src/jennifer/adapter/mysql.cr
+++ b/src/jennifer/adapter/mysql.cr
@@ -150,6 +150,10 @@ module Jennifer
         @@command_interface ||= CommandInterface.new(Config.instance)
       end
 
+      def self.default_max_bind_vars_count
+        32766
+      end
+
       def self.create_database
         db_connection do |db|
           db.exec "CREATE DATABASE #{Config.db}"

--- a/src/jennifer/adapter/postgres/quoting.cr
+++ b/src/jennifer/adapter/postgres/quoting.cr
@@ -1,0 +1,80 @@
+module Jennifer
+  module Postgres
+    module Quoting
+      def quote(value : String)
+        PG::EscapeHelper.escape_literal(value)
+      end
+
+      def quote(value : PG::Geo::Box)
+        "'((#{value.x1},#{value.y1}),(#{value.x2},#{value.y2}))'"
+      end
+
+      def quote(value : PG::Geo::Circle)
+        "'<(#{value.x},#{value.y}),#{value.radius}>'"
+      end
+
+      def quote(value : PG::Geo::Line)
+        "'{#{value.a},#{value.b},#{value.c} }'"
+      end
+
+      def quote(value : PG::Geo::LineSegment)
+        "'[(#{value.x1},#{value.y1}),(#{value.x2},#{value.y2})]'"
+      end
+
+      def quote(value : PG::Geo::Path)
+        String.build do |io|
+          io << "'["
+          value.points.each_with_index do |point, index|
+            io << ',' if index != 0
+            io << quote(point, false)
+          end
+          io << "]'"
+        end
+      end
+
+      def quote(value : PG::Geo::Point, quote = true)
+        return "'(#{value.x},#{value.y})'" if quote
+
+        "(#{value.x},#{value.y})"
+      end
+
+      def quote(value : PG::Geo::Polygon)
+        String.build do |io|
+          io << "'("
+          value.points.each_with_index do |point, index|
+            io << ',' if index != 0
+            io << quote(point, false)
+          end
+          io << ")'"
+        end
+      end
+
+      def quote(value : PG::Numeric)
+        value.to_s
+      end
+
+      def quote(value : Array)
+        String.build do |io|
+          io << "'{"
+          value.each_with_index do |element, index|
+            io << ',' if index != 0
+            io << quote_array_value(element)
+          end
+          io << "}'"
+        end
+      end
+
+      def quote(value : Slice(UInt8))
+        PG::EscapeHelper.escape_literal(value)
+      end
+
+      def quote_array_value(value : String)
+        "\"" + value.gsub(Jennifer::Adapter::Quoting::STRING_QUOTING_PATTERNS) + "\""
+      end
+
+      def quote_array_value(value)
+        value.to_s
+      end
+    end
+  end
+end

--- a/src/jennifer/adapter/postgres/schema_processor.cr
+++ b/src/jennifer/adapter/postgres/schema_processor.cr
@@ -33,7 +33,6 @@ module Jennifer
       # Schema manipulating methods
       # ============================
 
-      # TODO: sanitize query
       def define_enum(name : String | Symbol, values : Array)
         adapter.exec "CREATE TYPE #{name} AS ENUM(#{values.map { |e| adapter.sql_generator.quote(e) }.join(", ")})"
       end

--- a/src/jennifer/adapter/postgres/sql_generator.cr
+++ b/src/jennifer/adapter/postgres/sql_generator.cr
@@ -1,8 +1,11 @@
 require "../base_sql_generator"
+require "./quoting"
 
 module Jennifer
   module Postgres
     class SQLGenerator < Adapter::BaseSQLGenerator
+      extend Quoting
+
       # :nodoc:
       OPERATORS = {
         like: "LIKE",
@@ -105,17 +108,6 @@ module Jennifer
         "#{path.identifier}#{operator}#{quote(path.path)}"
       end
 
-      # for postgres column name
-      def self.escape(value : String)
-        case value
-        when "NULL", "TRUE", "FALSE"
-          value
-        else
-          value = value.gsub(/\\/, ARRAY_ESCAPE).gsub(/"/, "\\\"")
-          "\"#{value}\""
-        end
-      end
-
       def self.escape(value : Nil)
         quote(value)
       end
@@ -126,10 +118,6 @@ module Jennifer
 
       def self.escape(value : Int32 | Int16 | Float64 | Float32)
         quote(value)
-      end
-
-      def self.quote(value : String)
-        "'#{value.gsub(/\\/, "\&\&").gsub(/'/, "''")}'"
       end
 
       def self.parse_query(query, args : Array(DBAny))

--- a/src/jennifer/adapter/quoting.cr
+++ b/src/jennifer/adapter/quoting.cr
@@ -1,0 +1,93 @@
+module Jennifer
+  module Adapter
+    module Quoting
+      ARGUMENT_ESCAPE_STRING = "%s"
+      STRING_QUOTING_PATTERNS = { '\\' => "\\\\", '\'' => "''", '"' => "\\\"" }
+
+      # Quotes the column value to help prevent -[SQL injection attacks][https://en.wikipedia.org/wiki/SQL_injection].
+      abstract def quote(value : String)
+
+      abstract def quote_json_string(value : String)
+
+      # ditto
+      def quote(value : Nil)
+        "NULL"
+      end
+
+      # ditto
+      def quote(value : Bool)
+        value ? "TRUE" : "FALSE"
+      end
+
+      # ditto
+      def quote(value : Int | Float | UInt32)
+        value.to_s
+      end
+
+      # ditto
+      def quote(value : Char)
+        quote(value.to_s)
+      end
+
+      # ditto
+      def quote(value : Time)
+        "'#{value.to_utc.to_s("%F %T")}'"
+      end
+
+      # ditto
+      def quote(value : Time::Span)
+        # NOTE: isn't user by pg driver ATM
+        "'#{value.to_s}'"
+      end
+
+      # ditto
+      def quote(value : Slice(UInt8))
+        "x'#{value.hexstring}'"
+      end
+
+      # ditto
+      def quote(value : JSON::Any)
+        "'" + ::Jennifer::Adapter::JSONEncoder.encode(value, self) + "'"
+      end
+
+      # ditto
+      def quote(value)
+        raise ArgumentError.new("Value #{value} can't be quoted")
+      end
+
+      # Quotes strings of JSON column value to help prevent -[SQL injection attacks][https://en.wikipedia.org/wiki/SQL_injection].
+      def quote_json_string(value : String)
+        value.gsub('\'', "''")
+      end
+
+      def filter_out(arg)
+        escape_string
+      end
+
+      def escape_string
+        ARGUMENT_ESCAPE_STRING
+      end
+
+      def escape_string(size : Int32)
+        case size
+        when 1
+          ARGUMENT_ESCAPE_STRING
+        when 2
+          "#{ARGUMENT_ESCAPE_STRING}, #{ARGUMENT_ESCAPE_STRING}"
+        when 3
+          "#{ARGUMENT_ESCAPE_STRING}, #{ARGUMENT_ESCAPE_STRING}, #{ARGUMENT_ESCAPE_STRING}"
+        else
+          size.times.join(", ") { ARGUMENT_ESCAPE_STRING }
+        end
+      end
+
+      def filter_out(arg : Array, single : Bool = true)
+        single ? escape_string : arg.join(", ") { |a| filter_out(a) }
+      end
+
+      def filter_out(arg : QueryBuilder::SQLNode)
+        arg.as_sql(self)
+      end
+    end
+  end
+end

--- a/src/jennifer/adapter/transaction_observer.cr
+++ b/src/jennifer/adapter/transaction_observer.cr
@@ -2,6 +2,7 @@ module Jennifer
   module Adapter
     class TransactionObserver
       property transaction : DB::Transaction
+
       @rolled_back = false
       @commit_observers = [] of -> Bool
       @rollback_observers = [] of -> Bool

--- a/src/jennifer/adapter/transactions.cr
+++ b/src/jennifer/adapter/transactions.cr
@@ -42,12 +42,12 @@ module Jennifer
           conn.transaction do |tx|
             lock_connection(tx)
             begin
-              Config.logger.debug("TRANSACTION START")
+              Config.logger.debug("BEGIN")
               res = yield(tx)
-              Config.logger.debug("TRANSACTION COMMIT")
+              Config.logger.debug("COMMIT")
             rescue e
               @locks[fiber_id].rollback
-              Config.logger.debug("TRANSACTION ROLLBACK")
+              Config.logger.debug("ROLLBACK")
               raise e
             ensure
               lock_connection(previous_transaction)
@@ -70,7 +70,7 @@ module Jennifer
       # Starts manual transaction for current fiber. Designed for usage in test callback.
       def begin_transaction
         raise ::Jennifer::BaseException.new("Couldn't manually begin non top level transaction") if current_transaction
-        Config.logger.debug("TRANSACTION START")
+        Config.logger.debug("START")
         lock_connection(@db.checkout.begin_transaction)
       end
 
@@ -78,9 +78,10 @@ module Jennifer
       def rollback_transaction
         t = current_transaction
         raise ::Jennifer::BaseException.new("No transaction to rollback") unless t
+
         t = t.not_nil!
         t.rollback
-        Config.logger.debug("TRANSACTION ROLLBACK")
+        Config.logger.debug("ROLLBACK")
         t.connection.release
         lock_connection(nil)
       end

--- a/src/jennifer/query_builder/ordering.cr
+++ b/src/jennifer/query_builder/ordering.cr
@@ -78,6 +78,9 @@ module Jennifer
       # Contact.all.order { _name.asc }
       # Contact.all.order { [_name.asc, _age.desc] }
       # ```
+      #
+      # Specified block should return `OrderItem | Array(OrderItem)`. To convert `Criteria` or `RawSql` to
+      # order item call `#asc` or `#desc`.
       def order(&block)
         order(with @expression yield)
       end


### PR DESCRIPTION
# What does this PR do?

Fixes the case when we what to import total count of values that exceeds maximum allowed. In a such case all arguments will be just quoted.

# Release notes

**Adapter**

* add `Base.default_max_bind_vars_count` which returns default maximum count of bind variables that can be used in `Base#bulk_insert` (default is 32766)
* `Mysql.default_max_bind_vars_count` and `Postgres.default_max_bind_vars_count` returns `32766` 
* `Base#bulk_insert` doesn't do table lock no more
* if variables that should be inserted by `Base#bulk_insert` exceed `Base.max_bind_vars` all of them are quoted and put into a query
* remove `BaseSQLGenerator::ARRAY_ESCAPE`
* move `BaseSQLGenerator::ARGUMENT_ESCAPE_STRING` to `Quoting`
* move `BaseSQLGenerator` `.quote`, `.escape_string`, `.filter_out` to `Quoting`
* add correct values quoting for `postgres` adapter
* add correct values quoting for `mysql` adapter
* now logger writes `BEGIN` instead of `TRANSACTION START`, `COMMIT` instead of `TRANSACTION COMMIT` and `ROLLBACK` instead of `TRANSACTION ROLLBACK` on corresponding transaction commands

**Config**

* add `max_bind_vars_count` property to present maximum allowed count of bind variables to be used in bulk insert operation
