### PR TITLE
Feature/add string coercing

### DIFF
--- a/spec/model/authentication_spec.cr
+++ b/spec/model/authentication_spec.cr
@@ -32,6 +32,11 @@ describe Jennifer::Model::Authentication do
       end
 
       describe "#password=" do
+        it "returns raw password when it is acceptable" do
+          user = Factory.build_user
+          (user.password = "asdasdasdasd").should eq("asdasdasdasd")
+        end
+
         it do
           user = Factory.build_user
           user.password = nil
@@ -59,6 +64,7 @@ describe Jennifer::Model::Authentication do
 
       describe "#authenticate" do
         it { Factory.build_user([:with_password_digest]).authenticate("gibberish").should be_nil }
+
         it do
           user = Factory.build_user([:with_password_digest])
           user.authenticate("password").should eq(user)

--- a/spec/model/mapping_spec.cr
+++ b/spec/model/mapping_spec.cr
@@ -745,12 +745,12 @@ describe Jennifer::Model::Mapping do
         postgres_only do
           it "doesn't support PG::Numeric" do
             c = Factory.build_contact
-            expect_raises(Jennifer::BaseException, "Type ::Union(PG::Numeric, ::Nil) can't be coerced") { c.ballance = "32" }
+            expect_raises(Jennifer::BaseException, "Type (PG::Numeric | Nil) can't be coerced") { c.ballance = "32" }
           end
 
           it "doesn't support Array" do
             c = Factory.build_contact(tags: [32])
-            expect_raises(Jennifer::BaseException, "Type ::Union(Array(Int32), ::Nil) can't be coerced") { c.tags = "32" }
+            expect_raises(Jennifer::BaseException, "Type (Array(Int32) | Nil) can't be coerced") { c.tags = "32" }
           end
         end
 

--- a/spec/model/mapping_spec.cr
+++ b/spec/model/mapping_spec.cr
@@ -675,6 +675,11 @@ describe Jennifer::Model::Mapping do
         c.name.should eq("b")
       end
 
+      it "returns given value" do
+        c = Factory.build_contact(name: "a")
+        (c.name = "b").should eq("b")
+      end
+
       context "with DBAny" do
         it do
           hash = { :name => "new_name" } of Symbol => Jennifer::DBAny
@@ -700,6 +705,93 @@ describe Jennifer::Model::Mapping do
               c.name = hash[:age]
             end
           end
+        end
+      end
+
+      context "with stringified value" do
+        it "sets nil for empty value" do
+          c = Factory.build_contact(user_id: 1)
+          c.user_id = ""
+          c.user_id.should be_nil
+        end
+
+        it "raises an error for blank string if field isn't nullable" do
+          c = Factory.build_contact(age: 12)
+          expect_raises(NilAssertionError) { c.age = "" }
+        end
+
+        postgres_only do
+          it "doesn't support PG::Numeric" do
+            c = Factory.build_contact
+            expect_raises(Jennifer::BaseException, "Type ::Union(PG::Numeric, ::Nil) can't be coerced") { c.ballance = "32" }
+          end
+
+          it "doesn't support Array" do
+            c = Factory.build_contact(tags: [32])
+            expect_raises(Jennifer::BaseException, "Type ::Union(Array(Int32), ::Nil) can't be coerced") { c.tags = "32" }
+          end
+        end
+
+        it "supports Int16" do
+          record = AllTypeModel.new
+          record.short_f = "12"
+          record.short_f.should eq(12i16)
+        end
+
+        it "supports Int64" do
+          record = AllTypeModel.new
+          record.bigint_f = "12"
+          record.bigint_f.should eq(12i64)
+        end
+
+        it "supports Int32" do
+          record = AllTypeModel.new
+          record.integer_f = "12"
+          record.integer_f.should eq(12)
+        end
+
+        it "supports Float32" do
+          record = AllTypeModel.new
+          record.float_f = "12"
+          record.float_f.should eq(12.0f32)
+        end
+
+        it "supports Float64" do
+          record = AllTypeModel.new
+          record.double_f = "12"
+          record.double_f.should eq(12.0)
+        end
+
+        it "supports Bool" do
+          record = AllTypeModel.new
+          record.bool_f = "true"
+          record.bool_f.should be_true
+          record.bool_f = "1"
+          record.bool_f.should be_true
+          record.bool_f = "t"
+          record.bool_f.should be_true
+          record.bool_f = "f"
+          record.bool_f.should be_false
+          record.bool_f = "any"
+          record.bool_f.should be_false
+        end
+
+        it "supports JSON" do
+          record = AllTypeModel.new
+          record.json_f = %({"a": 1})
+          record.json_f.should eq(JSON.parse({a: 1}.to_json))
+        end
+
+        it "supports Time (short)" do
+          record = AllTypeModel.new
+          record.timestamp_f = "2010-12-10"
+          record.timestamp_f.should eq(Time.local(2010, 12, 10, 0, 0, 0, location: ::Jennifer::Config.local_time_zone))
+        end
+
+        it "supports Time (long)" do
+          record = AllTypeModel.new
+          record.timestamp_f = "2010-12-10 20:10:10"
+          record.timestamp_f.should eq(Time.local(2010, 12, 10, 20, 10, 10, location: ::Jennifer::Config.local_time_zone))
         end
       end
     end
