### PR TITLE
Deprecate Adapter .adapter and .adapter_class methods; remove Model::…

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,11 +176,11 @@ The fastest way to rollback all changes in the DB after test case is by using a 
 
 ```crystal
 Spec.before_each do
-  Jennifer::Adapter.adapter.begin_transaction
+  Jennifer::Adapter.default_adapter.begin_transaction
 end
 
 Spec.after_each do
-  Jennifer::Adapter.adapter.rollback_transaction
+  Jennifer::Adapter.default_adapter.rollback_transaction
 end
 ```
 

--- a/docs/crud.md
+++ b/docs/crud.md
@@ -103,9 +103,9 @@ end
 
 To truncate entire table use:
 ```crystal
-Jennifer::Adapter.adapter.truncate("contacts")
+Jennifer::Adapter.default_adapter.truncate("contacts")
 # or
-Jennifer::Adapter.adapter.truncate(Contact)
+Jennifer::Adapter.default_adapter.truncate(Contact)
 ```
 
 This functionality could be useful to clear db between test cases.

--- a/docs/model_mapping.md
+++ b/docs/model_mapping.md
@@ -158,7 +158,6 @@ If you don't want to define all the table fields - pass `false` as second argume
 | `#primary` | | value of primary key field |
 | `::primary` | | returns criterion for primary field (query DSL) |
 | `::primary_field_name` | | name of primary field |
-| `::primary_field_type` | | type of primary key |
 | `#new_record?` | | returns `true` if record has `nil` primary key (is not stored to db) |
 | `::create` | `Hash(String \| Symbol, DB::Any)`, `NamedTuple` | creates object, stores it to db and returns it |
 | `::create!` | `Hash(String \| Symbol, DB::Any)`, `NamedTuple` | creates object, stores it to db and returns it; otherwise raise exception |

--- a/docs/model_scopes.md
+++ b/docs/model_scopes.md
@@ -15,7 +15,9 @@ As you can see arguments are next:
 Also they are chainable, so you could do:
 
 ```crystal
-ModelName.all.where { _some_field > 1 }
-         .query_with_arguments("done", [1,2])
-         .order(f1: :asc).no_argument_query
+ModelName.all
+  .where { _some_field > 1 }
+  .query_with_arguments("done", [1,2])
+  .order(f1: :asc)
+  .no_argument_query
 ```

--- a/docs/transaction_and_lock.md
+++ b/docs/transaction_and_lock.md
@@ -5,7 +5,7 @@
 Transaction mechanism provides block-like syntax:
 
 ```crystal
-Jennifer::Adapter.adapter.transaction do |tx|
+Jennifer::Adapter.default_adapter.transaction do |tx|
   Contact.create({:name => "Chose", :age => 20})
 end
 ```
@@ -57,7 +57,7 @@ end
 To lock table use `Jennifer::Adapter#with_table_lock` method
 
 ```crystal
-Jennifer::Adapter.adapter("table_name") do
+Jennifer::Adapter.default_adapter("table_name") do
   # some operations here
 end
 ```

--- a/spec/adapter/base_spec.cr
+++ b/spec/adapter/base_spec.cr
@@ -1,7 +1,7 @@
 require "../spec_helper"
 
 describe Jennifer::Adapter::Base do
-  adapter = Jennifer::Adapter.adapter
+  adapter = Jennifer::Adapter.default_adapter
 
   describe Jennifer::BadQuery do
     describe "query" do

--- a/spec/adapter/base_sql_generator_spec.cr
+++ b/spec/adapter/base_sql_generator_spec.cr
@@ -1,8 +1,8 @@
 require "../spec_helper"
 
 describe Jennifer::Adapter::BaseSQLGenerator do
-  adapter = Jennifer::Adapter.adapter
-  described_class = Jennifer::Adapter.adapter.sql_generator
+  adapter = Jennifer::Adapter.default_adapter
+  described_class = Jennifer::Adapter.default_adapter.sql_generator
   expression_builder = Factory.build_expression
 
   describe "::filter_out" do
@@ -250,7 +250,7 @@ describe Jennifer::Adapter::BaseSQLGenerator do
 
     it "adds next query to current one" do
       query = Jennifer::Query["contacts"].union(Jennifer::Query["users"])
