### PR TITLE
Hoist RECURSIVE keyword to the top of CTE list

### DIFF
--- a/spec/adapter/base_sql_generator_spec.cr
+++ b/spec/adapter/base_sql_generator_spec.cr
@@ -302,10 +302,25 @@ describe Jennifer::Adapter::BaseSQLGenerator do
       end
     end
 
+    describe "multiple recursive" do
+      it do
+        query = Jennifer::Query["contacts"].with("test", Contact.all, true).with("test2", Address.all, true)
+        expected_sql = "WITH RECURSIVE test AS (SELECT contacts.* FROM contacts ) , test2 AS (SELECT addresses.* FROM addresses ) "
+        sb { |s| described_class.with_clause(s, query) }.should eq(expected_sql)
+      end
+    end
+
     context "with multiple expressions" do
       it do
         query = Jennifer::Query["contacts"].with("test", Contact.all).with("test 2", Contact.all)
         expected_sql = "WITH test AS (SELECT contacts.* FROM contacts ) , "\
+          "test 2 AS (SELECT contacts.* FROM contacts ) "
+        sb { |s| described_class.with_clause(s, query) }.should eq(expected_sql)
+      end
+
+      it "hoists the RECURSIVE keyword to the query beginning" do
+        query = Jennifer::Query["contacts"].with("test", Contact.all).with("test 2", Contact.all, true)
+        expected_sql = "WITH RECURSIVE test AS (SELECT contacts.* FROM contacts ) , "\
           "test 2 AS (SELECT contacts.* FROM contacts ) "
         sb { |s| described_class.with_clause(s, query) }.should eq(expected_sql)
       end

--- a/src/jennifer/adapter/base_sql_generator.cr
+++ b/src/jennifer/adapter/base_sql_generator.cr
@@ -256,10 +256,13 @@ module Jennifer
         return unless query._ctes?
 
         io << "WITH "
+        if query._ctes!.any?(&.recursive?)
+          io << "RECURSIVE "
+        end
+
         query._ctes!.each_with_index do |cte, index|
           cte_query = cte.query
           io << ", " if index != 0
-          io << "RECURSIVE " if cte.recursive?
           io << cte.name << " AS ("
           io <<
             if cte_query.is_a?(QueryBuilder::ModelQuery)


### PR DESCRIPTION
# What does this PR do?

This PR fixes an issue in the SQL query builder where multiple recursive CTEs would lead to invalid SQL.
As an example, the following construct
```crystal
Jennifer::Query["contacts"]
  .with("test", Contact.all, false)
  .with("test2", Address.all, true)
```

previously resulted in the following SQL
```sql
WITH test AS (SELECT contacts.* FROM contacts ) , RECURSIVE test2 AS (SELECT addresses.* FROM addresses ) 
```
According to both [PostgreSQL](https://www.postgresql.org/docs/13/queries-with.html) and [MySQL](https://dev.mysql.com/doc/refman/8.0/en/with.html#common-table-expressions-recursive) specs, the `RECURSIVE` keyword has to appear *once* at the top if *any* of the given CTEs uses recursion - the current implementation violates both of those rules.

The valid version would be 
```sql
WITH RECURSIVE test AS (SELECT contacts.* FROM contacts ) , test2 AS (SELECT addresses.* FROM addresses ) 
```

This PR simply checks once before generating the CTEs if there exists one with the `is_recursive` flag being set and - if so - produces the keyword once. The implementation of the fix therefore currently iterates over all CTEs twice which may not seem very elegant. Another possible solution would be to introduce another wrapper class between `Query` and `CommonTableExpression`, where i/o one `Query` having multple `CommonTableExpression` instances, a `Query` could have an optional `CTEContext` (?) which then has a property `is_recursive` and a list of actual `CommonTableExpression` instances (1:1..N). During generation, we could first check if the context property is set and then check its `is_recursive` property respectively. I chose the more simplistic approach first as to gather some feedback.

# Release notes

**SqlGenerator**
* `Jennifer::Adapter::BaseSQLGenerator` now produces valid SQL when using multiple recursive CTEs (`.with(..., true)`) in a single query
