### PR TITLE
Make migration DSL a bit more consistent

### DIFF
--- a/spec/migration/table_builder/change_table_spec.cr
+++ b/spec/migration/table_builder/change_table_spec.cr
@@ -87,6 +87,62 @@ describe Jennifer::Migration::TableBuilder::ChangeTable do
     end
   end
 
+  describe "#add_reference" do
+    it "creates column based on given field" do
+      table = change_table_expr
+      table.add_reference(:user)
+      table.@new_columns["user_id"].should eq({ :type => :integer, :null => true })
+
+      command = table.@commands[0].as(Jennifer::Migration::TableBuilder::CreateForeignKey)
+      command.from_table.should eq(DEFAULT_TABLE)
+      command.to_table.should eq("users")
+      command.column.should eq("user_id")
+      command.primary_key.should eq("id")
+      command.name.starts_with?("fk_cr_").should be_true
+    end
+
+    describe "polymorphic" do
+      it "adds foreign and polymorphic columns" do
+        table = change_table_expr
+        table.add_reference(:user, options: { :polymorphic => true })
+        table.@new_columns["user_id"].should eq({ :polymorphic => true, :type => :integer, :null => true })
+        table.@new_columns["user_type"].should eq({ :type => :string, :null => true })
+        table.@commands.should be_empty
+      end
+    end
+  end
+
+  describe "#drop_reference" do
+    it do
+      table = change_table_expr
+      table.drop_reference(:user)
+      table.drop_columns.should eq(["user_id"])
+
+      command = table.@commands[0].as(Jennifer::Migration::TableBuilder::DropForeignKey)
+      command.from_table.should eq(DEFAULT_TABLE)
+      command.to_table.should eq("users")
+      command.name.starts_with?("fk_cr_").should be_true
+    end
+
+    describe "polymorphic" do
+      it do
+        table = change_table_expr
+        table.drop_reference(:user, options: { :polymorphic => true })
+        table.drop_columns.should eq(["user_id", "user_type"])
+        table.@commands.should be_empty
+      end
+    end
+  end
+
+  describe "#add_timestamps" do
+    it "creates updated_at and created_at columns" do
+      table = change_table_expr
+      table.add_timestamps
+      table.@new_columns["created_at"].should eq({ :type => :timestamp, :null => false })
+      table.@new_columns["updated_at"].should eq({ :type => :timestamp, :null => false })
+    end
+  end
+
   describe "#add_index" do
     context "with named arguments" do
       it do
@@ -122,6 +178,15 @@ describe Jennifer::Migration::TableBuilder::ChangeTable do
         command.lengths.empty?.should be_true
         command.orders.should eq({ :uuid => :asc, :name => :desc })
       end
+    end
+  end
+
+  describe "#drop_index" do
+    it "creates DropIndex" do
+      table = change_table_expr
+      table.drop_index(:uuid)
+      command = table.@commands[0].as(Jennifer::Migration::TableBuilder::DropIndex)
+      command.@fields.should eq([:uuid])
     end
   end
 

--- a/spec/migration/table_builder/create_table_spec.cr
+++ b/spec/migration/table_builder/create_table_spec.cr
@@ -42,9 +42,23 @@ describe Jennifer::Migration::TableBuilder::CreateTable do
       table = create_table_expr
       table.reference(:user)
       table.fields["user_id"].should eq({ :type => :integer, :null => true })
+
+      command = table.@commands[0].as(Jennifer::Migration::TableBuilder::CreateForeignKey)
+      command.from_table.should eq(DEFAULT_TABLE)
+      command.to_table.should eq("users")
+      command.column.should eq("user_id")
+      command.primary_key.should eq("id")
+      command.name.starts_with?("fk_cr_").should be_true
     end
 
-    pending "adds foreign key" do
+    describe "polymorphic" do
+      it "adds foreign and polymorphic columns" do
+        table = create_table_expr
+        table.reference(:user, options: { :polymorphic => true })
+        table.fields["user_id"].should eq({ :polymorphic => true, :type => :integer, :null => true })
+        table.fields["user_type"].should eq({ :type => :string, :null => true })
+        table.@commands.should be_empty
+      end
     end
   end
 

--- a/src/jennifer/migration/base.cr
+++ b/src/jennifer/migration/base.cr
@@ -426,7 +426,7 @@ module Jennifer
       # # => CREATE INDEX by_branch_desc_party ON accounts(branch_id DESC, party_id ASC, surname)
       # ```
       #
-      # NOTE: MySQL only supports index order from  onwards (earlier versions will raise an exception).
+      # NOTE: MySQL only supports index order from 8.0.1 onwards (earlier versions will raise an exception).
       def add_index(table_name : String | Symbol, fields : Array(Symbol), type : Symbol? = nil, name : String? = nil,
                     lengths : Hash(Symbol, Int32) = {} of Symbol => Int32,
                     orders : Hash(Symbol, Symbol) = {} of Symbol => Symbol)

--- a/src/jennifer/migration/table_builder/base.cr
+++ b/src/jennifer/migration/table_builder/base.cr
@@ -2,18 +2,19 @@ module Jennifer
   module Migration
     module TableBuilder
       abstract class Base
-        # Base allowed types for migration DSL option values
+        # Base allowed types for migration DSL option values.
         alias AllowedTypes = String | Int32 | Int64 | Bool | Float32 | Float64 | JSON::Any | Nil
 
-        # Allowed types for migration DSL + Symbol
+        # Allowed types for migration DSL + Symbol.
         alias EAllowedTypes = AllowedTypes | Symbol
 
