### PR TITLE
Add crystal 0.36.1 support

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,6 +14,8 @@ Please fill the corresponding section regarding this pull request notes below in
 
 **Validation**
 
+**Relation**
+
 **View**
 
 **Adapter**

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ dependencies:
 ### Requirements
 
 - you need to choose one of the existing drivers for your DB: [mysql](https://github.com/crystal-lang/crystal-mysql) or [postgres](https://github.com/will/crystal-pg); sqlite3 adapter automatically installs required driver for it;
-- crystal `>= 0.35.0`.
+- crystal `>= 0.36.0`.
 
 ## Usage
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -310,7 +310,7 @@ This passes the record to a new instance of given validator class to be validate
 
 ```crystal
 class EnnValidator < Jennifer::Validations::Validator
-  def validate(record : Passport)
+  def validate(record, **opts)
     if record.enn!.size < 4 && record.enn![0].downcase == 'a'
       record.errors.add(:enn, "Invalid enn")
     end

--- a/shard.yml
+++ b/shard.yml
@@ -4,7 +4,7 @@ version: 0.10.0
 authors:
   - Roman Kalnytskyi <moranibaca@gmail.com>
 
-crystal: 0.35.1
+crystal: 0.36.1
 
 license: MIT
 
@@ -23,7 +23,7 @@ development_dependencies:
     version: "~> 0.3.0"
   ameba:
     github: crystal-ameba/ameba
-    version: "= 0.13.2"
+    version: "= 0.13.4"
   # TODO: add back after they add support of latest pg
   # micrate:
   #   github: "amberframework/micrate"

--- a/spec/model/relation_definition_spec.cr
+++ b/spec/model/relation_definition_spec.cr
@@ -180,13 +180,7 @@ module Jennifer::Model
 
       context "query" do
         it "sets correct query part" do
-          Contact.relation("addresses").condition_clause.as_sql.should eq("addresses.contact_id = contacts.id")
-        end
-
-        context "when declaration has additional block" do
-          it "sets correct query part" do
-            Contact.relation("main_address").condition_clause.as_sql.should match(/addresses\.contact_id = contacts\.id AND addresses\.main/)
-          end
+          Contact.relation("addresses").as(Jennifer::Relation::HasMany).condition_clause.as_sql.should eq("addresses.contact_id = contacts.id")
         end
       end
 
@@ -309,7 +303,7 @@ module Jennifer::Model
       end
 
       describe "polymorphic" do
-        relation = FacebookProfileWithDestroyNotable.relation("notes")
+        relation = FacebookProfileWithDestroyNotable.relation("notes").as(Jennifer::Relation::PolymorphicHasMany)
 
         describe "query" do
           it "sets correct query part" do
@@ -344,14 +338,15 @@ module Jennifer::Model
         Address::RELATIONS.has_key?("contact").should be_true
       end
 
-      context "query" do
+      describe "query" do
         it "sets correct query part" do
-          Address.relation("contact").condition_clause.as_sql.should eq("contacts.id = addresses.contact_id")
+          Address.relation("contact").as(Jennifer::Relation::BelongsTo).condition_clause.as_sql
+            .should eq("contacts.id = addresses.contact_id")
         end
 
         context "when declaration has additional block" do
           it "sets correct query part" do
-            query = JohnPassport.relation("contact").condition_clause
+            query = JohnPassport.relation("contact").as(Jennifer::Relation::BelongsTo).condition_clause
             query.as_sql.should match(/contacts\.id = passports\.contact_id AND contacts\.name = %s/)
             query.sql_args.should eq(db_array("John"))
           end
@@ -538,15 +533,16 @@ module Jennifer::Model
         Contact::RELATIONS.has_key?("addresses").should be_true
       end
 
-      context "query" do
+      describe "query" do
         it "sets correct query part" do
-          Contact.relation("passport").condition_clause.as_sql.should eq("passports.contact_id = contacts.id")
+          Contact.relation("passport").as(Jennifer::Relation::HasOne).condition_clause.as_sql
+            .should eq("passports.contact_id = contacts.id")
         end
 
         context "when declaration has additional block" do
           it "sets correct query part" do
             sql_reg = /addresses\.contact_id = contacts\.id AND addresses\.main/
-            Contact.relation("main_address").condition_clause.as_sql.should match(sql_reg)
+            Contact.relation("main_address").as(Jennifer::Relation::HasOne).condition_clause.as_sql.should match(sql_reg)
           end
         end
       end
@@ -636,7 +632,7 @@ module Jennifer::Model
       end
 
       describe "polymorphic" do
-        relation = ProfileWithOneNote.relation("note")
+        relation = ProfileWithOneNote.relation("note").as(Jennifer::Relation::PolymorphicHasOne)
 
         describe "query" do
           it "sets correct query part" do
@@ -665,9 +661,9 @@ module Jennifer::Model
     end
 
     describe "%has_and_belongs_many" do
-      context "query" do
+      describe "query" do
         it "sets correct query part" do
-          query = ContactWithDependencies.relation("u_countries")
+          query = ContactWithDependencies.relation("u_countries").as(Jennifer::Relation::ManyToMany)
           query.condition_clause.as_sql.should eq("countries.contact_id = contacts.id AND countries.name LIKE %s")
           query.condition_clause.sql_args.should eq(db_array("U%"))
         end

--- a/spec/model/validation_spec.cr
+++ b/spec/model/validation_spec.cr
@@ -72,9 +72,11 @@ class PresenceContact < ApplicationRecord
 end
 
 class ValidatorWithOptions < Jennifer::Validations::Validator
-  def validate(record, field, message = nil)
+  def validate(record, **opts)
+    field = opts[:field]
+
     if record.attribute(field) == "invalid"
-      record.errors.add(field, message || "blank")
+      record.errors.add(field, opts[:message]? || "blank")
     end
   end
 end

--- a/spec/models.cr
+++ b/spec/models.cr
@@ -20,7 +20,7 @@ class WithOwnArguments < Jennifer::QueryBuilder::QueryObject
 end
 
 class EnnValidator < Jennifer::Validations::Validator
-  def validate(record : Passport, **opts)
+  def validate(record, **opts)
     if record.enn!.size < 4 && record.enn![0].downcase == 'a'
       record.errors.add(:enn, "Invalid enn")
     end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -74,7 +74,13 @@ BERLIN = Time::Location.load("Europe/Berlin")
 
 macro validated_by_record(type, value, field = :age, allow_blank = true)
   Factory.build_contact.tap do |record|
-    described_class.instance.validate(record, {{field}}, {{value}}, {{allow_blank}}, **{{type}})
+    described_class.instance.validate(
+      record,
+      field: {{field}},
+      value: {{value}},
+      allow_blank: {{allow_blank}},
+      {{type.stringify[1...-1].id}}
+    )
   end
 end
 

--- a/spec/validations/numericality_spec.cr
+++ b/spec/validations/numericality_spec.cr
@@ -5,215 +5,216 @@ describe Jennifer::Validations::Numericality do
   described_class = Jennifer::Validations::Numericality
 
   describe "#validate" do
+    {% begin %}
     describe "greater_than" do
-      definition = {greater_than: 12}
+      {% definition = {greater_than: 12} %}
 
       describe "Int32" do
-        it { validated_by_record(definition, 13).should_not be_invalid }
-        it { validated_by_record(definition, 12).should be_invalid }
+        it { validated_by_record({{definition}}, 13).should_not be_invalid }
+        it { validated_by_record({{definition}}, 12).should be_invalid }
       end
 
       describe "Int16" do
-        it { validated_by_record(definition, 13i64).should_not be_invalid }
-        it { validated_by_record(definition, 12i64).should be_invalid }
+        it { validated_by_record({{definition}}, 13i64).should_not be_invalid }
+        it { validated_by_record({{definition}}, 12i64).should be_invalid }
       end
 
       describe "Float64" do
-        it { validated_by_record(definition, 13.0).should_not be_invalid }
-        it { validated_by_record(definition, 12.0).should be_invalid }
+        it { validated_by_record({{definition}}, 13.0).should_not be_invalid }
+        it { validated_by_record({{definition}}, 12.0).should be_invalid }
       end
 
       describe "Float32" do
-        it { validated_by_record(definition, 13.0f32).should_not be_invalid }
-        it { validated_by_record(definition, 12.0f32).should be_invalid }
+        it { validated_by_record({{definition}}, 13.0f32).should_not be_invalid }
+        it { validated_by_record({{definition}}, 12.0f32).should be_invalid }
       end
 
       describe "Nil" do
-        it { validated_by_record(definition, nil).should_not be_invalid }
+        it { validated_by_record({{definition}}, nil).should_not be_invalid }
       end
     end
 
     describe "greater_than_or_equal_to" do
-      definition = {greater_than_or_equal_to: 12}
+      {% definition = {greater_than_or_equal_to: 12} %}
 
       describe "Int32" do
-        it { validated_by_record(definition, 12).should_not be_invalid }
-        it { validated_by_record(definition, 11).should be_invalid }
+        it { validated_by_record({{definition}}, 12).should_not be_invalid }
+        it { validated_by_record({{definition}}, 11).should be_invalid }
       end
 
       describe "Int16" do
-        it { validated_by_record(definition, 12i64).should_not be_invalid }
-        it { validated_by_record(definition, 11i64).should be_invalid }
+        it { validated_by_record({{definition}}, 12i64).should_not be_invalid }
+        it { validated_by_record({{definition}}, 11i64).should be_invalid }
       end
 
       describe "Float64" do
-        it { validated_by_record(definition, 12.0).should_not be_invalid }
-        it { validated_by_record(definition, 11.0).should be_invalid }
+        it { validated_by_record({{definition}}, 12.0).should_not be_invalid }
+        it { validated_by_record({{definition}}, 11.0).should be_invalid }
       end
 
       describe "Float32" do
-        it { validated_by_record(definition, 12.0f32).should_not be_invalid }
-        it { validated_by_record(definition, 11.0f32).should be_invalid }
+        it { validated_by_record({{definition}}, 12.0f32).should_not be_invalid }
+        it { validated_by_record({{definition}}, 11.0f32).should be_invalid }
       end
 
       describe "Nil" do
-        it { validated_by_record(definition, nil).should_not be_invalid }
+        it { validated_by_record({{definition}}, nil).should_not be_invalid }
       end
     end
 
     describe "equal_to" do
-      definition = {equal_to: 12}
+      {% definition = {equal_to: 12} %}
 
       describe "Int32" do
-        it { validated_by_record(definition, 12).should_not be_invalid }
-        it { validated_by_record(definition, 11).should be_invalid }
-        it { validated_by_record(definition, 13).should be_invalid }
+        it { validated_by_record({{definition}}, 12).should_not be_invalid }
+        it { validated_by_record({{definition}}, 11).should be_invalid }
+        it { validated_by_record({{definition}}, 13).should be_invalid }
       end
 
       describe "Int16" do
-        it { validated_by_record(definition, 12i64).should_not be_invalid }
-        it { validated_by_record(definition, 11i64).should be_invalid }
-        it { validated_by_record(definition, 13i64).should be_invalid }
+        it { validated_by_record({{definition}}, 12i64).should_not be_invalid }
+        it { validated_by_record({{definition}}, 11i64).should be_invalid }
+        it { validated_by_record({{definition}}, 13i64).should be_invalid }
       end
 
       describe "Float64" do
-        it { validated_by_record(definition, 12.0).should_not be_invalid }
-        it { validated_by_record(definition, 11.0).should be_invalid }
-        it { validated_by_record(definition, 13.0).should be_invalid }
+        it { validated_by_record({{definition}}, 12.0).should_not be_invalid }
+        it { validated_by_record({{definition}}, 11.0).should be_invalid }
+        it { validated_by_record({{definition}}, 13.0).should be_invalid }
       end
 
       describe "Float32" do
-        it { validated_by_record(definition, 12.0f32).should_not be_invalid }
-        it { validated_by_record(definition, 11.0f32).should be_invalid }
-        it { validated_by_record(definition, 13.0f32).should be_invalid }
+        it { validated_by_record({{definition}}, 12.0f32).should_not be_invalid }
+        it { validated_by_record({{definition}}, 11.0f32).should be_invalid }
+        it { validated_by_record({{definition}}, 13.0f32).should be_invalid }
       end
 
       describe "Nil" do
-        it { validated_by_record(definition, nil).should_not be_invalid }
+        it { validated_by_record({{definition}}, nil).should_not be_invalid }
       end
     end
 
     describe "other_than" do
-      definition = {other_than: 12}
+      {% definition = {other_than: 12} %}
 
       describe "Int32" do
-        it { validated_by_record(definition, 12).should be_invalid }
-        it { validated_by_record(definition, 11).should_not be_invalid }
-        it { validated_by_record(definition, 13).should_not be_invalid }
+        it { validated_by_record({{definition}}, 12).should be_invalid }
+        it { validated_by_record({{definition}}, 11).should_not be_invalid }
+        it { validated_by_record({{definition}}, 13).should_not be_invalid }
       end
 
       describe "Int16" do
-        it { validated_by_record(definition, 12i64).should be_invalid }
-        it { validated_by_record(definition, 11i64).should_not be_invalid }
-        it { validated_by_record(definition, 13i64).should_not be_invalid }
+        it { validated_by_record({{definition}}, 12i64).should be_invalid }
+        it { validated_by_record({{definition}}, 11i64).should_not be_invalid }
+        it { validated_by_record({{definition}}, 13i64).should_not be_invalid }
       end
 
       describe "Float64" do
-        it { validated_by_record(definition, 12.0).should be_invalid }
-        it { validated_by_record(definition, 11.0).should_not be_invalid }
-        it { validated_by_record(definition, 13.0).should_not be_invalid }
+        it { validated_by_record({{definition}}, 12.0).should be_invalid }
+        it { validated_by_record({{definition}}, 11.0).should_not be_invalid }
+        it { validated_by_record({{definition}}, 13.0).should_not be_invalid }
       end
 
       describe "Float32" do
-        it { validated_by_record(definition, 12.0f32).should be_invalid }
-        it { validated_by_record(definition, 11.0f32).should_not be_invalid }
-        it { validated_by_record(definition, 13.0f32).should_not be_invalid }
+        it { validated_by_record({{definition}}, 12.0f32).should be_invalid }
+        it { validated_by_record({{definition}}, 11.0f32).should_not be_invalid }
+        it { validated_by_record({{definition}}, 13.0f32).should_not be_invalid }
       end
 
       describe "Nil" do
-        it { validated_by_record(definition, nil).should_not be_invalid }
+        it { validated_by_record({{definition}}, nil).should_not be_invalid }
       end
     end
 
     describe "less_than" do
-      definition = {less_than: 12}
+      {% definition = {less_than: 12} %}
 
       describe "Int32" do
-        it { validated_by_record(definition, 11).should_not be_invalid }
-        it { validated_by_record(definition, 12).should be_invalid }
+        it { validated_by_record({{definition}}, 11).should_not be_invalid }
+        it { validated_by_record({{definition}}, 12).should be_invalid }
       end
 
       describe "Int16" do
-        it { validated_by_record(definition, 11i64).should_not be_invalid }
-        it { validated_by_record(definition, 12i64).should be_invalid }
+        it { validated_by_record({{definition}}, 11i64).should_not be_invalid }
+        it { validated_by_record({{definition}}, 12i64).should be_invalid }
       end
 
       describe "Float64" do
-        it { validated_by_record(definition, 11.0).should_not be_invalid }
-        it { validated_by_record(definition, 12.0).should be_invalid }
+        it { validated_by_record({{definition}}, 11.0).should_not be_invalid }
+        it { validated_by_record({{definition}}, 12.0).should be_invalid }
       end
 
       describe "Float32" do
-        it { validated_by_record(definition, 11.0f32).should_not be_invalid }
-        it { validated_by_record(definition, 12.0f32).should be_invalid }
+        it { validated_by_record({{definition}}, 11.0f32).should_not be_invalid }
+        it { validated_by_record({{definition}}, 12.0f32).should be_invalid }
       end
 
       describe "Nil" do
-        it { validated_by_record(definition, nil).should_not be_invalid }
+        it { validated_by_record({{definition}}, nil).should_not be_invalid }
       end
     end
 
     describe "less_than_or_equal_to" do
-      definition = {less_than_or_equal_to: 12}
+      {% definition = {less_than_or_equal_to: 12} %}
 
       describe "Int32" do
-        it { validated_by_record(definition, 12).should_not be_invalid }
-        it { validated_by_record(definition, 13).should be_invalid }
+        it { validated_by_record({{definition}}, 12).should_not be_invalid }
+        it { validated_by_record({{definition}}, 13).should be_invalid }
       end
 
       describe "Int16" do
-        it { validated_by_record(definition, 12i64).should_not be_invalid }
-        it { validated_by_record(definition, 13i64).should be_invalid }
+        it { validated_by_record({{definition}}, 12i64).should_not be_invalid }
+        it { validated_by_record({{definition}}, 13i64).should be_invalid }
       end
 
       describe "Float64" do
-        it { validated_by_record(definition, 12.0).should_not be_invalid }
-        it { validated_by_record(definition, 13.0).should be_invalid }
+        it { validated_by_record({{definition}}, 12.0).should_not be_invalid }
+        it { validated_by_record({{definition}}, 13.0).should be_invalid }
       end
 
       describe "Float32" do
-        it { validated_by_record(definition, 12.0f32).should_not be_invalid }
-        it { validated_by_record(definition, 13.0f32).should be_invalid }
+        it { validated_by_record({{definition}}, 12.0f32).should_not be_invalid }
+        it { validated_by_record({{definition}}, 13.0f32).should be_invalid }
       end
 
       describe "Nil" do
-        it { validated_by_record(definition, nil).should_not be_invalid }
+        it { validated_by_record({{definition}}, nil).should_not be_invalid }
       end
     end
 
     describe "odd" do
-      definition = {odd: true}
+      {% definition = {odd: true} %}
 
       describe "Int32" do
-        it { validated_by_record(definition, 13).should_not be_invalid }
-        it { validated_by_record(definition, 14).should be_invalid }
+        it { validated_by_record({{definition}}, 13).should_not be_invalid }
+        it { validated_by_record({{definition}}, 14).should be_invalid }
       end
 
       describe "Int16" do
-        it { validated_by_record(definition, 13i64).should_not be_invalid }
-        it { validated_by_record(definition, 14i64).should be_invalid }
+        it { validated_by_record({{definition}}, 13i64).should_not be_invalid }
+        it { validated_by_record({{definition}}, 14i64).should be_invalid }
       end
 
       describe "Float64" do
-        it { validated_by_record(definition, 13.0).should_not be_invalid }
-        it { validated_by_record(definition, 14.0).should be_invalid }
+        it { validated_by_record({{definition}}, 13.0).should_not be_invalid }
+        it { validated_by_record({{definition}}, 14.0).should be_invalid }
       end
 
       describe "Float32" do
-        it { validated_by_record(definition, 13.0f32).should_not be_invalid }
-        it { validated_by_record(definition, 14.0f32).should be_invalid }
+        it { validated_by_record({{definition}}, 13.0f32).should_not be_invalid }
+        it { validated_by_record({{definition}}, 14.0f32).should be_invalid }
       end
 
       describe "String" do
         it do
           expect_raises(ArgumentError) do
-            validated_by_record(definition, "13").should_not be_invalid
+            validated_by_record({{definition}}, "13").should_not be_invalid
           end
         end
       end
 
       describe "Nil" do
-        it { validated_by_record(definition, nil).should_not be_invalid }
+        it { validated_by_record({{definition}}, nil).should_not be_invalid }
       end
     end
 
@@ -252,5 +253,6 @@ describe Jennifer::Validations::Numericality do
     end
 
     pending "test allow_blank"
+    {% end %}
   end
 end

--- a/src/jennifer/adapter/base.cr
+++ b/src/jennifer/adapter/base.cr
@@ -10,12 +10,6 @@ module Jennifer
       # NOTE: if any request will be performed before response of the previous one is finished
       # we will get freezed.
 
-      include Transactions
-      include ResultParsers
-      include RequestMethods
-
-      alias ArgsType = Array(DBAny)
-
       enum ConnectionType
         Root
         DB
@@ -28,7 +22,12 @@ module Jennifer
         abstract def protocol : String
       end
 
+      alias ArgsType = Array(DBAny)
+
       extend AbstractClassMethods
+      include Transactions
+      include ResultParsers
+      include RequestMethods
 
       @db : DB::Database?
       getter config : Config
@@ -304,9 +303,7 @@ module Jennifer
       # ```
       abstract def view_exists?(name) : Bool
 
-      abstract def update(obj)
-      abstract def update(q, h)
-      abstract def insert(obj)
+      abstract def insert(obj : Model::Base)
 
       # Returns where table with given *table* name exists.
       #
@@ -344,7 +341,7 @@ module Jennifer
       abstract def default_type_size(name)
       abstract def table_column_count(table)
       abstract def tables_column_count(tables : Array(String))
-      abstract def with_table_lock(table : String, type : String = "default", &block)
+      abstract def with_table_lock(table : String, type : String = "default", &block : DB::Transaction -> Void)
       abstract def explain(q)
 
       def refresh_materialized_view(name)

--- a/src/jennifer/adapter/base_sql_generator.cr
+++ b/src/jennifer/adapter/base_sql_generator.cr
@@ -8,10 +8,10 @@ module Jennifer
         # Generates query for inserting new record to db
         abstract def insert(obj : Model::Base)
         abstract def json_path(path : QueryBuilder::JSONSelector)
-        abstract def insert_on_duplicate(table, fields, values, unique_fields, on_conflict)
+        abstract def insert_on_duplicate(table, fields, rows : Int32, unique_fields, on_conflict)
 
         # Generates SQL for VALUES reference in `INSERT ... ON DUPLICATE` query.
-        abstract def values_expression(field)
+        abstract def values_expression(field : Symbol)
       end
 
       extend ClassMethods

--- a/src/jennifer/adapter/mysql.cr
+++ b/src/jennifer/adapter/mysql.cr
@@ -58,7 +58,7 @@ module Jennifer
         @schema_processor ||= SchemaProcessor.new(self)
       end
 
-      def translate_type(name : Symbol)
+      def translate_type(name)
         TYPE_TRANSLATIONS[name]
       rescue e : KeyError
         raise BaseException.new("Unknown data alias #{name}")
@@ -113,7 +113,7 @@ module Jennifer
         end.exists?
       end
 
-      def foreign_key_exists?(from_table, to_table = nil, column = nil, name : String? = nil)
+      def foreign_key_exists?(from_table, to_table = nil, column = nil, name : String? = nil) : Bool
         name = self.class.foreign_key_name(from_table, to_table, column, name)
         Query["information_schema.KEY_COLUMN_USAGE", self]
           .where { and(_constraint_name == name, _table_schema == config.db) }

--- a/src/jennifer/adapter/postgres.cr
+++ b/src/jennifer/adapter/postgres.cr
@@ -179,7 +179,7 @@ module Jennifer
           .exists?
       end
 
-      def foreign_key_exists?(from_table, to_table = nil, column = nil, name : String? = nil)
+      def foreign_key_exists?(from_table, to_table = nil, column = nil, name : String? = nil) : Bool
         name = self.class.foreign_key_name(from_table, to_table, column, name)
         Query["information_schema.table_constraints", self]
           .where { and(_constraint_name == name, _table_schema == config.schema) }
@@ -194,7 +194,7 @@ module Jennifer
         query_array("SELECT unnest(enum_range(NULL::#{name})::varchar[])", String).map { |array| array[0] }
       end
 
-      def with_table_lock(table : String, type : String = "default", &block)
+      def with_table_lock(table : String, type : String = "default", &block : DB::Transaction -> Void)
         transaction do |t|
           exec "LOCK TABLE #{table} IN #{TABLE_LOCK_TYPES[type]} MODE"
           yield t

--- a/src/jennifer/adapter/schema_processor.cr
+++ b/src/jennifer/adapter/schema_processor.cr
@@ -35,7 +35,7 @@ module Jennifer
       def initialize(@adapter)
       end
 
-      abstract def rename_table(old_name, new_name)
+      abstract def rename_table(old_name : String | Symbol, new_name : String | Symbol)
       private abstract def index_type_translate(name)
       private abstract def column_definition(name, options, io)
 

--- a/src/jennifer/model/base.cr
+++ b/src/jennifer/model/base.cr
@@ -240,7 +240,7 @@ module Jennifer
       # ```
       # contact.set_attribute(:name, "Ivan")
       # ```
-      abstract def set_attribute(name, value)
+      abstract def set_attribute(name : String | Symbol, value : AttrType)
 
       # Assigns record properties based on key-value pairs of *values* and stores them directly to the database
       # without running validations and callbacks.
@@ -253,7 +253,7 @@ module Jennifer
       # ```
       # user.update_columns({ :name => "Jennifer" })
       # ```
-      abstract def update_columns(values)
+      abstract def update_columns(values : Hash(String | Symbol, AttrType))
 
       # Returns whether any field was changed. If field again got first value - `true` anyway
       # will be returned.

--- a/src/jennifer/model/resource.cr
+++ b/src/jennifer/model/resource.cr
@@ -8,7 +8,7 @@ module Jennifer
     # Base abstract class for a database entity.
     abstract class Resource
       module AbstractClassMethods
-        abstract def build(values, new_record : Bool)
+        abstract def build(values : Hash | NamedTuple, new_record : Bool)
         abstract def build
 
         # Returns relation instance by given name.
@@ -297,7 +297,7 @@ module Jennifer
       # contact.attribute(:salary)        # => Jennifer::BaseException is raised
       # contact.attribute(:salary, false) # => nil
       # ```
-      abstract def attribute(name, raise_exception : Bool = true)
+      abstract def attribute(name : String | Symbol, raise_exception : Bool = true)
 
       # Returns value of primary field
       #

--- a/src/jennifer/relation/i_relation.cr
+++ b/src/jennifer/relation/i_relation.cr
@@ -5,16 +5,13 @@ module Jennifer
       abstract def table_name
       abstract def model_class
       abstract def join_query
-      abstract def condition_clause
-      abstract def condition_clause(a)
       abstract def join_condition(a, b)
 
       # Returns query for given primary field values
       abstract def query(primary_value)
-      abstract def insert(a, b)
 
       # Preloads relation into *collection* from *out_collection* depending on keys from *pk_repo*.
-      abstract def preload_relation(collection, out_collection, pk_repo)
+      abstract def preload_relation(collection, out_collection : Array(Model::Resource), pk_repo)
     end
   end
 end

--- a/src/jennifer/relation/polymorphic_belongs_to.cr
+++ b/src/jennifer/relation/polymorphic_belongs_to.cr
@@ -3,8 +3,7 @@ module Jennifer
     abstract class IPolymorphicBelongsTo < IRelation
       DEFAULT_PRIMARY_FIELD = "id"
 
-      getter foreign : String, primary : String
-      getter name : String, foreign_type : String
+      getter foreign : String, primary : String, name : String, foreign_type : String
 
       def initialize(@name, foreign : String | Symbol?, primary : String | Symbol?, foreign_type : String | Symbol?)
         @foreign_type = foreign_type ? foreign_type.to_s : "#{name}_type"
@@ -13,7 +12,7 @@ module Jennifer
       end
 
       private abstract def related_model(arg : String)
-      private abstract def table_name(type)
+      private abstract def table_name(type : String)
 
       def condition_clause(ids : Array(DBAny), polymorphic_type : String?)
         model = related_model(polymorphic_type)
@@ -163,14 +162,6 @@ module Jennifer
 
       def query(a)
         raise AbstractMethod.new("query", self)
-      end
-
-      def condition_clause
-        raise AbstractMethod.new("condition_clause", self)
-      end
-
-      def condition_clause(id : DBAny)
-        raise AbstractMethod.new("condition_clause", self)
       end
 
       def join_condition(query, type)

--- a/src/jennifer/validations/absence.cr
+++ b/src/jennifer/validations/absence.cr
@@ -4,8 +4,8 @@ module Jennifer
     #
     # For more details see `Macros.validates_absence`.
     class Absence < Validator
-      def validate(record, field, value, allow_blank)
-        record.errors.add(field, :present) if value.present?
+      def validate(record, **opts)
+        record.errors.add(opts[:field], :present) if opts[:value].present?
       end
     end
   end

--- a/src/jennifer/validations/acceptance.cr
+++ b/src/jennifer/validations/acceptance.cr
@@ -4,7 +4,10 @@ module Jennifer
     #
     # For more details see `Macros.validates_acceptance`.
     class Acceptance < Validator
-      def validate(record, field : Symbol, value, _allow_blank : Bool, accept : Array? = nil)
+      def validate(record, **opts)
+        value = opts[:value]
+        accept = opts[:accept]?
+
         return true if value.nil?
 
         invalid =
@@ -13,7 +16,7 @@ module Jennifer
           else
             !accept.not_nil!.includes?(value)
           end
-        record.errors.add(field, :accepted) if invalid
+        record.errors.add(opts[:field], :accepted) if invalid
       end
     end
   end

--- a/src/jennifer/validations/confirmation.cr
+++ b/src/jennifer/validations/confirmation.cr
@@ -4,11 +4,15 @@ module Jennifer
     #
     # For more details see `Macros.validates_confirmation`.
     class Confirmation < Validator
-      def validate(record, field : Symbol, value, allow_blank : Bool, confirmation, case_sensitive)
+      def validate(record, **opts)
+        field = opts[:field]
+        confirmation = opts[:confirmation]?
+
         return true if confirmation.nil?
 
-        with_blank_validation do
-          return true if value.not_nil!.compare(confirmation.not_nil!, !case_sensitive) == 0
+        value = opts[:value]
+        with_blank_validation(record, field, value, false) do
+          return true if value.not_nil!.compare(confirmation.not_nil!, !opts[:case_sensitive]?.not_nil!) == 0
           record.errors.add(
             field,
             :confirmation,

--- a/src/jennifer/validations/exclusion.cr
+++ b/src/jennifer/validations/exclusion.cr
@@ -4,9 +4,12 @@ module Jennifer
     #
     # For more details see `Macros.validates_exclusion`.
     class Exclusion < Validator
-      def validate(record, field : Symbol, value, allow_blank : Bool, collection)
-        with_blank_validation do
-          record.errors.add(field, :exclusion) if collection.includes?(value.not_nil!)
+      def validate(record, **opts)
+        field = opts[:field]
+        value = opts[:value]
+        allow_blank = opts[:allow_blank]
+        with_blank_validation(record, field, value, allow_blank) do
+          record.errors.add(field, :exclusion) if opts[:collection]?.not_nil!.includes?(value.not_nil!)
         end
       end
     end

--- a/src/jennifer/validations/format.cr
+++ b/src/jennifer/validations/format.cr
@@ -4,9 +4,12 @@ module Jennifer
     #
     # For more details see `Macros.validates_format`.
     class Format < Validator
-      def validate(record, field : Symbol, value, allow_blank : Bool, format)
-        with_blank_validation do
-          record.errors.add(field, :invalid) unless format =~ value
+      def validate(record, **opts)
+        field = opts[:field]
+        value = opts[:value]
+        allow_blank = opts[:allow_blank]
+        with_blank_validation(record, field, value, allow_blank) do
+          record.errors.add(field, :invalid) unless opts[:format]?.not_nil! =~ value
         end
       end
     end

--- a/src/jennifer/validations/inclusion.cr
+++ b/src/jennifer/validations/inclusion.cr
@@ -4,9 +4,12 @@ module Jennifer
     #
     # For more details see `Macros.validates_inclusion`.
     class Inclusion < Validator
-      def validate(record, field : Symbol, value, allow_blank : Bool, collection)
-        with_blank_validation do
-          record.errors.add(field, :inclusion) unless collection.includes?(value.not_nil!)
+      def validate(record, **opts)
+        field = opts[:field]
+        value = opts[:value]
+        allow_blank = opts[:allow_blank]
+        with_blank_validation(record, field, value, allow_blank) do
+          record.errors.add(field, :inclusion) unless opts[:collection]?.not_nil!.includes?(value.not_nil!)
         end
       end
     end

--- a/src/jennifer/validations/length.cr
+++ b/src/jennifer/validations/length.cr
@@ -4,8 +4,16 @@ module Jennifer
     #
     # For more details see `Macros.validates_length`.
     class Length < Validator
-      def validate(record, field : Symbol, value, allow_blank : Bool, in in_value = nil, is = nil, minimum = nil, maximum = nil)
-        with_blank_validation do
+      def validate(record, **opts)
+        field = opts[:field]
+        value = opts[:value]
+        allow_blank = opts[:allow_blank]
+        in_value = opts[:in]?
+        is = opts[:is]?
+        minimum = opts[:minimum]?
+        maximum = opts[:maximum]?
+
+        with_blank_validation(record, field, value, allow_blank) do
           size = value.not_nil!.size
           errors = record.errors
           if in_value

--- a/src/jennifer/validations/macros.cr
+++ b/src/jennifer/validations/macros.cr
@@ -68,7 +68,13 @@ module Jennifer
 
         # :nodoc:
         def %validate_method
-          ::Jennifer::Validations::Inclusion.instance.validate(self, {{field}}, {{field.id}}, {{allow_blank}}, {{in_value}})
+          ::Jennifer::Validations::Inclusion.instance.validate(
+            self,
+            field: {{field}},
+            value: {{field.id}},
+            allow_blank: {{allow_blank}},
+            collection: {{in_value}}
+          )
         end
       end
 
@@ -89,7 +95,13 @@ module Jennifer
 
         # :nodoc:
         def %validate_method
-          ::Jennifer::Validations::Exclusion.instance.validate(self, {{field}}, {{field.id}}, {{allow_blank}}, {{in_value}})
+          ::Jennifer::Validations::Exclusion.instance.validate(
+            self,
+            field: {{field}},
+            value: {{field.id}},
+            allow_blank: {{allow_blank}},
+            collection: {{in_value}}
+          )
         end
       end
 
@@ -111,7 +123,13 @@ module Jennifer
 
         # :nodoc:
         def %validate_method
-          ::Jennifer::Validations::Format.instance.validate(self, {{field}}, {{field.id}}, {{allow_blank}}, {{value}})
+          ::Jennifer::Validations::Format.instance.validate(
+            self,
+            field: {{field}},
+            value: {{field.id}},
+            allow_blank: {{allow_blank}},
+            format: {{value}}
+          )
         end
       end
 
@@ -139,7 +157,12 @@ module Jennifer
 
         # :nodoc:
         def %validate_method
-          ::Jennifer::Validations::Length.instance.validate(self, {{field}}, {{field.id}}, {{**options}})
+          ::Jennifer::Validations::Length.instance.validate(
+            self,
+            field: {{field}},
+            value: {{field.id}},
+            {{**options}}
+          )
         end
       end
 
@@ -180,11 +203,11 @@ module Jennifer
         def %validate_method
           ::Jennifer::Validations::Uniqueness.instance.validate(
             self,
-            :{{fields_identifier.id}},
+            field: :{{fields_identifier.id}},
             # pass on nil here to signal nil values in record
-            {{normalized_fields}}.all?(&.nil?) ? nil : {{normalized_fields}},
-            {{allow_blank_value}},
-            self.class{{fields_condition.id}}
+            value: {{normalized_fields}}.all?(&.nil?) ? nil : {{normalized_fields}},
+            allow_blank: {{allow_blank_value}},
+            query: self.class{{fields_condition.id}}
           )
         end
       end
@@ -206,7 +229,7 @@ module Jennifer
 
         # :nodoc:
         def %validate_method
-          ::Jennifer::Validations::Presence.instance.validate(self, {{field}}, {{field.id}}, false)
+          ::Jennifer::Validations::Presence.instance.validate(self, field: {{field}}, value: {{field.id}})
         end
       end
 
@@ -225,7 +248,7 @@ module Jennifer
 
         # :nodoc:
         def %validate_method
-          ::Jennifer::Validations::Absence.instance.validate(self, {{field}}, {{field.id}}, true)
+          ::Jennifer::Validations::Absence.instance.validate(self, field: {{field}}, value: {{field.id}})
         end
       end
 
@@ -256,7 +279,12 @@ module Jennifer
 
         # :nodoc:
         def %validate_method
-          ::Jennifer::Validations::Numericality.instance.validate(self, {{field}}, {{field.id}}, {{**options}})
+          ::Jennifer::Validations::Numericality.instance.validate(
+            self,
+            field: {{field}},
+            value: {{field.id}},
+            {{**options}}
+          )
         end
       end
 
@@ -282,7 +310,12 @@ module Jennifer
 
         # :nodoc:
         def %validate_method
-          ::Jennifer::Validations::Acceptance.instance.validate(self, {{field}}, {{field.id}}, false, {{accept}})
+          ::Jennifer::Validations::Acceptance.instance.validate(
+            self,
+            field: {{field}},
+            value: {{field.id}},
+            accept: {{accept}}
+          )
         end
       end
 
@@ -307,8 +340,13 @@ module Jennifer
 
         # :nodoc:
         def %validate_method
-          ::Jennifer::Validations::Confirmation.instance
-            .validate(self, {{field}}, {{field.id}}, false, {{field.id}}_confirmation, {{case_sensitive}})
+          ::Jennifer::Validations::Confirmation.instance.validate(
+            self,
+            field: {{field}},
+            value: {{field.id}},
+            confirmation: {{field.id}}_confirmation,
+            case_sensitive: {{case_sensitive}}
+          )
         end
       end
     end

--- a/src/jennifer/validations/numericality.cr
+++ b/src/jennifer/validations/numericality.cr
@@ -4,10 +4,20 @@ module Jennifer
     #
     # For more details see `Macros.validates_numericality`.
     class Numericality < Validator
-      def validate(record, field : Symbol, value, allow_blank : Bool, greater_than = nil, # ameba:disable Metrics/CyclomaticComplexity
-                   greater_than_or_equal_to = nil, equal_to = nil, less_than = nil, less_than_or_equal_to = nil,
-                   other_than = nil, odd = nil, even = nil)
-        with_blank_validation do
+      def validate(record, **opts) # ameba:disable Metrics/CyclomaticComplexity
+        field = opts[:field]
+        value = opts[:value]
+        allow_blank = opts[:allow_blank]
+        greater_than = opts[:greater_than]?
+        greater_than_or_equal_to = opts[:greater_than_or_equal_to]?
+        equal_to = opts[:equal_to]?
+        less_than = opts[:less_than]?
+        less_than_or_equal_to = opts[:less_than_or_equal_to]?
+        other_than = opts[:other_than]?
+        odd = opts[:odd]?
+        even = opts[:even]?
+
+        with_blank_validation(record, field, value, allow_blank) do
           value = value.not_nil!
           errors = record.errors
 

--- a/src/jennifer/validations/presence.cr
+++ b/src/jennifer/validations/presence.cr
@@ -4,8 +4,8 @@ module Jennifer
     #
     # For more details see `Macros.validates_presence`.
     class Presence < Validator
-      def validate(record, field : Symbol, value, _allow_blank : Bool)
-        record.errors.add(field, :blank) if value.blank?
+      def validate(record, **opts)
+        record.errors.add(opts[:field], :blank) if opts[:value].blank?
       end
     end
   end

--- a/src/jennifer/validations/uniqueness.cr
+++ b/src/jennifer/validations/uniqueness.cr
@@ -4,15 +4,18 @@ module Jennifer
     # Validates that the given field(s) of a record are unique for this type.
     #
     class Uniqueness < Validator
-      def validate(record, field : Symbol, value, allow_blank : Bool, query)
-        with_blank_validation do
-          _query = query.clone
+      def validate(record, **opts)
+        field = opts[:field]
+        value = opts[:value]
+        allow_blank = opts[:allow_blank]
+
+        with_blank_validation(record, field, value, allow_blank) do
+          _query = opts[:query]?.not_nil!.clone
           _query.where { primary != record.primary } unless record.new_record?
 
           record.errors.add(field, :taken) if _query.exists?
         end
       end # validate
     end # Uniqueness
-
   end # Validations
 end # Jennifer

--- a/src/jennifer/validations/validator.cr
+++ b/src/jennifer/validations/validator.cr
@@ -27,7 +27,7 @@ module Jennifer
       extend ClassMethods
 
       # Validates given *record* based on *args* and *opts*.
-      abstract def validate(record, *args, **opts)
+      abstract def validate(record, **opts)
 
       def blank_validation(record, field, value, allow_blank)
         if allow_blank
@@ -39,8 +39,8 @@ module Jennifer
         true
       end
 
-      macro with_blank_validation
-        case blank_validation(record, field, value, allow_blank)
+      macro with_blank_validation(record, field, value, allow_blank)
+        case blank_validation({{record}}, {{field}}, {{value}}, {{allow_blank}})
         when false
           false
         when nil


### PR DESCRIPTION
Address #360 

# Release notes

**General**

* add crystal 0.36.1 support
* fix inconsistent method signatures in multiple places

**Validation**

* change `Validator#validate` abstract interface to `#validate(record, **opts)`
* update all built-in validators to reflect new `Validator` interface
* make `Validator.with_blank_validation` macro to accept arguments to reference record, field name, value and blank value acceptance

**Relation**

* remove abstract `#condition_clause` & `#condition_clause(a)` declarations from `IRelation`

**Adapter**

* remove abstract `#update`  declaration from `Base`