### PR TITLE
Add query.where accepting hash

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,7 +37,16 @@ test:
   <<: *defaults
 ```
 
-This also can be written using DSL:
+You cam also use `.ecr` extension to leverage environmet variables in your configuration file. To do this use:
+
+```crystal
+config_file = YAML.parse(ECR.render("config/database.yml.ecr"))
+Jennifer::Config.configure do |conf|
+  conf.from_yaml(config_file[ENV["APP_ENV"]])
+end
+```
+
+All configurations also can be set using DSL:
 
 ```crystal
 Jennifer::Config.configure do |conf|

--- a/spec/query_builder/expression_builder_spec.cr
+++ b/spec/query_builder/expression_builder_spec.cr
@@ -125,64 +125,136 @@ describe ::Jennifer::QueryBuilder::ExpressionBuilder do
   end
 
   describe "#and" do
-    context "with 2 criteria" do
-      it do
-        c1 = Factory.build_criteria
-        c2 = Factory.build_criteria
-        e = Factory.build_expression
-        e.and(c1, c2).as_sql.should eq(e.g(c1 & c2).as_sql)
-      end
+    it "accepts 2 conditions" do
+      c1 = Factory.build_criteria
+      c2 = Factory.build_criteria
+      e = Factory.build_expression
+      e.and(c1, c2).as_sql.should eq(e.g(c1 & c2).as_sql)
     end
 
-    context "with 3 criteria" do
-      it do
-        c1 = Factory.build_criteria(field: "f1")
-        c2 = Factory.build_criteria(field: "f2")
-        c3 = Factory.build_criteria(field: "f3")
+    it "accepts 3 conditions" do
+      c1 = Factory.build_criteria(field: "f1")
+      c2 = Factory.build_criteria(field: "f2")
+      c3 = Factory.build_criteria(field: "f3")
+      e = Factory.build_expression
+      e.and(c1, c2, c3).as_sql.should eq(e.g(c1 & c2 & c3).as_sql)
+    end
+
+    it "accepts array of 1 condition" do
+      c1 = Factory.build_criteria(field: "f1").equal(1)
+      e = Factory.build_expression
+      e.and([c1]).as_sql.should eq(c1.as_sql)
+    end
+
+    it "accepts array of 2 conditions" do
+      c1 = Factory.build_criteria(field: "f1").equal(1)
+      c2 = Factory.build_criteria(field: "f2").equal(2)
+      e = Factory.build_expression
+      e.and([c1, c2]).as_sql.should eq(e.g(c1 & c2).as_sql)
+    end
+
+    it "accepts array of 3 and more conditions" do
+      c1 = Factory.build_criteria(field: "f1").equal(1)
+      c2 = Factory.build_criteria(field: "f2").equal(2)
+      c3 = Factory.build_criteria(field: "f3").equal(3)
+      e = Factory.build_expression
+      e.and([c1, c2, c3]).as_sql.should eq(e.g(c1 & c2 & c3).as_sql)
+    end
+
+    it "raises and error if an empty array is given" do
+      expect_raises(ArgumentError, "#and can't accept 0 conditions") do
         e = Factory.build_expression
-        e.and(c1, c2, c3).as_sql.should eq(e.g(c1 & c2 & c3).as_sql)
+        e.and([] of Jennifer::QueryBuilder::Condition).as_sql
       end
     end
   end
 
   describe "#or" do
-    context "with 2 criteria" do
-      it do
-        c1 = Factory.build_criteria
-        c2 = Factory.build_criteria
-        e = Factory.build_expression
-        e.or(c1, c2).as_sql.should eq(e.g(c1 | c2).as_sql)
-      end
+    it "accepts 2 conditions" do
+      c1 = Factory.build_criteria
+      c2 = Factory.build_criteria
+      e = Factory.build_expression
+      e.or(c1, c2).as_sql.should eq(e.g(c1 | c2).as_sql)
     end
 