@@ -803,7 +895,7 @@ describe Jennifer::Model::Mapping do
         end
       end
 
-      context "attribute exists" do
+      context "when attribute exists" do
         it "sets attribute if value has proper type" do
           c = Factory.build_contact
           c.set_attribute(:name, "123")
@@ -821,6 +913,12 @@ describe Jennifer::Model::Mapping do
           c = Factory.build_contact
           c.set_attribute(:name, "asd")
           c.name_changed?.should be_true
+        end
+
+        it "supports string coercing" do
+          c = Factory.build_contact
+          c.set_attribute(:user_id, "12")
+          c.user_id.should eq(12)
         end
       end
 

--- a/spec/model/mapping_spec.cr
+++ b/spec/model/mapping_spec.cr
@@ -248,6 +248,28 @@ describe Jennifer::Model::Mapping do
       end
 
       context "from hash" do
+        context "with string values for non-string properties" do
+          it "coerces types" do
+            record = AllTypeModel.new({
+              "bool_f" => "true",
+              "bigint_f" => "12",
+              "integer_f" => "13",
+              "short_f" => "14",
+              "float_f" => "12.0",
+              "double_f" => "15.0",
+              "timestamp_f" => "2010-12-10 20:10:10"
+            })
+
+            record.bool_f.should be_true
+            record.bigint_f.should eq(12i64)
+            record.integer_f.should eq(13)
+            record.short_f.should eq(14i16)
+            record.float_f.should eq(12.0f32)
+            record.double_f.should eq(15.0)
+            record.timestamp_f.should eq(Time.local(2010, 12, 10, 20, 10, 10, location: ::Jennifer::Config.local_time_zone))
+          end
+        end
+
         context "with string keys" do
           it "properly creates object" do
             contact = Contact.new({"name" => "Deepthi", "age" => 18, "gender" => "female"})
@@ -257,7 +279,7 @@ describe Jennifer::Model::Mapping do
           end
 
           it "properly maps column aliases" do
-            a = Author.new({"name1" => "Gener", "name2" => "Ric"})
+            a = Author.new({ "name1" => "Gener", "name2" => "Ric" })
             a.name1.should eq("Gener")
             a.name2.should eq("Ric")
           end

--- a/src/jennifer/model/authentication.cr
+++ b/src/jennifer/model/authentication.cr
@@ -38,6 +38,7 @@ module Jennifer
               unencrypted_password,
               cost: self.class.{{password_hash.id}}_cost
             ).to_s
+            unencrypted_password
           end
         end
 

--- a/src/jennifer/model/base.cr
+++ b/src/jennifer/model/base.cr
@@ -8,6 +8,7 @@ require "./mapping"
 require "./sti_mapping"
 require "./validation"
 require "./callback"
+require "./coercer"
 require "./enum_converter"
 require "./json_converter"
 require "./json_serializable_converter"
@@ -45,6 +46,8 @@ module Jennifer
         #
         # The metadata is a result of processing attributes passed to `.mapping` macro.
         abstract def columns_tuple
+
+        abstract def coercer
       end
 
       extend AbstractClassMethods
@@ -226,6 +229,10 @@ module Jennifer
       # Alias for `.new`.
       def self.build(pull : DB::ResultSet)
         new(pull)
+      end
+
+      def self.coercer
+        Coercer
       end
 
       # Sets *name* field with *value*

