### PR TITLE
reference type fix

### DIFF
--- a/src/jennifer/migration/table_builder/create_table.cr
+++ b/src/jennifer/migration/table_builder/create_table.cr
@@ -93,7 +93,10 @@ module Jennifer
           column = Inflector.foreign_key(name)
           is_null = options.has_key?(:null) ? options[:null] : true
 
-          field(column, type, { :null => is_null })
+          field_internal_type = options.has_key?(:sql_type) ? nil : type
+          @fields[column.to_s] =
+            build_column_options(field_internal_type, options.merge({:null => is_null}))
+
           if options[:polymorphic]?
             string("#{name}_type", { :null => is_null })
           else

--- a/src/jennifer/migration/table_builder/create_table.cr
+++ b/src/jennifer/migration/table_builder/create_table.cr
@@ -93,7 +93,7 @@ module Jennifer
           column = Inflector.foreign_key(name)
           is_null = options.has_key?(:null) ? options[:null] : true
 
-          integer(column, { :type => type, :null => is_null })
+          field(column, type, { :null => is_null })
           if options[:polymorphic]?
             string("#{name}_type", { :null => is_null })
           else


### PR DESCRIPTION
# What does this PR do?

Fixed a bug where the `type` parameter of the `CreateTable#reference` method was invalid

# Any background context you want to provide?

What is happening now is that, regardless of the value of the `type` parameter, the resulting SQL will always be of type integer.

This PR's commits is based on the `v0.8.4` tag, not the master branch. Because the master branch currently has compilation errors. 