-    context "with 3 criteria" do
-      it do
-        c1 = Factory.build_criteria(field: "f1")
-        c2 = Factory.build_criteria(field: "f2")
-        c3 = Factory.build_criteria(field: "f3")
+    it "accepts 3 conditions" do
+      c1 = Factory.build_criteria(field: "f1")
+      c2 = Factory.build_criteria(field: "f2")
+      c3 = Factory.build_criteria(field: "f3")
+      e = Factory.build_expression
+      e.or(c1, c2, c3).as_sql.should eq(e.g(c1 | c2 | c3).as_sql)
+    end
+
+    it "accepts array of 1 condition" do
+      c1 = Factory.build_criteria(field: "f1").equal(1)
+      e = Factory.build_expression
+      e.or([c1]).as_sql.should eq(c1.as_sql)
+    end
+
+    it "accepts array of 2 conditions" do
+      c1 = Factory.build_criteria(field: "f1").equal(1)
+      c2 = Factory.build_criteria(field: "f2").equal(2)
+      e = Factory.build_expression
+      e.or([c1, c2]).as_sql.should eq(e.g(c1 | c2).as_sql)
+    end
+
+    it "accepts array of 3 and more conditions" do
+      c1 = Factory.build_criteria(field: "f1").equal(1)
+      c2 = Factory.build_criteria(field: "f2").equal(2)
+      c3 = Factory.build_criteria(field: "f3").equal(3)
+      e = Factory.build_expression
+      e.or([c1, c2, c3]).as_sql.should eq(e.g(c1 | c2 | c3).as_sql)
+    end
+
+    it "raises and error if an empty array is given" do
+      expect_raises(ArgumentError, "#or can't accept 0 conditions") do
         e = Factory.build_expression
-        e.or(c1, c2, c3).as_sql.should eq(e.g(c1 | c2 | c3).as_sql)
+        e.or([] of Jennifer::QueryBuilder::Condition).as_sql
       end
     end
   end
 
   describe "#xor" do
-    context "with 2 criteria" do
-      it do
-        c1 = Factory.build_criteria
-        c2 = Factory.build_criteria
-        e = Factory.build_expression
-        e.xor(c1, c2).as_sql.should eq(e.g(c1.xor(c2)).as_sql)
-      end
+    it "accepts 2 conditions" do
+      c1 = Factory.build_criteria
+      c2 = Factory.build_criteria
+      e = Factory.build_expression
+      e.xor(c1, c2).as_sql.should eq(e.g(c1.xor(c2)).as_sql)
     end
 
-    context "with 3 criteria" do
-      it do
-        c1 = Factory.build_criteria(field: "f1")
-        c2 = Factory.build_criteria(field: "f2")
-        c3 = Factory.build_criteria(field: "f3")
+    it "accepts 3 conditions" do
+      c1 = Factory.build_criteria(field: "f1")
+      c2 = Factory.build_criteria(field: "f2")
+      c3 = Factory.build_criteria(field: "f3")
+      e = Factory.build_expression
+      e.xor(c1, c2, c3).as_sql.should eq(e.g(c1.xor(c2.xor(c3))).as_sql)
+    end
+
+    it "accepts array of 1 condition" do
+      c1 = Factory.build_criteria(field: "f1").equal(1)
+      e = Factory.build_expression
+      e.xor([c1]).as_sql.should eq(c1.as_sql)
+    end
+
+    it "accepts array of 2 conditions" do
+      c1 = Factory.build_criteria(field: "f1").equal(1)
+      c2 = Factory.build_criteria(field: "f2").equal(2)
+      e = Factory.build_expression
+      e.xor([c1, c2]).as_sql.should eq(e.g(c1.xor(c2)).as_sql)
+    end
+
+    it "accepts array of 3 and more conditions" do
+      c1 = Factory.build_criteria(field: "f1").equal(1)
+      c2 = Factory.build_criteria(field: "f2").equal(2)
+      c3 = Factory.build_criteria(field: "f3").equal(3)
+      e = Factory.build_expression
+      e.xor([c1, c2, c3]).as_sql.should eq(e.g(c1.xor(c2.xor(c3))).as_sql)
+    end
+
+    it "raises and error if an empty array is given" do
+      expect_raises(ArgumentError, "#xor can't accept 0 conditions") do
         e = Factory.build_expression
-        e.xor(c1, c2, c3).as_sql.should eq(e.g(c1.xor(c2.xor(c3))).as_sql)
+        e.xor([] of Jennifer::QueryBuilder::Condition).as_sql
       end
     end
   end

--- a/spec/query_builder/query_spec.cr
+++ b/spec/query_builder/query_spec.cr
@@ -177,6 +177,12 @@ describe Jennifer::QueryBuilder::Query do
       q1.tree.to_s.should eq("contacts.name = %s AND (age > %s)")
     end
 
