### PR TITLE
Relax CTE query type to allow more flexible query combinations

### DIFF
--- a/spec/query_builder/query_spec.cr
+++ b/spec/query_builder/query_spec.cr
@@ -295,6 +295,22 @@ describe Jennifer::QueryBuilder::Query do
         Jennifer::Query["cte"].with("cte", Jennifer::Query["contacts"]).count.should eq(1)
       end
     end
+
+    describe "varying query types" do
+      it do
+        c1 = Factory.create_contact(name: "Anton", age: 32)
+        Factory.create_contact(name: "Bertha", age: 43)
+        c3 = Factory.create_contact(name: "Caesar", age: 37)
+
+        Factory.create_address(street: "Test street 1", contact_id: c1.id!)
+        Factory.create_address(street: "Test street 2", contact_id: c3.id!)
+
+        Address.all
+          .with("acontacts", Contact.all.where { sql("contacts.name LIKE %s", ["A%"]) }, false)
+          .join("acontacts") { _acontacts__id == _addresses__contact_id }
+          .pluck(:street).should eq ["Test street 1"]
+      end
+    end
   end
 
   describe "#_select_fields" do

--- a/src/jennifer/query_builder/query.cr
+++ b/src/jennifer/query_builder/query.cr
@@ -468,7 +468,7 @@ module Jennifer
       # # WITH RECURSIVE test AS (SELECT users.* FROM users )
       # Jennifer::Query["contacts"].with("test", Jennifer::Query["users"], true)
       # ```
-      def with(name : String | Symbol, query : self, recursive : Bool = false)
+      def with(name : String | Symbol, query : Query, recursive : Bool = false)
         _ctes! << CommonTableExpression.new(name.to_s, query, recursive)
         self
       end


### PR DESCRIPTION
# What does this PR do?

This PR relaxes the type restriction on `Jennifer::QueryBuilder::Query#with` from requiring the `self` type on the corresponding query to using the supertype `Query` itself. Since CTEs often query resources from other tables, it probably makes more sense to allow arbitrary query types for CTEs (e.g. mixing different model queries, model queries and raw queries, etc.).

While the previous type restriction still worked for some of those cases, I experienced weird behaviour that could only be fixed that way.
As an example, while the following query compiled correctly
```crystal
Address.all
  .with("acontacts", Contact.all.where { sql("contacts.name LIKE %s", ["A%"]) })
  .join("acontacts") { _acontacts__id == _addresses__contact_id }
  .pluck(:street).should eq ["Test street 1"]
```

this one (only change is the additional Boolean flag) causes a compilation failure as it does not seem to resolve the method correctly

```crystal
Address.all
  .with("acontacts", Contact.all.where { sql("contacts.name LIKE %s", ["A%"]) }, false)
  .join("acontacts") { _acontacts__id == _addresses__contact_id }
  .pluck(:street).should eq ["Test street 1"]
```

```
In spec/query_builder/query_spec.cr:309:12

 309 | .with("acontacts", Contact.all.where { sql("contacts.name LIKE %s", ["A%"]) }, false)
        ^---
Error: no overload matches 'Jennifer::QueryBuilder::ModelQuery(Address)#with' with types String, Jennifer::QueryBuilder::ModelQuery(Contact), Bool

Overloads are:
 - Jennifer::QueryBuilder::Query#with(name : String | Symbol, query : self, recursive : Bool = false)
```

I'm honestly not sure why that is ... so any clarification or idea would be very welcome ;)
But anyways, I still think that generic `Query`s should be allowed as parameters there.

# Release notes

**QueryBuilder**
* Allow arbitrary `Query` instances as nested queries for CTEs