-        # Allowed types for migration DSL including array
+        # Allowed types for migration DSL including array of itself.
         alias AAllowedTypes = EAllowedTypes | Array(EAllowedTypes)
 
         # Hash type for options argument
         alias DB_OPTIONS = Hash(Symbol, EAllowedTypes | Array(EAllowedTypes))
 
+        # Default ON UPDATE/ON DELETE for foreign key.
         DEFAULT_ON_EVENT_ACTION = :restrict
 
         delegate schema_processor, table_exists?, index_exists?, column_exists?, to: adapter

--- a/src/jennifer/migration/table_builder/create_table.cr
+++ b/src/jennifer/migration/table_builder/create_table.cr
@@ -28,7 +28,7 @@ module Jennifer
         end
 
         {% for method in Jennifer::Adapter::TYPES %}
-          # Defines new column *name* of type `{{method}}` with given *options*.
+          # Defines new column *name* of type `{{method.id}}` with given *options*.
           #
           # For more details see `ChangeTable#add_column`.
           def {{method.id}}(name : String | Symbol, options = DB_OPTIONS.new)
@@ -42,8 +42,10 @@ module Jennifer
         # *values* argument specified allowed enum values.
         #
         # For more details see `ChangeTable#add_column`
-        def enum(name : String | Symbol, values : Array(String), options : Hash(Symbol, AAllowedTypes) = DB_OPTIONS.new)
-          options = Ifrit.sym_hash_cast(options, AAllowedTypes).merge!({ :values => Ifrit.typed_array_cast(values, EAllowedTypes) })
+        def enum(name : String | Symbol, values : Array(String),
+                 options : Hash(Symbol, AAllowedTypes) = DB_OPTIONS.new)
+          options = Ifrit.sym_hash_cast(options, AAllowedTypes)
+            .merge!({ :values => Ifrit.typed_array_cast(values, EAllowedTypes) })
           @fields[name.to_s] = build_column_options(:enum, options)
           self
         end
@@ -62,7 +64,8 @@ module Jennifer
         # ```
         #
         # Migration above will create PostreSQL enum and a table with column of that type.
-        def field(name : String | Symbol, type : Symbol | String, options : Hash(Symbol, AAllowedTypes) = DB_OPTIONS.new)
+        def field(name : String | Symbol, type : Symbol | String,
+                  options : Hash(Symbol, AAllowedTypes) = DB_OPTIONS.new)
           @fields[name.to_s] = ({ :sql_type => type } of Symbol => AAllowedTypes).merge(options)
           self
         end
@@ -74,7 +77,7 @@ module Jennifer
 
         # Adds a reference.
         #
-        # The reference column is an `integer` by default, the *type` argument can be used to specify a different type.
+        # The reference column is an `integer` by default, *type* argument can be used to specify a different type.
         #
         # If *polymorphic* option is `true` - additional string field `"#{name}_type"` is created and foreign key is
         # not added.
@@ -84,9 +87,7 @@ module Jennifer
         #
         # ```
         # reference :user
-        #
         # reference :order, :bigint
-        #
         # reference :taggable, { :polymorphic => true }
         # ```
         def reference(name, type : Symbol = :integer, options : Hash(Symbol, AAllowedTypes) = DB_OPTIONS.new)
@@ -115,25 +116,9 @@ module Jennifer
         # Defines `created_at` and `updated_at` timestamp fields.
         #
         # Argument *null* sets `:null` option for both fields.
-        def timestamps(null = false)
+        def timestamps(null : Bool = false)
           timestamp(:created_at, { :null => null })
           timestamp(:updated_at, { :null => null })
-        end
-
-        # Adds index.
-        #
-        # This is deprecated signature - please use one with the filed name at the beginning and optional index name.
-        #
-        # For more details see `Migration::Base#add_index`.
-        def index(name : String, fields : Array(Symbol), type : Symbol? = nil,
-                  lengths : Hash(Symbol, Int32) = {} of Symbol => Int32,
-                  orders : Hash(Symbol, Symbol) = {} of Symbol => Symbol)
-          index(fields, type, name, lengths, orders)
-        end
-
-        # ditto
-        def index(name : String, field : Symbol, type : Symbol? = nil, length : Int32? = nil, order : Symbol? = nil)
-          index(field, type, name, length, order)
         end
 
         # Adds index.
@@ -149,7 +134,8 @@ module Jennifer
         # Adds index.
         #
         # For more details see `Migration::Base#add_index`.
-        def index(field : Symbol, type : Symbol? = nil, name : String? = nil, length : Int32? = nil, order : Symbol? = nil)
+        def index(field : Symbol, type : Symbol? = nil, name : String? = nil, length : Int32? = nil,
+                  order : Symbol? = nil)
           orders = order ? {field => order.not_nil!} : {} of Symbol => Symbol
           lengths = length ? {field => length.not_nil!} : {} of Symbol => Int32
           index([field],type, name, lengths, orders)
@@ -159,7 +145,8 @@ module Jennifer
         #
         # For more details see `Migration::Base#add_foreign_key`.
         def foreign_key(to_table : String | Symbol, column = nil, primary_key = nil, name = nil, *,
-                        on_update : Symbol = DEFAULT_ON_EVENT_ACTION, on_delete : Symbol = DEFAULT_ON_EVENT_ACTION)
+                        on_update : Symbol = DEFAULT_ON_EVENT_ACTION,
+                        on_delete : Symbol = DEFAULT_ON_EVENT_ACTION)
           @commands << CreateForeignKey.new(
             @adapter,
             @name,


### PR DESCRIPTION
# Release notes

**Migration**

* add `#add_reference`, `#drop_reference`, `#add_timestamps` to `TableBuilder::CHangeTable`
* `TableBuilder::CHangeTable#drop_index` also accepts single column name
* remove deprecated `TableBuilder::CreateTable#index` overrides