### PR TITLE
Implement Jennifer::Model::Base::upsert

### DIFF
--- a/scripts/migrations/20210915152208786_add_email_to_contacts.cr
+++ b/scripts/migrations/20210915152208786_add_email_to_contacts.cr
@@ -1,0 +1,15 @@
+class AddEmailToContacts < Jennifer::Migration::Base
+  def up
+    change_table :contacts do |t|
+      t.add_column :email, :string
+      t.add_index :email, :unique
+    end
+  end
+
+  def down
+    change_table :contacts do |t|
+      t.drop_index :email
+      t.drop_column :email
+    end
+  end
+end

--- a/spec/adapter/postgres/sql_generator_spec.cr
+++ b/spec/adapter/postgres/sql_generator_spec.cr
@@ -62,6 +62,13 @@ postgres_only do
       end
     end
 
+    describe "::insert_on_duplicate" do
+      it "do not add on conflict columns if none present" do
+        query = described_class.insert_on_duplicate("contacts", ["field1"], 1, [] of String, {} of Nil => Nil)
+        query.should match(/ON CONFLICT DO NOTHING/)
+      end
+    end
+
     describe ".order_expression" do
       context "with nulls first" do
         it do

--- a/spec/adapter/record_spec.cr
+++ b/spec/adapter/record_spec.cr
@@ -83,6 +83,7 @@ describe Jennifer::Record do
             :updated_at  => record.updated_at,
             :description => nil,
             :user_id     => nil,
+            :email       => nil,
           }
         end,
         postgres: ->do
@@ -97,6 +98,7 @@ describe Jennifer::Record do
             :updated_at  => record.updated_at,
             :description => nil,
             :user_id     => nil,
+            :email       => nil,
           }
         end
       )
@@ -121,6 +123,7 @@ describe Jennifer::Record do
             :updated_at  => record.updated_at,
             :description => nil,
             :user_id     => nil,
+            :email       => nil,
           }
         end,
         postgres: ->do
@@ -134,6 +137,7 @@ describe Jennifer::Record do
             :updated_at  => record.updated_at,
             :description => nil,
             :user_id     => nil,
+            :email       => nil,
           }
         end
       )
@@ -156,6 +160,7 @@ describe Jennifer::Record do
               :updated_at  => record.updated_at,
               :description => nil,
               :user_id     => nil,
+              :email       => nil,
               :custom      => "value",
             }
           end,
@@ -171,6 +176,7 @@ describe Jennifer::Record do
               :updated_at  => record.updated_at,
               :description => nil,
               :user_id     => nil,
+              :email       => nil,
               :custom      => "value",
             }
           end
@@ -203,6 +209,7 @@ describe Jennifer::Record do
               :updated_at  => record.updated_at,
               :description => nil,
               :user_id     => nil,
+              :email       => nil,
               :custom      => "value",
             }
           end,
@@ -217,6 +224,7 @@ describe Jennifer::Record do
               :updated_at  => record.updated_at,
               :description => nil,
               :user_id     => nil,
+              :email       => nil,
               :custom      => "value",
             }
           end

--- a/spec/factories.cr
+++ b/spec/factories.cr
@@ -87,6 +87,7 @@ class ContactFactory < Factory::Jennifer::Base
   attr :name, "Deepthi"
   attr :age, 28
   attr :description, nil
+  attr :email, nil
   attr :gender, "male"
 end
 

--- a/spec/model/base_spec.cr
+++ b/spec/model/base_spec.cr
@@ -685,6 +685,19 @@ describe Jennifer::Model::Base do
     end
   end
 
+  describe "::upsert" do
+    it "do nothing on conflict when inserting" do
+      contact = Factory.build_contact
+      contact.description = "unique"
+      contact.save.should be_true
+
+      c = Factory.build_contact(age: 12, description: "unique")
+      Contact.upsert([c])
+      Contact.all.count.should eq(1)
+      Contact.all.first!.age.should_not eq(12)
+    end
+  end
+
   describe "#set_attributes" do
     context "when given attribute exists" do
       it "raises exception if value has wrong type" do

