### PR TITLE
created_at and updated_at should be dirty after the default before_save callbacks

### DIFF
--- a/spec/model/mapping_spec.cr
+++ b/spec/model/mapping_spec.cr
@@ -1196,6 +1196,7 @@ describe Jennifer::Model::Mapping do
       c.created_at.should be_nil
       c.__update_created_at
       c.created_at!.should_not be_nil
+      c.created_at_changed?.should be_true
       ((c.created_at! - Time.local).total_seconds < 1).should be_true
     end
   end
@@ -1206,6 +1207,7 @@ describe Jennifer::Model::Mapping do
       c.updated_at.should be_nil
       c.__update_updated_at
       c.updated_at!.should_not be_nil
+      c.updated_at_changed?.should be_true
       ((c.updated_at! - Time.local).total_seconds < 1).should be_true
     end
   end

--- a/src/jennifer/model/mapping.cr
+++ b/src/jennifer/model/mapping.cr
@@ -215,7 +215,7 @@ module Jennifer
 
           # :nodoc:
           def __update_created_at
-            @created_at = Time.local(Jennifer::Config.local_time_zone)
+            self.created_at = Time.local(Jennifer::Config.local_time_zone)
           end
         {% end %}
 
@@ -224,7 +224,7 @@ module Jennifer
 
           # :nodoc:
           def __update_updated_at
-            @updated_at = Time.local(Jennifer::Config.local_time_zone)
+            self.updated_at = Time.local(Jennifer::Config.local_time_zone)
           end
         {% end %}
       end


### PR DESCRIPTION
# What does this PR do?
Fix before_save callbacks generated by macro `with_timestamps`
# Any background context you want to provide?
created_at and updated_at should be set dirty in order to get injected into the UPDATE sql
# Release notes

Please fill the corresponding section regarding this pull request notes below instead of modifying `CHANGELOG.md` file. Please remove all redundant sections before posting request.

**Model**
Fix a bug where updated_at is not set in the generated sql qeury from model.save
