### PR TITLE
Fix nested #eager_load with empty intermediate relation

### DIFF
--- a/spec/query_builder/eager_loading_spec.cr
+++ b/spec/query_builder/eager_loading_spec.cr
@@ -68,6 +68,19 @@ describe Jennifer::QueryBuilder::EagerLoading do
       end
     end
 
+    context "with nested relation when intermediate relation is empty" do
+      it do
+        c = Factory.create_contact(name: "contact 1")
+        country = Factory.create_country
+
+        res = Contact.all.eager_load(countries: [:cities]).to_a
+        expect_query_silence do
+          res.size.should eq(1)
+          res[0].countries.size.should eq(0)
+        end
+      end
+    end
+
     context "with nested relation defined as array" do
       it do
         c = Factory.create_contact(name: "contact 1")

--- a/src/jennifer/query_builder/nested_relation_tree.cr
+++ b/src/jennifer/query_builder/nested_relation_tree.cr
@@ -47,6 +47,7 @@ module Jennifer
               context[0] = obj
               models.each_with_index do |model, i|
                 related_context_index = @bucket[i][0]
+                next if context[related_context_index].nil?
                 related_context = context[related_context_index].not_nil!
                 relation = @bucket[i][1]
                 h = build_hash(rs, column_index, model.actual_table_field_count)


### PR DESCRIPTION
# What does this PR do?

Fixes #eager_load with an empty intermediate relation.

# Any background context you want to provide?

Previously #eager_load would only work when the
intermediate relation is not empty.

For example:

```crystal
User.where { _id == some_id }.eager_load(group_memberships: :group)
```

This would work as intended when the `group_memberships`
table has rows for the given user. But fail with `Nil assertion failed`
when it doesn't.

# The patch

This PR adds a spec to simulate this problem and
the one-line fix that seems to resolve it.

The spec suite passes with the patch applied and
the new behavior now matches my expectations in
manual testing.

However, I'm still very new to the jennifer codebase,
please let me know in case I missed any 
undesirable side-effects.