--- a/src/jennifer/model/coercer.cr
+++ b/src/jennifer/model/coercer.cr
@@ -3,49 +3,69 @@ module Jennifer::Model
     DATE_TIME_FORMAT = "%F %T"
     DATE_FORMAT = "%F"
 
-    def self.to_s(value : String)
-      value
+    def self.coerce(value : String, type : (Int8?).class)
+      return nil if value.empty?
+
+      value.to_i8
     end
 
-    def self.to_pr64(value : String)
-      to_i64(value)
-    end
+    def self.coerce(value : String, type : (Int16?).class)
+      return nil if value.empty?
 
-    def self.to_s(value : String)
-      value
-    end
-
-    def self.to_i16(value : String)
       value.to_i16
     end
 
-    def self.to_i64(value : String)
-      value.to_i64
-    end
+    def self.coerce(value : String, type : (Int32?).class)
+      return nil if value.empty?
 
-    def self.to_i(value : String)
       value.to_i
     end
 
-    def self.to_f(value : String)
-      value.to_f
+    def self.coerce(value : String, type : (Int64?).class)
+      return nil if value.empty?
+
+      value.to_i64
     end
 
-    def self.to_f32(value : String)
+    def self.coerce(value : String, type : (String?).class)
+      return nil if value.empty?
+
+      value
+    end
+
+    def self.coerce(value : String, type : (Float32?).class)
+      return nil if value.empty?
+
       value.to_f32
     end
 
-    def self.to_bool(value : String)
+    def self.coerce(value : String, type : (Float64?).class)
+      return nil if value.empty?
+
+      value.to_f
+    end
+
+    def self.coerce(value : String, type : (Bool?).class)
+      return nil if value.empty?
+
       value == "true" || value == "1" || value == "t"
     end
 
-    def self.to_json(value : String)
+    def self.coerce(value : String, type : (JSON::Any?).class)
+      return nil if value.empty?
+
       JSON.parse(value)
     end
 
-    def self.to_time(value : String)
+    def self.coerce(value : String, type : (Time?).class)
+      return nil if value.empty?
+
       format = value =~ / / ? DATE_TIME_FORMAT : DATE_FORMAT
       Time.parse(value, format, Config.local_time_zone)
+    end
+
+    def self.coerce(value : String, type)
+      raise ::Jennifer::BaseException.new("Type #{type} can't be coerced")
     end
   end
 end

--- a/src/jennifer/model/coercer.cr
+++ b/src/jennifer/model/coercer.cr
@@ -3,8 +3,8 @@ module Jennifer::Model
     DATE_TIME_FORMAT = "%F %T"
     DATE_FORMAT = "%F"
 
-    def self.to_pr32(value : String)
-      to_i(value)
+    def self.to_s(value : String)
+      value
     end
 
     def self.to_pr64(value : String)

--- a/src/jennifer/model/coercer.cr
+++ b/src/jennifer/model/coercer.cr
@@ -1,0 +1,51 @@
+module Jennifer::Model
+  module Coercer
+    DATE_TIME_FORMAT = "%F %T"
+    DATE_FORMAT = "%F"
+
+    def self.to_pr32(value : String)
+      to_i(value)
+    end
+
+    def self.to_pr64(value : String)
+      to_i64(value)
+    end
+
+    def self.to_s(value : String)
+      value
+    end
+
+    def self.to_i16(value : String)
+      value.to_i16
+    end
+
+    def self.to_i64(value : String)
+      value.to_i64
+    end
+
+    def self.to_i(value : String)
+      value.to_i
+    end
+
+    def self.to_f(value : String)
+      value.to_f
+    end
+
+    def self.to_f32(value : String)
+      value.to_f32
+    end
+
+    def self.to_bool(value : String)
+      value == "true" || value == "1" || value == "t"
+    end
+
+    def self.to_json(value : String)
+      JSON.parse(value)
+    end
+
+    def self.to_time(value : String)
+      format = value =~ / / ? DATE_TIME_FORMAT : DATE_FORMAT
+      Time.parse(value, format, Config.local_time_zone)
+    end
+  end
+end

--- a/src/jennifer/model/field_declaration.cr
+++ b/src/jennifer/model/field_declaration.cr
@@ -8,6 +8,43 @@ module Jennifer::Model
         @[JSON::Field(ignore: true)]
         @{{key.id}}_changed = false
 
