### PR TITLE
Add presentable interface

### DIFF
--- a/spec/model/mapping_spec.cr
+++ b/spec/model/mapping_spec.cr
@@ -81,6 +81,30 @@ describe Jennifer::Model::Mapping do
     end
   end
 
+  describe "#attribute_metadata" do
+    describe "with symbol argument" do
+      it do
+        Factory.build_contact.attribute_metadata(:id)
+          .should eq({type: Int32, primary: true, parsed_type: "Int32?", column: "id", auto: true})
+        Factory.build_contact.attribute_metadata(:name)
+          .should eq({type: String, parsed_type: "String", column: "name"})
+        Factory.build_address.attribute_metadata(:street)
+          .should eq({type: String, parsed_type: "String", column: "street"})
+      end
+    end
+
+    describe "with string argument" do
+      it do
+        Factory.build_contact.attribute_metadata("id")
+          .should eq({type: Int32, primary: true, parsed_type: "Int32?", column: "id", auto: true})
+        Factory.build_contact.attribute_metadata("name")
+          .should eq({type: String, parsed_type: "String", column: "name"})
+        Factory.build_address.attribute_metadata("street")
+          .should eq({type: String, parsed_type: "String", column: "street"})
+      end
+    end
+  end
+
   describe "%mapping" do
     describe "converter" do
       postgres_only do

--- a/spec/model/translation_spec.cr
+++ b/spec/model/translation_spec.cr
@@ -135,4 +135,9 @@ describe Jennifer::Model::Translation do
       end
     end
   end
+
+  describe "#class_name" do
+    it { Factory.build_contact.class_name.should eq("contact") }
+    it { Jennifer::Migration::Version.new({ version: "1" }).class_name.should eq("jennifer_migration_version") }
+  end
 end

--- a/src/jennifer/model/base.cr
+++ b/src/jennifer/model/base.cr
@@ -3,6 +3,7 @@ require "../relation/*"
 require "../model/errors"
 
 require "./resource"
+require "./presentable"
 require "./mapping"
 require "./sti_mapping"
 require "./validation"
@@ -44,6 +45,7 @@ module Jennifer
       end
 
       extend AbstractClassMethods
+      include Presentable
       include Mapping
       include STIMapping
       include Validation

--- a/src/jennifer/model/mapping.cr
+++ b/src/jennifer/model/mapping.cr
@@ -130,6 +130,15 @@ module Jennifer
       include FieldDeclaration
       include CommonMapping
 
+      def attribute_metadata(name : String | Symbol)
+        name = name.to_s
+        self.class.columns_tuple.each do |key, props|
+          return props if key.to_s == name
+        end
+
+        raise ArgumentError.new("Unknown attribute #{name}")
+      end
+
       # :nodoc:
       macro copy_properties
         {%

--- a/src/jennifer/model/presentable.cr
+++ b/src/jennifer/model/presentable.cr
@@ -1,0 +1,23 @@
+module Jennifer
+  # This is an abstract interface
+  module Presentable
+    # Returns value by attribute *name* or raises `Jennifer::BaseException` if none.
+    #
+    # ```
+    # User.all.last.attribute(:email) # => "test@example.com"
+    # ```
+    abstract def attribute(name : String | Symbol, raise_exception : Bool = true)
+    # Returns container with object's validation errors.
+    abstract def errors : Jennifer::Model::Errors
+    # Returns human readable attribute name based on translations.
+    abstract def human_attribute_name(name : String | Symbol)
+    # Returns field *name* metadata or raises `ArgumentError`.
+    abstract def attribute_metadata(name : String | Symbol)
+    # Returns underscored model class name.
+    #
+    # ```
+    # Admin::User.all.last.class_name # => "admin_user"
+    # ```
+    abstract def class_name : String
+  end
+end

--- a/src/jennifer/model/translation.cr
+++ b/src/jennifer/model/translation.cr
@@ -4,9 +4,6 @@ module Jennifer
     #
     # Depends of parent class `::lookup_ancestors` and `::i18n_scope` methods.
     module Translation
-      # Default global translation scope.
-      GLOBAL_SCOPE = "jennifer"
-
       module ClassMethods
         # Search translation for given attribute.
         def human_attribute_name(attribute : String | Symbol)
@@ -60,12 +57,21 @@ module Jennifer
       # All possible types to be used for localization.
       alias LocalizeableTypes = Int32 | Int64 | Nil | Float32 | Float64 | Time | String | Symbol | Bool
 
+      # Default global translation scope.
+      GLOBAL_SCOPE = "jennifer"
+
+      # Delegates the call to `self.class`.
       def lookup_ancestors(&block)
         self.class.lookup_ancestors { |ancestor| yield ancestor }
       end
 
+      # Delegates the call to `self.class`.
       def human_attribute_name(attribute : String | Symbol)
         self.class.human_attribute_name(attribute)
+      end
+
+      def class_name : String
+        self.class.to_s.underscore.gsub(/::/, "_")
       end
 
       macro included

--- a/src/jennifer/model/validation.cr
+++ b/src/jennifer/model/validation.cr
@@ -9,7 +9,7 @@ module Jennifer
       @errors : Errors?
 
       # Returns container with object's validation errors.
-      def errors
+      def errors : Errors
         @errors ||= Errors.new(self)
       end
 


### PR DESCRIPTION
# What does this PR do?

Add `Jennifer::Presentable` to formalize abstract interface for the dynamic access to model metadata and attribute interface.

# Release notes

**General**

* add `Jennifer::Presentable` with abstract methods declarations (`#attribute`, `#errors`, `#human_attribute_name`, `#attribute_metadata`, `#class_name`)

**Model**

* `Base` includes `Jennifer::Presentable`
* add `Translation#class_name` method to return underscored class name
* add `Mapping#attribute_metadata` to return attribute metadata by it's name