### PR TITLE
Extend some converters to support string values in `.from_hash` method

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
     branches: "*"
+  push:
+    branches: master
   schedule:
     - cron: "0 7 * * 1"
 

--- a/spec/model/base_spec.cr
+++ b/spec/model/base_spec.cr
@@ -332,10 +332,12 @@ describe Jennifer::Model::Base do
         c.id.nil?.should be_false
         c.name = "new name"
         c.save.should be_true
+        Contact.all.count.should eq(1)
       end
 
       it "returns false if record wasn't saved" do
-        Factory.create_address.save.should be_true
+        Factory.create_address.save.should be_false
+        Address.all.count.should eq(1)
       end
 
       it "calls after_save_callback" do

--- a/spec/model/base_spec.cr
+++ b/spec/model/base_spec.cr
@@ -335,9 +335,15 @@ describe Jennifer::Model::Base do
         Contact.all.count.should eq(1)
       end
 
-      it "returns false if record wasn't saved" do
-        Factory.create_address.save.should be_false
+      it "returns true if record wasn't changed" do
+        Factory.create_address.save.should be_true
         Address.all.count.should eq(1)
+      end
+
+      it "returns false if record wasn't saved" do
+        record = Factory.create_address
+        record.street = "invalid"
+        record.save.should be_false
       end
 
       it "calls after_save_callback" do

--- a/spec/model/big_decimal_converter_spec.cr
+++ b/spec/model/big_decimal_converter_spec.cr
@@ -3,7 +3,7 @@ require "../spec_helper"
 describe Jennifer::Model::BigDecimalConverter do
   described_class = Jennifer::Model::BigDecimalConverter(PG::Numeric)
 
-  describe "#from_db" do
+  describe ".from_db" do
     postgres_only do
       it "reads numeric from result set" do
         ballance = PG::Numeric.new(2i16, 0i16, 0i16, 3i16, [1234i16, 6800i16])
@@ -28,7 +28,7 @@ describe Jennifer::Model::BigDecimalConverter do
     end
   end
 
-  describe "#to_db" do
+  describe ".to_db" do
     postgres_only do
       it "writes value to a result set" do
         balance = described_class.to_db(BigDecimal.new(123468, 2), {name: "ballance", scale: 2})
@@ -38,7 +38,7 @@ describe Jennifer::Model::BigDecimalConverter do
     end
   end
 
-  describe "#from_hash" do
+  describe ".from_hash" do
     postgres_only do
       it "converts numeric" do
         balance = PG::Numeric.new(2i16, 0i16, 0i16, 2i16, [1234i16, 6800i16])
@@ -50,5 +50,25 @@ describe Jennifer::Model::BigDecimalConverter do
     it "accepts nil value" do
       described_class.from_hash({"ballance" => nil}, "ballance", {name: "ballance", scale: 2}).should be_nil
     end
+
+    it "accepts string value" do
+      described_class.from_hash({"ballance" => "12.123"}, "ballance", {name: "ballance", scale: 2})
+        .should eq(BigDecimal.new(12123, 3))
+    end
+
+    it "accepts int value" do
+      described_class.from_hash({"ballance" => 12}, "ballance", {name: "ballance", scale: 2})
+        .should eq(BigDecimal.new(1200, 2))
+    end
+
+    it "accepts float value" do
+      described_class.from_hash({"ballance" => 12.123}, "ballance", {name: "ballance", scale: 2})
+        .should eq(BigDecimal.new(1212, 2))
+    end
+  end
+
+  describe ".coerce" do
+    it { described_class.coerce("123.12", {scale: 2}).should eq(BigDecimal.new(12312, 2)) }
+    it { described_class.coerce("", {scale: 2}).should be_nil }
   end
 end

--- a/spec/model/coercer_spec.cr
+++ b/spec/model/coercer_spec.cr
@@ -1,9 +1,7 @@
 require "../spec_helper"
 
 describe Jennifer::Model::Coercer do