+        {% unless value[:parsed_type] =~ /String/ %}
+          # :nodoc:
+          def self.coerce_{{key.id}}(_{{key.id}} : String)
+            return nil{% if !value[:null] %}.not_nil! {% end %} if _{{key.id}}.empty?
+
+            {%
+              method =
+                if value[:parsed_type] =~ /Array/
+                  "not_supported"
+                elsif value[:parsed_type] =~ /Int16/
+                  "to_i16"
+                elsif value[:parsed_type] =~ /Int64/
+                  "to_i64"
+                elsif value[:parsed_type] =~ /Int/
+                  "to_i"
+                elsif value[:parsed_type] =~ /Float32/
+                  "to_f32"
+                elsif value[:parsed_type] =~ /Float/
+                  "to_f"
+                elsif value[:parsed_type] =~ /Bool/
+                  "to_bool"
+                elsif value[:parsed_type] =~ /JSON/
+                  "to_json"
+                elsif value[:parsed_type] =~ /Time/
+                  "to_time"
+                else
+                  "not_supported"
+                end
+            %}
+            {% if method == "not_supported" %}
+              raise ::Jennifer::BaseException.new("Type {{value[:parsed_type].id}} can't be coerced")
+            {% else %}
+              coercer.{{method.id}}(_{{key.id}})
+            {% end %}
+          end
+        {% end %}
+
         {% if value[:setter] != false %}
           def {{key.id}}=(_{{key.id}} : {{value[:parsed_type].id}})
             {% if !value[:virtual] %}
@@ -22,37 +59,7 @@ module Jennifer::Model
 
           {% unless value[:parsed_type] =~ /String/ %}
             def {{key.id}}=(_{{key.id}} : String)
-              return self.{{key.id}} = nil{% if !value[:null] %}.not_nil! {% end %} if _{{key.id}}.empty?
-
-              {%
-                method =
-                  if value[:parsed_type] =~ /Array/
-                    "not_supported"
-                  elsif value[:parsed_type] =~ /Int16/
-                    "to_i16"
-                  elsif value[:parsed_type] =~ /Int64/
-                    "to_i64"
-                  elsif value[:parsed_type] =~ /Int/
-                    "to_i"
-                  elsif value[:parsed_type] =~ /Float32/
-                    "to_f32"
-                  elsif value[:parsed_type] =~ /Float/
-                    "to_f"
-                  elsif value[:parsed_type] =~ /Bool/
-                    "to_bool"
-                  elsif value[:parsed_type] =~ /JSON/
-                    "to_json"
-                  elsif value[:parsed_type] =~ /Time/
-                    "to_time"
-                  else
-                    "not_supported"
-                  end
-              %}
-              {% if method == "not_supported" %}
-                raise ::Jennifer::BaseException.new("Type {{value[:parsed_type].id}} can't be coerced")
-              {% else %}
-                self.{{key.id}} = self.class.coercer.{{method.id}}(_{{key.id}})
-              {% end %}
+              self.{{key.id}} = self.class.coerce_{{key.id}}(_{{key.id}})
             end
           {% end %}
         {% end %}

--- a/src/jennifer/model/field_declaration.cr
+++ b/src/jennifer/model/field_declaration.cr
@@ -8,42 +8,12 @@ module Jennifer::Model
         @[JSON::Field(ignore: true)]
         @{{key.id}}_changed = false
 
-        {% unless value[:parsed_type] =~ /String/ %}
-          # :nodoc:
-          def self.coerce_{{key.id}}(_{{key.id}} : String)
-            return nil{% if !value[:null] %}.not_nil! {% end %} if _{{key.id}}.empty?
-
-            {%
-              method =
-                if value[:parsed_type] =~ /Array/
-                  "not_supported"
-                elsif value[:parsed_type] =~ /Int16/
-                  "to_i16"
-                elsif value[:parsed_type] =~ /Int64/
-                  "to_i64"
-                elsif value[:parsed_type] =~ /Int/
-                  "to_i"
-                elsif value[:parsed_type] =~ /Float32/
-                  "to_f32"
-                elsif value[:parsed_type] =~ /Float/
-                  "to_f"
-                elsif value[:parsed_type] =~ /Bool/
-                  "to_bool"
-                elsif value[:parsed_type] =~ /JSON/
-                  "to_json"
-                elsif value[:parsed_type] =~ /Time/
-                  "to_time"
-                else
-                  "not_supported"
-                end
-            %}
-            {% if method == "not_supported" %}
-              raise ::Jennifer::BaseException.new("Type {{value[:parsed_type].id}} can't be coerced")
-            {% else %}
-              coercer.{{method.id}}(_{{key.id}})
-            {% end %}
-          end
-        {% end %}
+        # :nodoc:
+        def self.coerce_{{key.id}}(_{{key.id}} : String)
+          coercer
+            .coerce(_{{key.id}}, {{value[:parsed_type].id}})
+            {% if !value[:null] %}.not_nil!{% end %}
+        end
 
         {% if value[:setter] != false %}
           def {{key.id}}=(_{{key.id}} : {{value[:parsed_type].id}})