-      sb { |s| described_class.union_clause(s, query) }.should match(Regex.new(Jennifer::Adapter.adapter.sql_generator.select(Jennifer::Query["users"])))
+      sb { |s| described_class.union_clause(s, query) }.should match(Regex.new(Jennifer::Adapter.default_adapter.sql_generator.select(Jennifer::Query["users"])))
     end
   end
 

--- a/spec/adapter/mysql/schema_processor_spec.cr
+++ b/spec/adapter/mysql/schema_processor_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 mysql_only do
   describe Jennifer::Mysql::SchemaProcessor do
-    adapter = Jennifer::Adapter.adapter
+    adapter = Jennifer::Adapter.default_adapter
     processor = adapter.schema_processor
 
     describe "#rename_table" do

--- a/spec/adapter/mysql/sql_generator_spec.cr
+++ b/spec/adapter/mysql/sql_generator_spec.cr
@@ -22,8 +22,8 @@ end
 
 mysql_only do
   describe Jennifer::Mysql::SQLGenerator do
-    described_class = Jennifer::Adapter.adapter.sql_generator
-    adapter = Jennifer::Adapter.adapter
+    described_class = Jennifer::Adapter.default_adapter.sql_generator
+    adapter = Jennifer::Adapter.default_adapter
 
     describe "::lock_clause" do
       it "render custom query part if specified" do

--- a/spec/adapter/mysql_spec.cr
+++ b/spec/adapter/mysql_spec.cr
@@ -2,7 +2,7 @@ require "../spec_helper"
 
 mysql_only do
   describe Jennifer::Mysql::Adapter do
-    adapter = Jennifer::Adapter.adapter.as(Jennifer::Mysql::Adapter)
+    adapter = Jennifer::Adapter.default_adapter.as(Jennifer::Mysql::Adapter)
 
     describe "#index_exists?" do
       it "returns true if table has index with given name" do

--- a/spec/adapter/postgres/schema_processor_spec.cr
+++ b/spec/adapter/postgres/schema_processor_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 postgres_only do
   describe Jennifer::Postgres::SchemaProcessor do
-    adapter = Jennifer::Adapter.adapter
+    adapter = Jennifer::Adapter.default_adapter
     processor = adapter.schema_processor
 
     context "index manipulation" do

--- a/spec/adapter/postgres/sql_generator_spec.cr
+++ b/spec/adapter/postgres/sql_generator_spec.cr
@@ -17,8 +17,8 @@ end
 
 postgres_only do
   describe Jennifer::Postgres::SQLGenerator do
-    described_class = Jennifer::Adapter.adapter.sql_generator
-    adapter = Jennifer::Adapter.adapter
+    described_class = Jennifer::Adapter.default_adapter.sql_generator
+    adapter = Jennifer::Adapter.default_adapter
 
     describe "::lock_clause" do
       it "render custom query part if specified" do

--- a/spec/adapter/postgres_spec.cr
+++ b/spec/adapter/postgres_spec.cr
@@ -2,7 +2,7 @@ require "../spec_helper"
 
 postgres_only do
   describe Jennifer::Postgres::Adapter do
-    adapter = Jennifer::Adapter.adapter.as(Jennifer::Postgres::Adapter)
+    adapter = Jennifer::Adapter.default_adapter.as(Jennifer::Postgres::Adapter)
 
     describe "#parse_query" do
       it "replaces %s by dollar-and-numbers" do

--- a/spec/adapter/record_spec.cr
+++ b/spec/adapter/record_spec.cr
@@ -4,7 +4,7 @@ def get_record
   result = nil
   Factory.create_contact(name: "Jennifer", age: 20)
   Contact.all.each_result_set do |rs|
-    result = Jennifer::Record.new(Jennifer::Adapter.adapter.result_to_hash(rs))
+    result = Jennifer::Record.new(Jennifer::Adapter.default_adapter.result_to_hash(rs))
   end
   result.not_nil!
 end

--- a/spec/adapter/schema_processor_spec.cr
+++ b/spec/adapter/schema_processor_spec.cr
@@ -3,7 +3,7 @@ require "../spec_helper"
 alias DBOption = Jennifer::Migration::TableBuilder::Base::EAllowedTypes | Array(Jennifer::Migration::TableBuilder::Base::EAllowedTypes)
 
 describe Jennifer::Adapter::SchemaProcessor do
-  adapter = Jennifer::Adapter.adapter
+  adapter = Jennifer::Adapter.default_adapter
   processor = adapter.schema_processor
 
   describe "#add_index" do