-  described_class = Jennifer::Model::Coercer
+  # described_class = Jennifer::Model::Coercer
 
-  describe BigDecimal do
-    it { described_class.coerce("123.12", BigDecimal?).should eq(BigDecimal.new(12312, 2)) }
-  end
+  pending
 end

--- a/spec/model/errors_spec.cr
+++ b/spec/model/errors_spec.cr
@@ -273,6 +273,14 @@ describe Jennifer::Model::Errors do
     end
   end
 
+  describe "#inspect" do
+    it do
+      errors = described_class.new(facebook_profile)
+      errors.add(:uid)
+      errors.inspect.should match(/#<Jennifer::Model::Errors:0x[\w\d]{12} @messages={:uid => \["is invalid"\]}>/)
+    end
+  end
+
   describe ".new" do
     it do
       described_class.new(Factory.build_contact)

--- a/spec/model/mapping_spec.cr
+++ b/spec/model/mapping_spec.cr
@@ -1182,33 +1182,4 @@ describe Jennifer::Model::Mapping do
       it { NoteWithManualId.primary_auto_incrementable?.should be_false }
     end
   end
-
-  describe "%with_timestamps" do
-    it "adds callbacks" do
-      Contact::CALLBACKS[:create][:before].should contain("__update_created_at")
-      Contact::CALLBACKS[:save][:before].should contain("__update_updated_at")
-    end
-  end
-
-  describe "#__update_created_at" do
-    it "updates created_at field" do
-      c = Factory.build_contact
-      c.created_at.should be_nil
-      c.__update_created_at
-      c.created_at!.should_not be_nil
-      c.created_at_changed?.should be_true
-      ((c.created_at! - Time.local).total_seconds < 1).should be_true
-    end
-  end
-
-  describe "#__update_updated_at" do
-    it "updates updated_at field" do
-      c = Factory.build_contact
-      c.updated_at.should be_nil
-      c.__update_updated_at
-      c.updated_at!.should_not be_nil
-      c.updated_at_changed?.should be_true
-      ((c.updated_at! - Time.local).total_seconds < 1).should be_true
-    end
-  end
 end

--- a/spec/model/numeric_to_float64_converter_spec.cr
+++ b/spec/model/numeric_to_float64_converter_spec.cr
@@ -2,6 +2,8 @@ require "../spec_helper"
 
 postgres_only do
   describe Jennifer::Model::NumericToFloat64Converter do
+    described_class = Jennifer::Model::NumericToFloat64Converter
+
     it "loads field from the database" do
       ballance = PG::Numeric.new(1i16, 0i16, 0i16, 0i16, [3i16])
       id = Factory.create_contact(ballance: ballance).id
@@ -32,7 +34,15 @@ postgres_only do
     describe ".from_hash" do
       it "accepts PG::Numeric" do
         value = PG::Numeric.new(1i16, 0i16, 0i16, 0i16, [3i16])
-        Jennifer::Model::NumericToFloat64Converter.from_hash({"value" => value}, "value", {name: "value"}).should eq(3.0)
+        described_class.from_hash({"value" => value}, "value", {name: "value"}).should eq(3.0)
+      end
+
+      it "accepts string" do
+        described_class.from_hash({"value" => "3.01"}, "value", {name: "value"}).should eq(3.01)
+      end
+
+      it "accepts int" do
+        described_class.from_hash({"value" => 2}, "value", {name: "value"}).should eq(2.0)
       end
     end
   end

--- a/spec/model/time_zone_converter_spec.cr
+++ b/spec/model/time_zone_converter_spec.cr
@@ -44,6 +44,11 @@ describe Jennifer::Model::TimeZoneConverter do
       value.should eq(time.to_local_in(Jennifer::Config.local_time_zone))
       value.zone.should eq(Jennifer::Config.local_time_zone.lookup(Time.utc))
     end
+
+    it "accepts string value" do
+      described_class.from_hash({"value" => "2010-12-10"}, "value", {name: "value"})
+        .should eq(Time.local(2010, 12, 10, 0, 0, 0, location: ::Jennifer::Config.local_time_zone))
+    end
   end
 
   describe ".coerce" do

--- a/spec/model/timestamp_spec.cr
+++ b/spec/model/timestamp_spec.cr
@@ -1,0 +1,32 @@
+require "../spec_helper"
+
+describe Jennifer::Model::Timestamp do
+  it "sets both created_at and updated_at on create" do
+    c = Factory.build_contact
+    c.created_at.should be_nil
+    c.updated_at.should be_nil
+    c.save!
+    c.updated_at.should eq(c.created_at)
+    c.updated_at.should_not be_nil
+  end
+
+  it "changes updated_at on update" do
+    c = Factory.create_contact
+    c.updated_at.should eq(c.created_at)
+    sleep(0.1)
+    c.name = "new name"
+    c.save!
+    (c.updated_at! > c.created_at!).should be_true
+  end
+
+  it "doesn't trigger update if nothing changed" do
+    c = Factory.create_contact
+    c.updated_at.should eq(c.created_at)
+    sleep(0.1)
+    c.save!
+    c.updated_at.should eq(c.created_at)
+  end
+
+  pending "when created_at is disabled"
+  pending "when updated_at is disabled"
+end

--- a/src/jennifer/adapter/postgres/model/numeric_to_float64_converter.cr
+++ b/src/jennifer/adapter/postgres/model/numeric_to_float64_converter.cr
@@ -27,7 +27,7 @@ module Jennifer::Model
     def self.from_hash(hash : Hash, column, options)
       value = hash[column]
       case value
-      when PG::Numeric
+      when PG::Numeric, String
         value.to_f64
       else
         value

--- a/src/jennifer/model/base.cr
+++ b/src/jennifer/model/base.cr
@@ -14,6 +14,7 @@ require "./enum_converter"
 require "./json_converter"
 require "./json_serializable_converter"
 require "./time_zone_converter"
+require "./timestamp"
 
 module Jennifer
   module Model
@@ -54,6 +55,7 @@ module Jennifer
       extend AbstractClassMethods
       include Presentable
       include Mapping
+      include Timestamp
       include STIMapping
       include Validation
       include Callback
@@ -456,6 +458,7 @@ module Jennifer
         return false unless __before_update_callback
         return true unless changed?
 
+        track_timestamps_on_update
         res = self.class.write_adapter.update(self)
         __after_update_callback
         res.rows_affected == 1
@@ -464,6 +467,7 @@ module Jennifer
       private def store_record : Bool
         return false unless __before_create_callback
 
+        track_timestamps_on_create
         res = self.class.write_adapter.insert(self)
         init_primary_field(res.last_insert_id.as(Int)) if primary.nil? && res.last_insert_id > -1
         raise ::Jennifer::BaseException.new("Record hasn't been stored to the db") if res.rows_affected == 0

--- a/src/jennifer/model/big_decimal_converter.cr
+++ b/src/jennifer/model/big_decimal_converter.cr
@@ -44,7 +44,7 @@ module Jennifer::Model
       scale = options[:scale]
       value = hash[column]
       case value
-      when T
+      when T, Float, Int
         BigDecimal.new((value.to_f64 * 10 ** scale).to_i, scale)
       else
         value

--- a/src/jennifer/model/big_decimal_converter.cr
+++ b/src/jennifer/model/big_decimal_converter.cr
@@ -46,9 +46,15 @@ module Jennifer::Model
       case value
       when T, Float, Int
         BigDecimal.new((value.to_f64 * 10 ** scale).to_i, scale)
+      when String
+        coerce(value, options)
       else
         value
       end
+    end
+
+    def self.coerce(value : String, _options) : BigDecimal?
+      BigDecimal.new(value) unless value.empty?
     end
   end
 end

--- a/src/jennifer/model/errors.cr
+++ b/src/jennifer/model/errors.cr
@@ -181,7 +181,7 @@ module Jennifer
 
       def inspect(io) : Nil
         io << "#<" << {{@type.name.id.stringify}} << ":0x"
-        object_id.to_s(16, io)
+        object_id.to_s(io, 16)
         io << " @messages="
         @messages.inspect(io)
         io << '>'

--- a/src/jennifer/model/mapping.cr
+++ b/src/jennifer/model/mapping.cr
@@ -196,39 +196,6 @@ module Jennifer
         alias AttrType = ::Jennifer::DBAny | {{new_props.map { |field, mapping| mapping[:parsed_type] }.join(" | ").id}}
       end
 
-      # Adds callbacks for `created_at` and `updated_at` fields.
-      #
-      # ```
-      # class MyModel < Jennifer::Model::Base
-      #   with_timestamps
-      #
-      #   mapping(
-      #     id: {type: Int32, primary: true},
-      #     created_at: {type: Time, null: true},
-      #     updated_at: {type: Time, null: true}
-      #   )
-      # end
-      # ```
-      macro with_timestamps(created_at = true, updated_at = true)
-        {% if created_at %}
-          before_save :__update_updated_at
-
-          # :nodoc:
-          def __update_created_at
-            self.created_at = Time.local(Jennifer::Config.local_time_zone)
-          end
-        {% end %}
-
-        {% if updated_at %}
-          before_create :__update_created_at
-
-          # :nodoc:
-          def __update_updated_at
-            self.updated_at = Time.local(Jennifer::Config.local_time_zone)
-          end
-        {% end %}
-      end
-
       # :nodoc:
       macro module_mapping
         __field_declaration({{COLUMNS_METADATA}}, false)

--- a/src/jennifer/model/time_zone_converter.cr
+++ b/src/jennifer/model/time_zone_converter.cr
@@ -39,6 +39,8 @@ module Jennifer::Model
         else
           value.in(Config.local_time_zone)
         end
+      when String
+        coerce(value, options)
       else
         value
       end

--- a/src/jennifer/model/timestamp.cr
+++ b/src/jennifer/model/timestamp.cr
@@ -1,0 +1,42 @@
+module Jennifer::Model
+  module Timestamp
+    private abstract def track_timestamps_on_update
+    private abstract def track_timestamps_on_create
+
+    macro included
+      def track_timestamps_on_update; end
+      def track_timestamps_on_create; end
+    end
+
+    # Adds callbacks for `created_at` and `updated_at` fields.
+    #
+    # ```
+    # class MyModel < Jennifer::Model::Base
+    #   with_timestamps
+    #
+    #   mapping(
+    #     id: {type: Int32, primary: true},
+    #     created_at: {type: Time, null: true},
+    #     updated_at: {type: Time, null: true}
+    #   )
+    # end
+    # ```
+    macro with_timestamps(created_at = true, updated_at = true)
+      {% if updated_at %}
+        def track_timestamps_on_update
+          self.updated_at = Time.local(Jennifer::Config.local_time_zone)
+        end
+      {% end %}
+
+      def track_timestamps_on_create
+        {% if updated_at %}
+        self.updated_at =
+        {% end %}
+        {% if created_at %}
+          self.created_at =
+        {% end %}
+            Time.local(Jennifer::Config.local_time_zone)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Release notes

**Model**

* `NumericToFloat64Converter`, `BigDecimalConverter`, `TimeZoneConverter` `#from_hash` accepts string as field value
* `BigDecimalConverter#from_hash` accepts integer and float values as field value 
* fix `Errors#inspect` bug using old `UInt64#to_s` signature
* introduce `Timestamp` module that now includes `with_timestamps` macro
* reworked how `updated_at` and `created_at` fields are set before save - now they are set explicitly without utilizing callbacks