--- a/src/jennifer/model/mapping.cr
+++ b/src/jennifer/model/mapping.cr
@@ -334,8 +334,8 @@ module Jennifer
           {% for key, value in properties %}
             {% if value[:setter] != false %}
               when "{{key.id}}"
-                if value.is_a?({{value[:parsed_type].id}})
-                  self.{{key.id}} = value.as({{value[:parsed_type].id}})
+                if value.is_a?({{value[:parsed_type].id}}) || value.is_a?(String)
+                  self.{{key.id}} = value
                 else
                   raise ::Jennifer::BaseException.new("wrong type for #{name} : #{value.class}")
                 end

--- a/src/jennifer/model/mapping.cr
+++ b/src/jennifer/model/mapping.cr
@@ -442,10 +442,6 @@ module Jennifer
         private def _extract_attributes(values : Hash(String, AttrType))
           {% for key, value in properties %}
             %var{key.id} = {{value[:default]}}
-            %found{key.id} = true
-          {% end %}
-
-          {% for key, value in properties %}
             {% column1 = key.id.stringify %}
             {% column2 = value[:column] %}
             if values.has_key?({{column1}})
@@ -462,19 +458,18 @@ module Jennifer
                 {% else %}
                   values[{{column2}}]
                 {% end %}
-            else
-              %found{key.id} = false
             end
           {% end %}
 
           {% for key, value in properties %}
             begin
               %casted_var{key.id} =
-                {% if value[:default] != nil %}
-                  %found{key.id} ? %var{key.id}.as({{value[:parsed_type].id}}) : {{value[:default]}}
+                {% if value[:parsed_type] =~ /String/ %}
+                  %var{key.id}
                 {% else %}
-                  %var{key.id}.as({{value[:parsed_type].id}})
+                  (%var{key.id}.is_a?(String) ? self.class.coerce_{{key.id}}(%var{key.id}) : %var{key.id})
                 {% end %}
+                .as({{value[:parsed_type].id}})
             rescue e : Exception
               raise ::Jennifer::DataTypeCasting.match?(e) ? ::Jennifer::DataTypeCasting.new({{key.id.stringify}}, {{@type}}, e) : e
             end

--- a/src/jennifer/model/sti_mapping.cr
+++ b/src/jennifer/model/sti_mapping.cr
@@ -275,8 +275,8 @@ module Jennifer
           {% for key, value in properties %}
             {% if value[:setter] != false %}
               when "{{key.id}}"
-                if value.is_a?({{value[:parsed_type].id}})
-                  self.{{key.id}} = value.as({{value[:parsed_type].id}})
+                if value.is_a?({{value[:parsed_type].id}}) || value.is_a?(String)
+                  self.{{key.id}} = value
                 else
                   raise ::Jennifer::BaseException.new("Wrong type for #{name} : #{value.class}")
                 end


### PR DESCRIPTION
# What does this PR do?

Add string coercing to expected data type to simplify integration into web ecosystem

# Release notes

**Model**

* `Authentication#password` returns given unecrypted value
* add `Coercer` module with static methods to localize all coercing logic for different types
* add `.coercer` method to return object responding to all coercing methods described in `Coercer`
* `mapping` generates `.coerce_{{attribute}(value : String)` methods for every field to coerce string value to `attribute`'s type
* `mapping` generates for every non-string attribute with a setter additional `#{{attribute}}=(value : String)` setter
* allow all build methods (`.new`, `.create` and `.update`) to receive `Hash(String, String)` and coerce values to expected types