--- a/spec/integration/concurrency_test.cr
+++ b/spec/integration/concurrency_test.cr
@@ -26,7 +26,7 @@ Spec.before_each do
 end
 
 describe "Concurrent execution" do
-  adapter = Jennifer::Adapter.adapter
+  adapter = Jennifer::Adapter.default_adapter
   tread_count = POOL_SIZE + 1
 
   describe "Jennifer::Adapter::Base" do

--- a/spec/migration/base_spec.cr
+++ b/spec/migration/base_spec.cr
@@ -23,7 +23,7 @@ describe Jennifer::Migration::Base do
 
   # TODO: add aka transactional schema tests for MySQL
   postgres_only do
-    adapter = Jennifer::Adapter.adapter.as(Jennifer::Postgres::Adapter)
+    adapter = Jennifer::Adapter.default_adapter.as(Jennifer::Postgres::Adapter)
 
     describe "#create_table" do
       it "creates table" do

--- a/spec/migration/table_builder/change_table_spec.cr
+++ b/spec/migration/table_builder/change_table_spec.cr
@@ -1,7 +1,7 @@
 require "./spec_helper"
 
 def change_table_expr
-  Jennifer::Migration::TableBuilder::ChangeTable.new(Jennifer::Adapter.adapter, DEFAULT_TABLE)
+  Jennifer::Migration::TableBuilder::ChangeTable.new(Jennifer::Adapter.default_adapter, DEFAULT_TABLE)
 end
 
 describe Jennifer::Migration::TableBuilder::ChangeTable do

