### PR TITLE
Add association_primary to has_and_belongs_to_many

### DIFF
--- a/src/jennifer/model/relation_definition.cr
+++ b/src/jennifer/model/relation_definition.cr
@@ -226,6 +226,7 @@ module Jennifer
       # - *primary* - specify the name of the column to use as the primary key for the relation
       # - *join_table* - specifies the name of the join table if the default based on lexical order isn't what you want
       # - *association_foreign* - specifies the foreign key used for the association on the receiving side of the association
+      # - *association_primary* - specifies the primary key used for the association on the receiving side of the association
       #
       # The following methods for retrieval and query of a single associated object will be added:
       #
@@ -238,11 +239,11 @@ module Jennifer
       # - `#remove_association(rel)`
       # - `#association_query`
       # - `#association_reload`
-      macro has_and_belongs_to_many(name, klass, request = nil, foreign = nil, primary = nil, join_table = nil, association_foreign = nil)
+      macro has_and_belongs_to_many(name, klass, request = nil, foreign = nil, primary = nil, join_table = nil, association_foreign = nil, association_primary = nil)
         {{"{% RELATION_NAMES << #{name.id.stringify} %}".id}}
         RELATIONS["{{name.id}}"] =
           ::Jennifer::Relation::ManyToMany({{klass}}, {{@type}}).new("{{name.id}}", {{foreign}}, {{primary}},
-            {{klass}}.all{% if request %}.exec {{request}} {% end %}, {{join_table}}, {{association_foreign}})
+            {{klass}}.all{% if request %}.exec {{request}} {% end %}, {{join_table}}, {{association_foreign}}, {{association_primary}})
 
         before_destroy :__{{name.id}}_clean
 


### PR DESCRIPTION
First, let me say if this already exists and I am using jennifer wrong, please just let me know!

# What does this PR do?
Adds `association_primary` to `has_and_belongs_to_many`. Currently, the query is built by defaulting to the primary key of the other table with `T.primary`. This allows users to define a different column, like `uuid`, while keeping `id` as the primary key for the table. 

# Any background context you want to provide?

Right now i have an `App` & a `User` model. They are connected by `has_and_belongs_to_many` with the join table being `apps_users`. 

App psuedo sql table:
```
id, integer, not null, nextval
name, string
uuid, string, unique, not null # this is what apps_users is referencing
"apps_pkey" PRIMARY KEY, btree (id)
TABLE "apps_users" CONSTRAINT "fk_cr_606d320c60" FOREIGN KEY (app_id) REFE
RENCES apps(uuid) ON UPDATE RESTRICT ON DELETE RESTRICT
```

`apps_users` sql table:
```
id, integer, not null, nextval
user_id, integer
app_id, string
"apps_users_pkey" PRIMARY KEY, btree (id)
FOREIGN KEY (app_id) REFERENCES apps(uuid) ON UPDATE R
ESTRICT ON DELETE RESTRICT
```

Right now when i do:
```crystal
user = User.find 1
user.apps if user
```
It throws a bad query error. The sql looks like this:
```sql
SELECT apps.* FROM apps JOIN apps_users ON apps_users.app_id = apps.id AND apps_users.user_id = $1
```
Notice the `apps_users.app_id = apps.id`. A proper query would look like:
```sql
apps_users.app_id = apps.uuid
```

In the user class i can do `association_foreign: :uuid` which is obviously wrong but changes the sql query to:
```sql
apps_users.uuid = apps.id
```
Almost right. That's what led me down this rabbit hole. With this PR, i can change the above to `association_primary: :uuid`
```sql
apps_users.id = apps.uuid
```

# Release notes

Please fill the corresponding section regarding this pull request notes below instead of modifying `CHANGELOG.md` file. Please remove all redundant sections before posting request.

**Model**
Adds `association_primary` to `has_and_belongs_to_many` relation to allow specifying a separate column for querying other than the primary key column

### Other

I am not too happy with how `association_primary_key` came out in `ManyToMany` and would love to see a more elegant solution.