+    it "generates correct request for given hash arguments" do
+      q1 = Query["contacts"].where({:name => "John", :age => 12})
+      q1.tree.to_s.should eq("(contacts.name = %s AND contacts.age = %s)")
+      q1.tree.not_nil!.sql_args.should eq(db_array("John", 12))
+    end
+
     postgres_only do
       it "gracefully handle argument type mismatch" do
         void_transaction do

--- a/src/jennifer/adapter/base_sql_generator.cr
+++ b/src/jennifer/adapter/base_sql_generator.cr
@@ -229,7 +229,7 @@ module Jennifer
         where_clause(io, query.tree.not_nil!) if query.tree
       end
 
-      # ditto
+      # :ditto:
       def self.where_clause(io : String::Builder, tree)
         return unless tree
 

--- a/src/jennifer/adapter/quoting.cr
+++ b/src/jennifer/adapter/quoting.cr
@@ -9,48 +9,48 @@ module Jennifer
 
       abstract def quote_json_string(value : String)
 
-      # ditto
+      # :ditto:
       def quote(value : Nil)
         "NULL"
       end
 
-      # ditto
+      # :ditto:
       def quote(value : Bool)
         value ? "TRUE" : "FALSE"
       end
 
-      # ditto
+      # :ditto:
       def quote(value : Int | Float | UInt32)
         value.to_s
       end
 
-      # ditto
+      # :ditto:
       def quote(value : Char)
         quote(value.to_s)
       end
 
-      # ditto
+      # :ditto:
       def quote(value : Time)
         "'#{value.to_utc.to_s("%F %T")}'"
       end
 
-      # ditto
+      # :ditto:
       def quote(value : Time::Span)
         # NOTE: isn't user by pg driver ATM
         "'#{value}'"
       end
 
-      # ditto
+      # :ditto:
       def quote(value : Slice(UInt8))
         "x'#{value.hexstring}'"
       end
 
-      # ditto
+      # :ditto:
       def quote(value : JSON::Any)
         "'" + ::Jennifer::Adapter::JSONEncoder.encode(value, self) + "'"
       end
 
-      # ditto
+      # :ditto:
       def quote(value)
         raise ArgumentError.new("Value #{value} can't be quoted")
       end

--- a/src/jennifer/adapter/record.cr
+++ b/src/jennifer/adapter/record.cr
@@ -34,7 +34,7 @@ module Jennifer
       raise BaseException.new("Column '#{name}' is missing")
     end
 
-    # ditto
+    # :ditto:
     def attribute(name : Symbol)
       attribute(name.to_s)
     end

--- a/src/jennifer/config.cr
+++ b/src/jennifer/config.cr
@@ -189,7 +189,7 @@ module Jennifer
       instance
     end
 
-    # ditto
+    # :ditto:
     def self.config : self
       instance
     end
@@ -271,7 +271,7 @@ module Jennifer
       read(path, env.to_s)
     end
 
-    # ditto
+    # :ditto:
     def read(path : String, env : String)
       read(path) { |document| document[env] }
     end

--- a/src/jennifer/model/base.cr
+++ b/src/jennifer/model/base.cr
@@ -356,7 +356,7 @@ module Jennifer
         values.each { |k, v| set_attribute(k, v) }
       end
 
-      # ditto
+      # :ditto:
       def set_attributes(**values)
         set_attributes(values)
       end
@@ -534,7 +534,7 @@ module Jennifer
         destroy(ids.to_a)
       end
 
-      # ditto
+      # :ditto:
       def self.destroy(ids : Array)
         _ids = ids
         all.where do
@@ -551,7 +551,7 @@ module Jennifer
         delete(ids.to_a)
       end
 
-      # ditto
+      # :ditto:
       def self.delete(ids : Array)
         _ids = ids
         all.where do

--- a/src/jennifer/model/mapping.cr
+++ b/src/jennifer/model/mapping.cr
@@ -516,7 +516,7 @@ module Jennifer
         draw_mapping({{strict}})
       end
 
-      # ditto
+      # :ditto:
       macro mapping(**properties)
         {% if properties.size > 0 %}
           mapping({{properties}})

--- a/src/jennifer/model/resource.cr
+++ b/src/jennifer/model/resource.cr
@@ -220,12 +220,12 @@ module Jennifer
         new(values)
       end
 