--- a/spec/migration/table_builder/create_foreign_key_spec.cr
+++ b/spec/migration/table_builder/create_foreign_key_spec.cr
@@ -4,7 +4,7 @@ module H
   def self.create_foreign_key(table = DEFAULT_TABLE, to_table = "to_tables", column = nil, primary = nil,
                          name = nil, on_update = :restrict, on_delete = :restrict)
     Jennifer::Migration::TableBuilder::CreateForeignKey.new(
-      Jennifer::Adapter.adapter,
+      Jennifer::Adapter.default_adapter,
       table,
       to_table,
       column,

--- a/spec/migration/table_builder/create_table_spec.cr
+++ b/spec/migration/table_builder/create_table_spec.cr
@@ -1,7 +1,7 @@
 require "./spec_helper"
 
 private def create_table_expr
-  Jennifer::Migration::TableBuilder::CreateTable.new(Jennifer::Adapter.adapter, DEFAULT_TABLE)
+  Jennifer::Migration::TableBuilder::CreateTable.new(Jennifer::Adapter.default_adapter, DEFAULT_TABLE)
 end
 
 describe Jennifer::Migration::TableBuilder::CreateTable do

--- a/spec/migration/table_builder/create_view_spec.cr
+++ b/spec/migration/table_builder/create_view_spec.cr
@@ -1,7 +1,7 @@
 require "./spec_helper"
 
 def create_view_expr
-  Jennifer::Migration::TableBuilder::CreateView.new(Jennifer::Adapter.adapter, DEFAULT_TABLE)
+  Jennifer::Migration::TableBuilder::CreateView.new(Jennifer::Adapter.default_adapter, DEFAULT_TABLE)
 end
 
 describe Jennifer::Migration::TableBuilder::CreateView do

--- a/spec/migration/table_builder/drop_table_spec.cr
+++ b/spec/migration/table_builder/drop_table_spec.cr
@@ -1,7 +1,7 @@
 require "./spec_helper"
 
 def drop_table_expr
-  Jennifer::Migration::TableBuilder::DropTable.new(Jennifer::Adapter.adapter, DEFAULT_TABLE)
+  Jennifer::Migration::TableBuilder::DropTable.new(Jennifer::Adapter.default_adapter, DEFAULT_TABLE)
 end
 
 describe Jennifer::Migration::TableBuilder::DropTable do

--- a/spec/migration/table_builder/drop_view_spec.cr
+++ b/spec/migration/table_builder/drop_view_spec.cr
@@ -1,7 +1,7 @@
 require "./spec_helper"
 
 def create_view_expr
-  Jennifer::Migration::TableBuilder::DropView.new(Jennifer::Adapter.adapter, DEFAULT_TABLE)
+  Jennifer::Migration::TableBuilder::DropView.new(Jennifer::Adapter.default_adapter, DEFAULT_TABLE)
 end
 
 describe Jennifer::Migration::TableBuilder::DropView do

--- a/spec/migration/table_builder/spec_helper.cr
+++ b/spec/migration/table_builder/spec_helper.cr
@@ -3,5 +3,5 @@ require "../../spec_helper"
 DEFAULT_TABLE = "test_table"
 
 def drop_table(name = DEFAULT_TABLE)
-  Jennifer::Adapter.adapter.exec("DROP TABLE IF EXISTS #{name}")
+  Jennifer::Adapter.default_adapter.exec("DROP TABLE IF EXISTS #{name}")
 end

--- a/spec/model/base_spec.cr
+++ b/spec/model/base_spec.cr
@@ -53,16 +53,6 @@ describe Jennifer::Model::Base do
     end
   end
 
-  describe "::primary_field_type" do
-    it "returns type of custom primary field" do
-      Passport.primary_field_type.should eq(String?)
-    end
-
-    it "returns type of default primary field name" do
-      Contact.primary_field_type.should eq(Int32?)
-    end
-  end
-
   describe "#init_primary_field" do
     it "sets primary field" do
       c = Factory.build_contact
@@ -415,7 +405,7 @@ describe Jennifer::Model::Base do
   describe "%scope" do
     context "with block" do
       it "executes in query context" do
-        ::Jennifer::Adapter.adapter.sql_generator.select(Contact.all.ordered).should match(/ORDER BY contacts\.name ASC/)
+        ::Jennifer::Adapter.default_adapter.sql_generator.select(Contact.all.ordered).should match(/ORDER BY contacts\.name ASC/)
       end
 
       context "without argument" do
@@ -450,7 +440,7 @@ describe Jennifer::Model::Base do
 
     context "with query object class" do
       it "executes in class context" do
-        ::Jennifer::Adapter.adapter.sql_generator.select(Contact.johny).should match(/name =/)
+        ::Jennifer::Adapter.default_adapter.sql_generator.select(Contact.johny).should match(/name =/)
       end
 
       context "without argument" do

--- a/spec/model/mapping_spec.cr
+++ b/spec/model/mapping_spec.cr
@@ -321,13 +321,13 @@ describe Jennifer::Model::Mapping do
       describe "mapping types" do
         describe "Primary32" do
           it "makes field nillable" do
-            Contact.primary_field_type.should eq(Int32?)
+            Contact.columns_tuple[:id][:parsed_type].should eq("Int32?")
           end
         end
 
         describe "Primary64" do
           it "makes field nillable" do
-            ContactWithInValidation.primary_field_type.should eq(Int64?)
+            ContactWithInValidation.columns_tuple[:id][:parsed_type].should eq("Int64?")
           end
         end
 

--- a/spec/query_builder/eager_loading_spec.cr
+++ b/spec/query_builder/eager_loading_spec.cr
@@ -138,7 +138,7 @@ describe Jennifer::QueryBuilder::EagerLoading do
       it "it generates proper request" do
         Factory.create_contact
         query = Contact.all.eager_load(:main_address)
-        Jennifer::Adapter.adapter.sql_generator.select(query).should match(/addresses\.main/)
+        Jennifer::Adapter.default_adapter.sql_generator.select(query).should match(/addresses\.main/)
       end
     end
 

--- a/spec/query_builder/model_query_spec.cr
+++ b/spec/query_builder/model_query_spec.cr
@@ -20,12 +20,12 @@ end
 # TODO: add checking for log entries when we shouldn't hit db
 
 describe Jennifer::QueryBuilder::ModelQuery do
-  adapter = Jennifer::Adapter.adapter
+  adapter = Jennifer::Adapter.default_adapter
 
   describe "#relation" do
     # TODO: this should be tested under sql generating process
     it "makes join using relation scope" do
-      ::Jennifer::Adapter.adapter
+      adapter
         .sql_generator
         .select(Contact.all.relation(:addresses))
         .should match(/LEFT JOIN addresses ON addresses.contact_id = contacts.id/)

--- a/spec/view/base_spec.cr
+++ b/spec/view/base_spec.cr
@@ -24,12 +24,6 @@ describe Jennifer::View::Base do
     end
   end
 
-  describe "::primary_field_type" do
-    it "returns type of primary field" do
-      MaleContact.primary_field_type.should eq(Int32?)
-    end
-  end
-
   describe "::view_name" do
     it "loads from class name automatically" do
       FemaleContact.view_name.should eq("female_contacts")
@@ -63,7 +57,8 @@ describe Jennifer::View::Base do
   describe "%scope" do
     context "with block" do
       it "executes in query context" do
-        ::Jennifer::Adapter.adapter.sql_generator.select(MaleContact.all.older(18)).should match(/male_contacts.age >/)
+        ::Jennifer::Adapter.default_adapter.sql_generator.select(MaleContact.all.older(18))
+          .should match(/male_contacts.age >/)
       end
 
       context "without arguemnt" do
@@ -95,7 +90,7 @@ describe Jennifer::View::Base do
 
     context "with query object class" do
       it "executes in class context" do
-        ::Jennifer::Adapter.adapter.sql_generator.select(MaleContact.johny).should match(/name =/)
+        ::Jennifer::Adapter.default_adapter.sql_generator.select(MaleContact.johny).should match(/name =/)
       end
 
       context "without arguemnt" do

--- a/src/jennifer/adapter.cr
+++ b/src/jennifer/adapter.cr
@@ -22,49 +22,30 @@ module Jennifer
       point lseg path box polygon line circle
     )
 
