### PR TITLE
Allow to set custom values for created_at and updated_at

### DIFF
--- a/spec/model/timestamp_spec.cr
+++ b/spec/model/timestamp_spec.cr
@@ -27,6 +27,24 @@ describe Jennifer::Model::Timestamp do
     c.updated_at.should eq(c.created_at)
   end
 
+  it "allows to set custom created_at and updated_at on object creation" do
+    c = Factory.build_contact
+    time = Time.local(2020, 10, 11, 12, location: Jennifer::Config.local_time_zone)
+    c.updated_at = c.created_at = time
+    c.save!
+    c.reload.created_at.should eq(time)
+    c.updated_at.should eq(time)
+  end
+
+  it "allows to set custom value for updated_at on update" do
+    c = Factory.create_contact
+    time = Time.local(2020, 10, 11, 12, location: Jennifer::Config.local_time_zone)
+    c.updated_at = time
+    c.name = "new name"
+    c.save!
+    c.reload.updated_at.should eq(time)
+  end
+
   pending "when created_at is disabled"
   pending "when updated_at is disabled"
 end

--- a/src/jennifer/model/timestamp.cr
+++ b/src/jennifer/model/timestamp.cr
@@ -24,14 +24,14 @@ module Jennifer::Model
     macro with_timestamps(created_at = true, updated_at = true)
       {% if updated_at %}
         def track_timestamps_on_update
-          self.updated_at = Time.local(Jennifer::Config.local_time_zone)
+          self.updated_at = Time.local(Jennifer::Config.local_time_zone) unless updated_at_changed?
         end
       {% end %}
 
       def track_timestamps_on_create
-        {% if updated_at %}self.updated_at ={% end %}
-        {% if created_at %}self.created_at ={% end %}
-          Time.local(Jennifer::Config.local_time_zone)
+        current_time = Time.local(Jennifer::Config.local_time_zone)
+        {% if updated_at %}self.updated_at ||= current_time{% end %}
+        {% if created_at %}self.created_at ||= current_time{% end %}
       end
     end
   end


### PR DESCRIPTION
# Release notes

**Model**

* `updated_at` and `created_at` fields aren't override on save if have been set manually 