### PR TITLE
Use fully qualified model name references in the models macro 

### DIFF
--- a/src/jennifer/model/base.cr
+++ b/src/jennifer/model/base.cr
@@ -204,7 +204,7 @@ module Jennifer
           {% if !models.empty? %}
             [
               {% for model in models %}
-                {{model.id}},
+                ::{{model.name}},
               {% end %}
             ]
           {% else %}


### PR DESCRIPTION
If you have a `Jennifer::Model::Base` subclass named `Model` or `Record`, Jennifer can't compile with an error like so:

```
In lib/jennifer/src/jennifer/adapter/base.cr:44:24

 44 | models[model.table_name] << model
                   ^---------
Error: undefined method 'table_name' for Jennifer::Record.class (compile-time type is (Jennifer::Model::Base.class | Jennifer::Record.class))
```

The macro producing  `Jennifer::Model::Base.models` is accidentally including `Jennifer::Record` instead of `::Record` in the return value, so the type is now a union which breaks stuff. Instead, `#models` should return `::Record`, which can be accomplished by changing the macro to use a fully qualified name! https://crystal-lang.org/api/0.32.1/Crystal/Macros/TypeNode.html#name:MacroId-instance-method says that the `#name` method on `TypeNode` is fully qualified, and we add `::` to enforce the lookup from the root of the namespaces.
# Release notes

Please fill the corresponding section regarding this pull request notes below instead of modifying `CHANGELOG.md` file. Please remove all redundant sections before posting request.

**Model**

- Prevent compile time error with models named `Model` or `Record`