--- a/spec/model/base_spec.cr
+++ b/spec/model/base_spec.cr
@@ -639,7 +639,7 @@ describe Jennifer::Model::Base do
 
   describe "::import" do
     argument_regex = db_specific(mysql: ->{ /\(\?/ }, postgres: ->{ /\(\$\d/ })
-    amount = db_specific(mysql: ->{ 4096 }, postgres: ->{ 3641 })
+    amount = db_specific(mysql: ->{ 3641 }, postgres: ->{ 3277 })
 
     context "with autoincrementable primary key" do
       context "when count of fields doesn't exceed limit" do

--- a/spec/model/mapping_spec.cr
+++ b/spec/model/mapping_spec.cr
@@ -399,8 +399,8 @@ describe Jennifer::Model::Mapping do
     describe "::field_count" do
       it "returns correct number of model fields" do
         proper_count = db_specific(
-          mysql: ->{ 9 },
-          postgres: ->{ 10 }
+          mysql: ->{ 10 },
+          postgres: ->{ 11 }
         )
         Contact.field_count.should eq(proper_count)
       end

--- a/spec/models.cr
+++ b/spec/models.cr
@@ -109,7 +109,8 @@ class Contact < ApplicationRecord
         created_at: Time?,
         updated_at: Time?,
         user_id: Int32?,
-        tags: {type: Array(Int32)?}
+        tags: {type: Array(Int32)?},
+        email: String?
       )
     {% else %}
       mapping(
@@ -121,7 +122,8 @@ class Contact < ApplicationRecord
         description: String?,
         created_at: Time?,
         updated_at: Time?,
-        user_id: Int32?
+        user_id: Int32?,
+        email: String?
       )
     {% end %}
   end

--- a/src/jennifer/adapter/base.cr
+++ b/src/jennifer/adapter/base.cr
@@ -143,6 +143,18 @@ module Jennifer
         end
       end
 
+      def upsert(collection : Array(Model::Base), unique_fields)
+        return collection if collection.empty?
+
+        klass = collection[0].class
+
+        all_arguments_to_insert = collection.map(&.arguments_to_insert)
+        fields = all_arguments_to_insert[0][:fields]
+        values = all_arguments_to_insert.map(&.[:args])
+
+        upsert(klass.table_name, fields, values, unique_fields, {} of Nil => Nil)
+      end
+
       def upsert(table : String, fields : Array(String), values : Array(ArgsType), unique_fields, on_conflict : Hash)
         query = sql_generator.insert_on_duplicate(table, fields, values.size, unique_fields, on_conflict)
         args = [] of DBAny

--- a/src/jennifer/adapter/postgres/sql_generator.cr
+++ b/src/jennifer/adapter/postgres/sql_generator.cr
@@ -64,9 +64,12 @@ module Jennifer
           escaped_row = "(" + escape_string(fields.size) + ")"
           io << ") VALUES "
           rows.times.join(io, ", ") { io << escaped_row }
-          io << " ON CONFLICT ("
-          unique_fields.join(io, ", ") { |field| io << quote_identifier(field) }
-          io << ") "
+          io << " ON CONFLICT "
+          unless unique_fields.empty?
+            io << "("
+            unique_fields.join(io, ", ") { |field| io << quote_identifier(field) }
+            io << ") "
+          end
           if on_conflict.empty?
             io << "DO NOTHING"
           else

--- a/src/jennifer/model/base.cr
+++ b/src/jennifer/model/base.cr
@@ -586,6 +586,23 @@ module Jennifer
         write_adapter.bulk_insert(collection)
       end
 
+      # Performs bulk import of given *collection* while ignoring models that would cause a duplicate value of any `UNIQUE` index on given *unique_fields*.
+      #
+      # Some RDBMS (like MySQL) doesn't require specifying exact constraint to be violated, therefore *unique_fields* argument by default is `[] of String`.
+      #
+      # Any callback is ignored.
+      #
+      # ```
+      # Order.create({:uid => 123})
+      # Order.upsert([
+      #   Order.new({:uid => 123}),
+      #   Order.new({:uid => 321}),
+      # ])
+      # ```
+      def self.upsert(collection : Array(self), unique_fields = [] of String)
+        write_adapter.upsert(collection, unique_fields)
+      end
+
       macro inherited
         ::Jennifer::Model::Validation.inherited_hook
         ::Jennifer::Model::Callback.inherited_hook


### PR DESCRIPTION
# What does this PR do?

This PR exposes the Adapter method `#upsert` to the model class. This makes it possible to call 

```crystal
Order.upsert([Order.new, Order.new])
```

similar to the `#import` method.

This also fixes a SQL Syntax error occurring when generating upsert-SQL for the postgres adapter with an empty `unique_fields`-array.

# Any background context you want to provide?

The feature was discussed in #385.

MySQL does not seem to support passing specific unique fields. Should we add a warning if unique fields were passed in a MySQL environment?

# Release notes

**Model**

* add `upsert` class method to insert multiple models while ignoring conflicts on specified unique fields

**Adapter**

* add a new `upsert` overload that allows passing a collection of `Jennifer::Model::Base`
* fix `insert_on_duplicates` sql generation for postgres adapter if no unique fields given

