### PR TITLE
Fix possible name collision; fix model table name prefix generating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .vscode
 jennifer.code-workspace
 /spec/fixtures/*.db
+sam.cr
 
 # Libraries don't need dependency lock
 # Dependencies will be locked in application that uses them

--- a/docs/model_mapping.md
+++ b/docs/model_mapping.md
@@ -266,19 +266,20 @@ end
 
 ## Table name
 
-Automatically model is associated with table with underscored pluralized name of it's class, but custom one can be specified defining `::table_name`. This means no modules will affect name generating.
+By default model determines related table name by underscoring and pluralizing own class name. In the case when model is define under some namespace, it's underscored name is considered as table name prefix.
 
 ```crystal
-Admin::User.table_name # "users"
+User.table_name # "users"
+API::Admin::User.table_name # "api_admin_users"
 ```
 
-To provide special table prefix per module basis use super class with defined `::table_prefix` method:
+To override table name prefix define own `.table_prefix`
 
 ```crystal
 module Admin
   class Base < Jennifer::Model::Base
     def self.table_prefix
-      "admin_"
+      "private_"
     end
   end
 
@@ -287,8 +288,30 @@ module Admin
   end
 end
 
-Admin::User.table_name # "admin_users"
+Admin::User.table_name # "private_users"
 ```
+
+> As you see `.table_prefix` should return `"_"` at the end to keep naming across application consistent.
+
+> Also to prevent adding table prefix at all - return `nil`.
+
+To override table name just call `.table_name`:
+
+```crystal
+class User < Jennifer::Model::Base
+  table_name :posts
+  # ...
+end
+
+class Admin::User < Jennifer::Model::Base
+  table_name "users"
+end
+
+User.table_name # "posts"
+Admin::User.table_name # "users"
+```
+
+> `.table_name` accepts table name that already includes prefix.
 
 ## Virtual attributes
 

--- a/docs/pagination_and_ordering.md
+++ b/docs/pagination_and_ordering.md
@@ -19,7 +19,7 @@ Contact.all.order(name: :asc, id: "desc")
 Contact.all.order({ :name => :asc })
 # string key hash
 Contact.all.order({ "name" => :asc })
-# with block returning array of OrderItem
+# with block returning array of Jennifer::QueryBuilder::OrderExpression
 Contact.all.order{ [_name.asc] }
 # or pass it as an argument
 Contact.all.order(Contact._name.asc)

--- a/spec/model/base_spec.cr
+++ b/spec/model/base_spec.cr
@@ -11,6 +11,14 @@ module SomeModule
   class SomeModel < Jennifer::Model::Base
     mapping(id: Primary32)
   end
+
+  class AnotherModel < Jennifer::Model::Base
+    mapping(id: Primary32)
+
+    def self.table_prefix
+      "custom_table_prefix_"
+    end
+  end
 end
 
 abstract class SuperModel < Jennifer::Model::Base
@@ -362,7 +370,6 @@ describe Jennifer::Model::Base do
 
   describe "::table_name" do
     it { Contact.table_name.should eq("contacts") }
-    it { SomeModule::SomeModel.table_name.should eq("some_models") }
     it { ModelWithTablePrefix.table_name.should eq("custom_table_prefix_model_with_table_prefixes") }
 
     it "returns specified name" do
@@ -372,11 +379,15 @@ describe Jennifer::Model::Base do
     describe "STI" do
       it { TwitterProfile.table_name.should eq("profiles") }
     end
+
+    describe "inside of module" do
+      it { SomeModule::SomeModel.table_name.should eq("some_module_some_models") }
+      it { SomeModule::AnotherModel.table_name.should eq("custom_table_prefix_another_models") }
+    end
   end
 
   describe "::foreign_key_name" do
     it { Contact.foreign_key_name.should eq("contact_id") }
-    it { SomeModule::SomeModel.foreign_key_name.should eq("some_model_id") }
     it { ModelWithTablePrefix.foreign_key_name.should eq("custom_table_prefix_model_with_table_prefix_id") }
 
     it "returns specified name" do
@@ -385,6 +396,11 @@ describe Jennifer::Model::Base do
 
     describe "STI" do
       it { TwitterProfile.foreign_key_name.should eq("profile_id") }
+    end
+
+    describe "inside of module" do
+      it { SomeModule::SomeModel.foreign_key_name.should eq("some_module_some_model_id") }
+      it { SomeModule::AnotherModel.foreign_key_name.should eq("custom_table_prefix_another_model_id") }
     end
   end
 

--- a/spec/models.cr
+++ b/spec/models.cr
@@ -377,6 +377,53 @@ class AllTypeModel < ApplicationRecord
   )
 end
 
+class Author < Jennifer::Model::Base
+  mapping({
+    id:         Primary32,
+    name1:      { type: String, column: :first_name },
+    name2:      { type: String, column: :last_name }
+  })
+end
+
+class Publication < Jennifer::Model::Base
+  {% if env("DB") == "postgres" || env("DB") == nil %}
+    mapping(
+      id:         Primary32,
+      name:       { type: String, column: :title },
+      version:    Int32,
+      publisher:  String,
+      type:       { type: String, converter: Jennifer::Model::EnumConverter }
+    )
+  {% else %}
+    mapping(
+      id:         Primary32,
+      name:       { type: String, column: :title },
+      version:    Int32,
+      publisher:  String,
+      type:       String
+    )
+  {% end %}
+end
+
+class Book < Publication
+  mapping({
+    pages:      Int32?
+  })
+end
+
+class Article < Publication
+  mapping({
+    size:       { type: Int32?, column: :pages }
+  })
+end
+
+class BlogPost < Publication
+  mapping({
+    url:        String?,
+    created_at:    {type: Time?, virtual: true, column: :created}
+  })
+end
+
 # ===================
 # synthetic models
 # ===================
@@ -643,49 +690,8 @@ class NoteWithManualId < Jennifer::Model::Base
   )
 end
 
-class Author < Jennifer::Model::Base
-  mapping({
-    id:         Primary32,
-    name1:      { type: String, column: :first_name },
-    name2:      { type: String, column: :last_name }
-  })
-end
+class OrderItem < ApplicationRecord
+  table_name "all_types"
 
-class Publication < Jennifer::Model::Base
-  {% if env("DB") == "postgres" || env("DB") == nil %}
-    mapping(
-      id:         Primary32,
-      name:       { type: String, column: :title },
-      version:    Int32,
-      publisher:  String,
-      type:       { type: String, converter: Jennifer::Model::EnumConverter }
-    )
-  {% else %}
-    mapping(
-      id:         Primary32,
-      name:       { type: String, column: :title },
-      version:    Int32,
-      publisher:  String,
-      type:       String
-    )
-  {% end %}
-end
-
-class Book < Publication
-  mapping({
-    pages:      Int32?
-  })
-end
-
-class Article < Publication
-  mapping({
-    size:       { type: Int32?, column: :pages }
-  })
-end
-
-class BlogPost < Publication
-  mapping({
-    url:        String?,
-    created_at:    {type: Time?, virtual: true, column: :created}
-  })
+  mapping(id: Primary32)
 end

--- a/spec/query_builder/order_expression_spec.cr
+++ b/spec/query_builder/order_expression_spec.cr
@@ -1,11 +1,11 @@
 require "../spec_helper"
 
-describe Jennifer::QueryBuilder::OrderItem do
-  described_class = Jennifer::QueryBuilder::OrderItem
+describe Jennifer::QueryBuilder::OrderExpression do
+  described_class = Jennifer::QueryBuilder::OrderExpression
 
   describe ".new" do
     it "makes RawSQL not to use brackets" do
-      described_class.new(Factory.build_expression.sql("raw sql"), Jennifer::QueryBuilder::OrderItem::Direction::ASC).as_sql.should eq("raw sql ASC")
+      described_class.new(Factory.build_expression.sql("raw sql"), Jennifer::QueryBuilder::OrderExpression::Direction::ASC).as_sql.should eq("raw sql ASC")
     end
   end
 

--- a/spec/relation/polymorphic_belongs_to_spec.cr
+++ b/spec/relation/polymorphic_belongs_to_spec.cr
@@ -5,6 +5,8 @@ module Spec
     include ::Note::Mapping
 
     belongs_to :notable, Union(::User | ::Spec::Contact), polymorphic: true
+
+    def self.table_prefix; end
   end
 
   class Contact < ApplicationRecord
@@ -13,6 +15,8 @@ module Spec
     mapping
 
     has_one :note, Note, inverse_of: :notable, polymorphic: true, dependent: :nullify
+
+    def self.table_prefix; end
   end
 end
 

--- a/src/jennifer/adapter/base_sql_generator.cr
+++ b/src/jennifer/adapter/base_sql_generator.cr
@@ -278,7 +278,7 @@ module Jennifer
 
       # ======== utils
 
-      def self.order_expression(expression : QueryBuilder::OrderItem)
+      def self.order_expression(expression : QueryBuilder::OrderExpression)
         "#{expression.criteria.identifier} #{expression.direction}"
       end
 

--- a/src/jennifer/adapter/mysql/sql_generator.cr
+++ b/src/jennifer/adapter/mysql/sql_generator.cr
@@ -62,7 +62,7 @@ module Jennifer
         "#{path.identifier}->#{json_quote(value)}"
       end
 
-      def self.order_expression(expression : QueryBuilder::OrderItem)
+      def self.order_expression(expression : QueryBuilder::OrderExpression)
         if expression.null_position.none?
           super
         else

--- a/src/jennifer/adapter/postgres/sql_generator.cr
+++ b/src/jennifer/adapter/postgres/sql_generator.cr
@@ -83,7 +83,7 @@ module Jennifer
         "excluded.#{field}"
       end
 
-      def self.order_expression(expression : QueryBuilder::OrderItem)
+      def self.order_expression(expression : QueryBuilder::OrderExpression)
         if expression.null_position.none?
           super
         else

--- a/src/jennifer/query_builder/criteria.cr
+++ b/src/jennifer/query_builder/criteria.cr
@@ -1,5 +1,5 @@
 require "./json_selector"
-require "./order_item"
+require "./order_expression"
 
 module Jennifer
   module QueryBuilder
@@ -159,11 +159,11 @@ module Jennifer
       end
 
       def asc
-        OrderItem.new(self, OrderItem::Direction::ASC)
+        OrderExpression.new(self, OrderExpression::Direction::ASC)
       end
 
       def desc
-        OrderItem.new(self, OrderItem::Direction::DESC)
+        OrderExpression.new(self, OrderExpression::Direction::DESC)
       end
 
       def sql_args : Array(DBAny)

--- a/src/jennifer/query_builder/order_expression.cr
+++ b/src/jennifer/query_builder/order_expression.cr
@@ -1,6 +1,6 @@
 module Jennifer
   module QueryBuilder
-    class OrderItem < SQLNode
+    class OrderExpression < SQLNode
       # Sorting direction
       enum Direction
         ASC
@@ -28,11 +28,11 @@ module Jennifer
         @null_position = other.@null_position.dup
       end
 
-      def ==(other : OrderItem)
+      def ==(other : OrderExpression)
         eql?(other)
       end
 
-      def eql?(other : OrderItem)
+      def eql?(other : OrderExpression)
         criteria.eql?(other.criteria) &&
           direction == other.direction &&
           null_position == other.null_position

--- a/src/jennifer/query_builder/ordering.cr
+++ b/src/jennifer/query_builder/ordering.cr
@@ -43,22 +43,22 @@ module Jennifer
         self
       end
 
-      # Allow to specify an order by *OrderItem*.
+      # Allow to specify an order by *OrderExpression*.
       #
       # ```
       # Contact.all.order(Contact._name.asc)
       # ```
-      def order(opt : OrderItem)
+      def order(opt : OrderExpression)
         _order! << opt
         self
       end
 
-      # Allow to specify an order by *OrderItem* array.
+      # Allow to specify an order by *OrderExpression* array.
       #
       # ```
       # Contact.all.order([Contact._name.asc])
       # ```
-      def order(opts : Array(OrderItem))
+      def order(opts : Array(OrderExpression))
         opts.each { |opt| _order! << opt }
         self
       end
@@ -80,8 +80,8 @@ module Jennifer
       # Contact.all.order { [_name.asc, _age.desc] }
       # ```
       #
-      # Specified block should return `OrderItem | Array(OrderItem)`. To convert `Criteria` or `RawSql` to
-      # order item call `#asc` or `#desc`.
+      # Specified block should return `OrderExpression | Array(OrderExpression)`.
+      # To convert `Criteria` or `RawSql` to order item call `#asc` or `#desc`.
       def order(&block)
         order(with @expression yield)
       end
@@ -106,12 +106,12 @@ module Jennifer
         order(opts)
       end
 
-      def reorder(opt : OrderItem)
+      def reorder(opt : OrderExpression)
         @order = nil
         order(opt)
       end
 
-      def reorder(opts : Array(OrderItem))
+      def reorder(opts : Array(OrderExpression))
         @order = nil
         order(opts)
       end

--- a/src/jennifer/query_builder/query.cr
+++ b/src/jennifer/query_builder/query.cr
@@ -51,7 +51,7 @@ module Jennifer
       @joins : Array(Join)?
       @unions : Array(UnionType)?
       @groups : Array(Criteria)?
-      @order : Array(OrderItem)?
+      @order : Array(OrderExpression)?
       @select_fields : Array(Criteria)?
       @ctes : Array(CommonTableExpression)?
 
@@ -93,7 +93,7 @@ module Jennifer
 
       # :nodoc:
       def _order!
-        @order ||= [] of OrderItem
+        @order ||= [] of OrderExpression
       end
 
       # :nodoc:


### PR DESCRIPTION
# What does this PR do?

Fix #288 .

# Release notes

**QueryBuilder**

* `OrderItem` is renamed to `OrderExpression` to avoid possible name collisions

**Model**

* `Resource.table_prefix` now returns underscored namespace name (if any) by default