-      # ditto
+      # :ditto:
       def self.build(values : Hash(String, ::Jennifer::DBAny))
         new(values)
       end
 
-      # ditto
+      # :ditto:
       def self.build(**values)
         new(values)
       end
@@ -309,6 +309,11 @@ module Jennifer
         tree = with ac.expression_builder yield ac.expression_builder
         ac.set_tree(tree)
         ac
+      end
+
+      # :ditto:
+      def self.where(conditions : Hash(Symbol, _))
+        all.where(conditions)
       end
 
       # Starts database transaction.

--- a/src/jennifer/model/timestamp.cr
+++ b/src/jennifer/model/timestamp.cr
@@ -29,13 +29,9 @@ module Jennifer::Model
       {% end %}
 
       def track_timestamps_on_create
-        {% if updated_at %}
-        self.updated_at =
-        {% end %}
-        {% if created_at %}
-          self.created_at =
-        {% end %}
-            Time.local(Jennifer::Config.local_time_zone)
+        {% if updated_at %}self.updated_at ={% end %}
+        {% if created_at %}self.created_at ={% end %}
+          Time.local(Jennifer::Config.local_time_zone)
       end
     end
   end

--- a/src/jennifer/query_builder/criteria.cr
+++ b/src/jennifer/query_builder/criteria.cr
@@ -67,10 +67,22 @@ module Jennifer
       end
 
       def ==(value : Symbol)
-        self.==(value.to_s)
+        equal(value.to_s)
       end
 
       def ==(value : Rightable)
+        equal(value)
+      end
+
+      def !=(value : Symbol)
+        not_equal(value.to_s)
+      end
+
+      def !=(value : Rightable)
+        not_equal(value)
+      end
+
+      def equal(value : Rightable)
         # NOTE: here crystal improperly resolves override methods with Nil argument
         if !value.nil?
           Condition.new(self, :==, value)
@@ -79,15 +91,7 @@ module Jennifer
         end
       end
 
-      def !=(value : Symbol)
-        self.!=(value.to_s)
-      end
-
-      def !=(value : Nil)
-        not(value)
-      end
-
-      def !=(value : Rightable)
+      def not_equal(value)
         # NOTE: here crystal improperly resolves override methods with Nil argument
         if !value.nil?
           Condition.new(self, :!=, value)

--- a/src/jennifer/query_builder/executables.cr
+++ b/src/jennifer/query_builder/executables.cr
@@ -255,7 +255,7 @@ module Jennifer
         end
       end
 
-      # ditto
+      # :ditto:
       def decrement(**fields)
         decrement(fields.to_h)
       end

--- a/src/jennifer/query_builder/expression_builder.cr
+++ b/src/jennifer/query_builder/expression_builder.cr
@@ -68,7 +68,7 @@ module Jennifer
         RawSql.new(query, args, use_brackets)
       end
 
-      # ditto
+      # :ditto:
       def sql(query : String, use_brackets : Bool = true)
         RawSql.new(query, use_brackets)
       end
@@ -177,6 +177,25 @@ module Jennifer
         )
       end
 
+      # Combines given array of conditions by `AND` operator.
+      #
+      # All given conditions will be wrapped in `Grouping`.
+      #
+      # ```
+      # User.all.where { and([_name.like("%on"), _age > 3]) }
+      # # WHERE (users.name LIKE '%on' AND users.age > 3)
+      # ```
+      def and(conditions : Array)
+        case conditions.size
+        when 0
+          raise ArgumentError.new("#and can't accept 0 conditions")
+        when 1
+          conditions[0]
+        else
+          g(conditions[2..-1].reduce(conditions[0] & conditions[1]) { |sum, e| sum & e })
+        end
+      end
+
       # Combines given *first_condition*, *second_condition* and all other *conditions* by `OR` operator.
       #
       # All given conditions will be wrapped in `Grouping`.
@@ -189,6 +208,25 @@ module Jennifer
         g(conditions.reduce(first_condition | second_condition) { |sum, e| sum | e })
       end
 
