### PR TITLE
Extend #pluck to accept splatted named tuple

### DIFF
--- a/docs/crud.md
+++ b/docs/crud.md
@@ -35,7 +35,7 @@ Object could be retrieved by id using `#find` (returns `T?`) and `#find!` (retur
 Contact.find!(1)
 ```
 
-Also there is flexible DSL for building queries.
+Also there is flexible DSL for building queries. To check out other supported methods see [query SQL](./query_dsl.md) section.
 
 To reload all fields from db use `#reload`
 

--- a/docs/query_dsl.md
+++ b/docs/query_dsl.md
@@ -213,15 +213,15 @@ They allows pass argument (tuple, named tuple or hash - depending on context) of
 
 ## SELECT
 
-Raw SQL for `SELECT` clause could be passed into `#select` method. This have highest priority during forming this query part.
+Raw SQL for `SELECT` clause could be passed into `#select` method. This have the highest priority during `SELECT` clause composing  of SQL request.
 
 ```crystal
 Contact
   .all
-  .select("COUNT(id) as count, contacts.name")
+  .select("COUNT(id) AS count")
   .group("name")
   .having { sql("COUNT(id)") > 1 }
-  .pluck(:name)
+  .pluck(:count)
 ```
 
 Also `#select` accepts block where all fields could be specified and aliased:
@@ -229,10 +229,13 @@ Also `#select` accepts block where all fields could be specified and aliased:
 ```crystal
 Contact
   .all
-  .select { [sql("COUNT(id)").alias("count"), _name] }
+  .select { [sql("COUNT(id)").alias("count")] }
   .group("name")
-  .having { sql("count") > 1 }.pluck(:name)
+  .having { sql("count") > 1 }
+  .pluck(:count)
 ```
+
+It is important to note that currently it is impossible to pass `Jennifer::QueryBuilder::Condition` to `#select`. In other words `Contact.all.select { [(_age * 2).alias("age")] }` isn't allowed. As a workaround you can temporary use `#sql`: `Contact.all.select { [sql("age * 2").alias("age")] }`.
 
 ## JOIN
 

--- a/src/jennifer/adapter/base_sql_generator.cr
+++ b/src/jennifer/adapter/base_sql_generator.cr
@@ -59,7 +59,7 @@ module Jennifer
       end
 
       # Generates common select SQL request
-      def self.select(query, exact_fields = [] of String)
+      def self.select(query, exact_fields : Array = [] of String)
         String.build do |s|
           with_clause(s, query)
           select_clause(s, query, exact_fields)
@@ -165,15 +165,15 @@ module Jennifer
       def self.select_clause(io : String::Builder, query, exact_fields : Array = [] of String)
         io << "SELECT "
         io << "DISTINCT " if query._distinct
-        if !query._raw_select
-          table = query._table
-          if !exact_fields.empty?
-            exact_fields.join(io, ", ") { |f| io << "#{table}.#{f}" }
-          else
-            query._select_fields.join(io, ", ") { |f| io << f.definition(self) }
-          end
-        else
+        if query._raw_select
           io << query._raw_select.not_nil!
+        else
+          table = query._table
+          if exact_fields.empty? || !query._select_fields!.empty?
+            query._select_fields.join(io, ", ") { |f| io << f.definition(self) }
+          else
+            exact_fields.join(io, ", ") { |f| io << "#{table}.#{f}" }
+          end
         end
         io << ' '
       end

--- a/src/jennifer/query_builder/criteria.cr
+++ b/src/jennifer/query_builder/criteria.cr
@@ -39,6 +39,9 @@ module Jennifer
         @relation = nil
       end
 
+      # Specifies identifier alias
+      #
+      # `nil` value disable alias.
       def alias(name : String?)
         @alias = name
         self

--- a/src/jennifer/query_builder/executables.cr
+++ b/src/jennifer/query_builder/executables.cr
@@ -91,6 +91,27 @@ module Jennifer
         read_adapter.pluck(self, field.to_s)
       end
 
+      def pluck(**types : **T) forall T
+        {% begin %}
+          if do_nothing?
+            return [] of {
+              {% for name, type in T %}
+                {{name}}: {{type.instance}},
+              {% end %}
+            }
+          end
+
+          read_adapter.pluck(self, types.keys.to_a.map(&.to_s)).map do |record|
+            {
+              {% index = -1 %}
+              {% for name, type in T %}
+                {{name}}: record[{{index += 1}}].as({{type.instance}}),
+              {% end %}
+            }
+          end
+        {% end %}
+      end
+
       # Delete all records which satisfy given conditions.
       #
       # No model callbacks or validation will be executed.


### PR DESCRIPTION
# What does this PR do?

Extend `Query#pluck` so it is possible to select only desired attributes from a database without a need to cast values later in the code.

# Release notes

**QueryBuilder**

* `#pluck` accepts splatted named tuple of desired attribute-type pairs and returns array of such tuples as a records 

**SqlGenerator**

* `.select_clause`  uses specified query attributes to select and fall back to custom fields only if there is no custom attribute to select
