### PR TITLE
rework connection query parameter building

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,30 +14,46 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - crystal_version: 1.0.0
+            DB: mysql
+            db_user: root
+            db_password:
+          - crystal_version: 1.0.0
+            DB: postgres
+            db_user: dbuser
+            db_password: dbpassword
           - crystal_version: 1.1.0
+            DB: mysql
+            db_user: root
+            db_password:
+          - crystal_version: 1.1.0
+            DB: postgres
+            db_user: dbuser
+            db_password: dbpassword
+          - crystal_version: 1.2.0
             DB: mysql
             other: INTEGRATION=1
             linter: true
             db_user: root
             db_password:
-          - crystal_version: 1.1.0
+          - crystal_version: 1.2.0
             DB: postgres
             other: INTEGRATION=1
             linter: true
             db_user: dbuser
             db_password: dbpassword
-          - crystal_version: 1.1.0
+          - crystal_version: 1.2.0
             DB: postgres
             mt: true
             db_user: dbuser
             db_password: dbpassword
-          - crystal_version: 1.1.0
+          - crystal_version: 1.2.0
             DB: postgres
             pair: true
             db_user: dbuser
             db_password: dbpassword
             other: PAIR_DB_USER=root PAIR_DB_PASSWORD=
-          - crystal_version: 1.1.0
+          - crystal_version: 1.2.0
             DB: mysql
             pair: true
             db_user: root

--- a/src/jennifer/adapter/base.cr
+++ b/src/jennifer/adapter/base.cr
@@ -27,7 +27,6 @@ module Jennifer
       extend AbstractClassMethods
       include Transactions
       include ResultParsers
-      include RequestMethods
 
       @db : DB::Database?
       getter config : Config
@@ -248,7 +247,7 @@ module Jennifer
           config.host,
           config.port.try(&.>(0)) ? config.port : nil,
           type.db? ? config.db : "",
-          URI.encode(connection_query),
+          connection_query,
           config.user,
           config.password && !config.password.empty? ? config.password : nil
         ).to_s
@@ -351,15 +350,15 @@ module Jennifer
       # private ===========================
 
       private def connection_query
-        String.build do |s|
+        URI::Params.encode(
           {% begin %}
-          [
-            {% for arg in Config::CONNECTION_URI_PARAMS %}
-              "{{arg.id}}=#{config.{{arg.id}}}",
-            {% end %}
-          ].join(s, "&")
+            {
+              {% for arg in Config::CONNECTION_URI_PARAMS %}
+                "{{arg.id}}": config.{{arg.id}}.to_s,
+              {% end %}
+            }
           {% end %}
-        end
+        )
       end
 
       private def model_escaped_bulk_insert(collection : Array, klass, fields : Array)

--- a/src/jennifer/adapter/mysql.cr
+++ b/src/jennifer/adapter/mysql.cr
@@ -8,6 +8,8 @@ require "./mysql/schema_processor"
 module Jennifer
   module Mysql
     class Adapter < Adapter::Base
+      include ::Jennifer::Adapter::RequestMethods
+
       alias EnumType = String
 
       TYPE_TRANSLATIONS = {

--- a/src/jennifer/adapter/postgres.cr
+++ b/src/jennifer/adapter/postgres.cr
@@ -12,6 +12,8 @@ require "./postgres/command_interface"
 module Jennifer
   module Postgres
     class Adapter < Adapter::Base
+      include ::Jennifer::Adapter::RequestMethods
+
       alias EnumType = Bytes
 
       TYPE_TRANSLATIONS = {


### PR DESCRIPTION
# What does this PR do?

Adopt for crystal `1.2.0` crystal

# Release notes

**Adapter**

* fix database connection query arguments building
* each adapter includes `RequestMethods` instead of including it by base adapter class