+      # Combines given array of conditions by `OR` operator.
+      #
+      # All given conditions will be wrapped in `Grouping`.
+      #
+      # ```
+      # User.all.where { or([_name.like("%on"), _age > 3]) }
+      # # WHERE (users.name LIKE '%on' OR users.age > 3)
+      # ```
+      def or(conditions : Array)
+        case conditions.size
+        when 0
+          raise ArgumentError.new("#or can't accept 0 conditions")
+        when 1
+          conditions[0]
+        else
+          g(conditions[2..-1].reduce(conditions[0] | conditions[1]) { |sum, e| sum | e })
+        end
+      end
+
       # Combines given *first_condition*, *second_condition* and all other *conditions* by `XOR` operator.
       #
       # All given conditions will be wrapped in `Grouping`.
@@ -198,9 +236,26 @@ module Jennifer
       # # => WHERE (users.name LIKE '%on' XOR users.age > 3)
       # ```
       def xor(first_condition, second_condition, *conditions)
-        g(
-          conditions.reduce(first_condition.xor second_condition) { |sum, e| sum.xor e }
-        )
+        g(conditions.reduce(first_condition.xor second_condition) { |sum, e| sum.xor(e) })
+      end
+
+      # Combines given array of conditions by `XOR` operator.
+      #
+      # All given conditions will be wrapped in `Grouping`.
+      #
+      # ```
+      # User.all.where { xor([_name.like("%on"), _age > 3]) }
+      # # WHERE (users.name LIKE '%on' XOR users.age > 3)
+      # ```
+      def xor(conditions : Array)
+        case conditions.size
+        when 0
+          raise ArgumentError.new("#xor can't accept 0 conditions")
+        when 1
+          conditions[0]
+        else
+          g(conditions[2..-1].reduce(conditions[0].xor(conditions[1])) { |sum, e| sum.xor(e) })
+        end
       end
 
       macro method_missing(call)

--- a/src/jennifer/query_builder/i_model_query.cr
+++ b/src/jennifer/query_builder/i_model_query.cr
@@ -107,7 +107,7 @@ module Jennifer
         find_each(&.update(options))
       end
 
-      # ditto
+      # :ditto:
       def patch(**opts)
         patch(opts)
       end
@@ -124,7 +124,7 @@ module Jennifer
         find_each(&.update!(options))
       end
 
-      # ditto
+      # :ditto:
       def patch!(**opts)
         patch!(opts)
       end

--- a/src/jennifer/query_builder/query.cr
+++ b/src/jennifer/query_builder/query.cr
@@ -314,6 +314,20 @@ module Jennifer
         self
       end
 
+      # Mutates query by given conditions.
+      #
+      # All key-value pairs are treated as a sequence of equal conditions
+      #
+      # ```
+      # Jennifer::Query["contacts"].where({:name => "test", :age => 23})
+      # # SELECT contacts.* FROM contacts WHERE (contacts.name = 'test' AND contacts.age = 23)
+      # ```
+      def where(conditions : Hash(Symbol, _))
+        array = conditions.map { |field, value| @expression.c(field.to_s).equal(value) }
+        set_tree(@expression.and(array))
+        self
+      end
+
       # Specifies raw SELECT clause value.
       #
       # ```
@@ -569,17 +583,17 @@ module Jennifer
         self
       end
 
-      # ditto
+      # :ditto:
       def set_tree(other : Query)
         set_tree(other.tree)
       end
 
-      # ditto
+      # :ditto:
       def set_tree(other : SQLNode)
         set_tree(other.to_condition)
       end
 
-      # ditto
+      # :ditto:
       def set_tree(other : Nil)
         raise ArgumentError.new("Condition tree can't be blank.")
       end

--- a/src/jennifer/view/base.cr
+++ b/src/jennifer/view/base.cr
@@ -54,7 +54,7 @@ module Jennifer
         new(pull)
       end
 
-      # ditto
+      # :ditto:
       def self.build(values : Hash | NamedTuple, new_record : Bool)
         build(values)
       end


### PR DESCRIPTION
# What does this PR do?

Introduces `#where` query method that accepts hash with keys representing table columns and values representing desired values. Currently it accepts only Symbols as key type to prevent SQL injection until we add table column quoting.

# Any background context you want to provide?

Thanks @huuhait for initial work in #317. 

# Release notes

**QueryBuilder**

* add `#where` accepting `Hash(Symbol, _)`
* add `Criteria#equal` and `Criteria#not_equal` as original implementation of `Criteria#==` and `Criteria#!=`
* add `ExpressionBuilder` `#and`, `#or` and `#xor` methods that accepts array of conditions

**Model**

* add `Resource.where` accepting `Hash(Symbol, _)`