### PR TITLE
[WIP] Ensure reconnects are performed when connection is lost

### DIFF
--- a/src/jennifer/adapter/transactions.cr
+++ b/src/jennifer/adapter/transactions.cr
@@ -16,11 +16,10 @@ module Jennifer
 
       # Yields new checkout connection.
       def with_manual_connection(&block)
-        conn = db.checkout
-        begin
-          yield conn
-        ensure
-          conn.release
+        db.retry do
+          db.using_connection do |conn|
+            yield conn
+          end
         end
       end
 
@@ -110,13 +109,9 @@ module Jennifer
         if under_transaction?
           yield @locks[fiber_id].transaction
         else
-          conn = db.checkout
-          begin
-            res = yield conn
-          ensure
-            conn.release
-          end
-          res || false
+          with_manual_connection do |conn|
+            yield conn
+          end || false
         end
       end
     end


### PR DESCRIPTION
Hi,

we discovered (and correct me if I'm wrong here) that Jennifer actually does not seem to use the [reconnect facilities](https://github.com/crystal-lang/crystal-db/blob/ed686ad3015f48f8b22cf4fbec80e8c8088ef44b/src/db/pool.cr#L142-L168) of the main Crystal DB shard. 
This pull request therefore replaces the manual connection checkout/releases with calls to the provided APIs that also ensure that reconnects are performed - otherwise the `retry_attempts` flag is actually useless for model and transactional queries.

This PR is still sort of WIP as we are still unsure about how to handle the "cached" transactional connections in the `Transactions` class. Is retrying there even a goal? Would a retry then automatically begin a new transaction?
Therefore, we are open for feedback of any kind on how to improve this further (and maybe also design specs that verify the behavior)!