### PR TITLE
Added support for Crystal 0.36.1 - 1.x.x

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,7 +4,7 @@ version: 0.10.0
 authors:
   - Roman Kalnytskyi <moranibaca@gmail.com>
 
-crystal: ">= 0.36.1, < 2.0.0"
+crystal: ">= 0.36.0"
 
 license: MIT
 

--- a/shard.yml
+++ b/shard.yml
@@ -4,7 +4,7 @@ version: 0.10.0
 authors:
   - Roman Kalnytskyi <moranibaca@gmail.com>
 
-crystal: 0.36.1
+crystal: ">= 0.36.1, < 2.0.0"
 
 license: MIT
 


### PR DESCRIPTION
# What does this PR do?
I updated the Crystal version so that I can use this shard in my new Amber application that uses Crystal 1.0

# Any background context you want to provide?
Updated the shard file, and was able to setup a local test DB and run all specs with the following results:
```bash
Finished in 7.83 seconds
1789 examples, 0 failures, 0 errors, 94 pending
```

# Release notes
Adds support for any official releases of Crystal from 0.36.1 - 1.x.x specifically allowing for any of the minor releases because Crystal 1.x is supposed to avoid any breaking changes until Crystal 2.0