-    @@adapter : Base?
+    @@default_adapter : Base?
     @@adapters = {} of String => Base.class
-    @@adapter_class : Base.class | Nil
-
-    def self.exec(*opts)
-      adapter.exec(*opts)
-    end
-
-    def self.scalar(*opts)
-      adapter.scalar(*opts)
-    end
-
-    def self.query(_query, args = [] of DBAny)
-      adapter.query(_query, args) { |rs| yield rs }
-    end
-
-    # Allows to assign newly created adapter and call setup methods with existing adapter
-    private def self.adapter=(value)
-      @@adapter = value
-    end
+    @@default_adapter_class : Base.class | Nil
 
     # Returns adapter instance.
     #
-    # The first call greps all model's table column numbers.
-    def self.adapter
-      @@adapter ||= self.adapter = adapter_class.not_nil!.new(Config.instance)
-    end
-
-    # Returns default adapter.
-    #
-    # NOTE: this is a temporary solution to decouple adapter dependency or query class.
+    # The first call of this method greps all models table column numbers.
     def self.default_adapter
-      adapter
+      @@default_adapter ||= default_adapter_class.not_nil!.new(Config.instance)
     end
 
-    # Returns default adapter class.
-    def self.default_adapter_class
-      adapter_class
+    @[Deprecated("Use .default_adapter instead")]
+    def self.adapter
+      default_adapter
+    end
+
+    @[Deprecated("Use .default_adapter_class instead")]
+    def self.adapter_class
+      default_adapter_class
     end
 
     # Returns adapter class.
-    def self.adapter_class
-      @@adapter_class ||= adapters[Config.adapter]
+    def self.default_adapter_class
+      @@default_adapter_class ||= adapters[Config.adapter]
     rescue e : KeyError
       if Config.adapter.empty?
         raise BaseException.new(

--- a/src/jennifer/migration/base.cr
+++ b/src/jennifer/migration/base.cr
@@ -131,7 +131,9 @@ module Jennifer
       @@with_transaction = true
 
       # Database adapter connection instance.
-      delegate adapter, to: Adapter
+      def adapter
+        Adapter.default_adapter
+      end
 
       # Returns where table with given *table* name exists.
       #

--- a/src/jennifer/model/field_declaration.cr
+++ b/src/jennifer/model/field_declaration.cr
@@ -69,11 +69,6 @@ module Jennifer::Model
             end
 
             # :nodoc:
-            def self.primary_field_type
-              {{value[:parsed_type].id}}
-            end
-
-            # :nodoc:
             def init_primary_field(value : Int)
               {% if primary_auto_incrementable %}
                 raise ::Jennifer::AlreadyInitialized.new(@{{key.id}}, value) if @{{key.id}}

--- a/src/jennifer/view/mapping.cr
+++ b/src/jennifer/view/mapping.cr
@@ -55,11 +55,6 @@ module Jennifer
             def self.primary_field_name
               {{key.stringify}}
             end
-
-            # :nodoc:
-            def self.primary_field_type
-              {{value[:parsed_type].id}}
-            end
           {% end %}
         {% end %}
       end


### PR DESCRIPTION
…Base.primary_field_type

# Release notes

**Model**

* remove `Base::primary_field_type`

**View**

* remove `Base::primary_field_type`

**Adapter**

* deprecate `.adapter` & `.adapter_class`
* remove `.query`, `.exec` & `.scalar`