### PR TITLE
Add generated column support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
         if: ${{ matrix.DB == 'postgres' || matrix.pair }}
         uses: harmon758/postgresql-action@v1
         with:
-          postgresql version: '9.5'
+          postgresql version: '12.0'
           postgresql user: ${{ env.DB_USER }}
           postgresql password: ${{ env.DB_PASSWORD }}
 

--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,6 @@ db-reset:
 
 format:
 	crystal tool format --check -e"./scripts"
+
+format-fix:
+	crystal tool format -e"./scripts"

--- a/docs/model_mapping.md
+++ b/docs/model_mapping.md
@@ -117,7 +117,8 @@ instead of type. Next keys are supported:
 | `:column` | database column name associated with this attribute (default is attribute name) |
 | `:getter` | if getter should be created (default - `true`) |
 | `:setter` | if setter should be created (default - `true`) |
-| `:virtual` | mark field as virtual - will not be stored and retrieved from db |
+| `:virtual` | mark field as virtual - will not be stored and retrieved from DB |
+| `:generated` | field represents generated column (is only read from the DB)
 | `:converter` | class/module/object that is used to serialize/deserialize field |
 | `:auto` | indicate whether primary field is autoincrementable (by default `true` for `Int32` and `Int64`) |
 
@@ -339,7 +340,7 @@ Existing mapping types:
 - `Primary64 = { type: Int64, primary: true }`
 - `Password = { type: String?, virtual: true, setter: false }`
 
-### Virtual attributes
+### Virtual and generated attributes
 
 If you pass `virtual: true` option for some field - it will not be stored to db and tried to be retrieved from there. Such behavior is useful if you have model-level attributes but it is not obvious to store them into db. Such approach allows mass assignment and dynamic get/set based on their name.
 
@@ -363,6 +364,23 @@ end
 
 User.create!(password: "qwe", password_confirmation: "qwe")
 ```
+
+It is important to distinguish between virtual and generated attributes. Generated attributes belongs to the database level (they are created using `GENERATED ALWAYS AS` statements). As their values are handled by database itself we should only read them from database but don't write. To achieve this use `generated: true`.
+
+```crystal
+class User < Jennifer::Model::Base
+  mapping(
+    id: Primary32,
+    first_name: String,
+    last_name: String,
+    full_name: { type: String?, generated: true}
+  )
+end
+```
+
+For convenient `generated: true` doesn't disable setter from being generated, but you can do this explicitly by `setter: false` option.
+
+> Some database versions doesn't support this feature, e.g. `postgresql >= 12.0` starts to supported stored generated columns.
 
 ## Table name
 

--- a/scripts/migrations/20181017202211501_create_column_alias_models.cr
+++ b/scripts/migrations/20181017202211501_create_column_alias_models.cr
@@ -3,6 +3,11 @@ class AddColumnAliasModels20181017202211501 < Jennifer::Migration::Base
     create_table :authors do |t|
       t.string  :first_name,  { :null => false }
       t.string  :last_name,   { :null => false }
+      {% if env("DB") == "postgres" || env("DB") == nil %}
+        t.generated :full_name, :string, "first_name || ' ' || last_name", {:stored => true}
+      {% else %}
+        t.generated :full_name, :string, "CONCAT(first_name, ' ', last_name)", {:stored => true}
+      {% end %}
     end
 
     {% if env("DB") == "postgres" || env("DB") == nil %}

--- a/spec/adapter/base_spec.cr
+++ b/spec/adapter/base_spec.cr
@@ -328,7 +328,7 @@ describe Jennifer::Adapter::Base do
     end
   end
 
-  describe "::join_table_name" do
+  describe ".join_table_name" do
     it "returns join table name in alphabetic order" do
       default_adapter.class.join_table_name("b", "a").should eq("a_b")
     end

--- a/spec/adapter/mysql/sql_generator_spec.cr
+++ b/spec/adapter/mysql/sql_generator_spec.cr
@@ -25,7 +25,7 @@ mysql_only do
     described_class = Jennifer::Adapter.default_adapter.sql_generator
     adapter = Jennifer::Adapter.default_adapter
 
-    describe "::lock_clause" do
+    describe ".lock_clause" do
       it "render custom query part if specified" do
         query = Contact.all.lock("LOCK IN SHARE MODE")
         sb { |s| described_class.lock_clause(s, query) }.should match(/LOCK IN SHARE MODE/)
@@ -48,7 +48,7 @@ mysql_only do
       end
     end
 
-    describe "::parse_query" do
+    describe ".parse_query" do
       it "replace placeholders with question marks" do
         described_class.parse_query("asd %s qwe %s", [1, 2] of Jennifer::DBAny).should eq({"asd ? qwe ?", [1, 2]})
       end

--- a/spec/adapter/postgres/sql_generator_spec.cr
+++ b/spec/adapter/postgres/sql_generator_spec.cr
@@ -20,7 +20,7 @@ postgres_only do
     described_class = Jennifer::Adapter.default_adapter.sql_generator
     adapter = Jennifer::Adapter.default_adapter
 
-    describe "::lock_clause" do
+    describe ".lock_clause" do
       it "render custom query part if specified" do
         query = Contact.all.lock("FOR NO KEY UPDATE")
         sb { |s| described_class.lock_clause(s, query) }.should match(/FOR NO KEY UPDATE/)
@@ -50,7 +50,7 @@ postgres_only do
       end
     end
 
-    describe "::parse_query" do
+    describe ".parse_query" do
       it "replace placeholders with dollar numbers" do
         described_class.parse_query("asd %s qwe %s", [1, 2] of Jennifer::DBAny).should eq({"asd $1 qwe $2", [1, 2]})
       end
@@ -62,7 +62,7 @@ postgres_only do
       end
     end
 
-    describe "::insert_on_duplicate" do
+    describe ".insert_on_duplicate" do
       it "do not add on conflict columns if none present" do
         query = described_class.insert_on_duplicate("contacts", ["field1"], 1, [] of String, {} of Nil => Nil)
         query.should match(/ON CONFLICT DO NOTHING/)

--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -7,19 +7,19 @@ end
 describe Jennifer::Config do
   described_class = Jennifer::Config
 
-  describe "::read" do
+  describe ".read" do
     it "reads data from yaml file" do
       config.read("./spec/fixtures/database.yml")
       config.db.should eq("jennifer_develop")
     end
 
-    it "" do
+    it do
       config.read("./spec/fixtures/database_with_nesting.yml", &.["database"]["development"])
       config.db.should eq("jennifer_develop")
     end
   end
 
-  describe "::from_uri" do
+  describe ".from_uri" do
     it "should parse uri string" do
       db_uri = "mysql://root:password@somehost:3306/some_database"
       config.from_uri(db_uri)

--- a/spec/model/authentication_spec.cr
+++ b/spec/model/authentication_spec.cr
@@ -27,7 +27,7 @@ describe Jennifer::Model::Authentication do
         end
       end
 
-      describe "::password_digest_cost" do
+      describe ".password_digest_cost" do
         pending { User.password_digest_cost.should eq(Crypto::Bcrypt::DEFAULT_COST) }
       end
 

--- a/spec/model/sti_mapping_spec.cr
+++ b/spec/model/sti_mapping_spec.cr
@@ -41,7 +41,7 @@ describe Jennifer::Model::STIMapping do
       end
     end
 
-    describe "::columns_tuple" do
+    describe ".columns_tuple" do
       it "returns named tuple mith column metedata" do
         metadata = FacebookProfile.columns_tuple
         metadata.is_a?(NamedTuple).should be_true
@@ -185,7 +185,7 @@ describe Jennifer::Model::STIMapping do
     end
   end
 
-  describe "::all" do
+  describe ".all" do
     it "generates correct query" do
       q = FacebookProfile.all
       q.as_sql.should match(/#{reg_quote_identifier("profiles.type")} = %s/)

--- a/spec/models.cr
+++ b/spec/models.cr
@@ -425,9 +425,10 @@ end
 
 class Author < Jennifer::Model::Base
   mapping({
-    id:    Primary32,
-    name1: {type: String, column: :first_name},
-    name2: {type: String, column: :last_name},
+    id:        Primary32,
+    name1:     {type: String, column: :first_name},
+    name2:     {type: String, column: :last_name},
+    full_name: {type: String?, generated: true},
   })
 end
 

--- a/spec/view/base_spec.cr
+++ b/spec/view/base_spec.cr
@@ -10,7 +10,7 @@ describe Jennifer::View::Base do
     end
   end
 
-  describe "::primary" do
+  describe ".primary" do
     it "return criteria with primary key" do
       c = MaleContact.primary
       c.table.should eq("male_contacts")
@@ -18,13 +18,13 @@ describe Jennifer::View::Base do
     end
   end
 
-  describe "::primary_field_name" do
+  describe ".primary_field_name" do
     it "returns name of primary field" do
       MaleContact.primary_field_name.should eq("id")
     end
   end
 
-  describe "::view_name" do
+  describe ".view_name" do
     it "loads from class name automatically" do
       FemaleContact.view_name.should eq("female_contacts")
     end
@@ -34,23 +34,21 @@ describe Jennifer::View::Base do
     end
   end
 
-  describe "::c" do
-    describe "::c" do
-      it "creates criteria with given name" do
-        c = FemaleContact.c("some_field")
-        c.is_a?(Jennifer::QueryBuilder::Criteria)
-        c.field.should eq("some_field")
-        c.table.should eq("female_contacts")
-        c.relation.should be_nil
-      end
+  describe ".c" do
+    it "creates criteria with given name" do
+      c = FemaleContact.c("some_field")
+      c.is_a?(Jennifer::QueryBuilder::Criteria)
+      c.field.should eq("some_field")
+      c.table.should eq("female_contacts")
+      c.relation.should be_nil
+    end
 
-      it "creates criteria with given name and relation" do
-        c = FemaleContact.c("some_field", "some_relation")
-        c.is_a?(Jennifer::QueryBuilder::Criteria)
-        c.field.should eq("some_field")
-        c.table.should eq("female_contacts")
-        c.relation.should eq("some_relation")
-      end
+    it "creates criteria with given name and relation" do
+      c = FemaleContact.c("some_field", "some_relation")
+      c.is_a?(Jennifer::QueryBuilder::Criteria)
+      c.field.should eq("some_field")
+      c.table.should eq("female_contacts")
+      c.relation.should eq("some_relation")
     end
   end
 
@@ -113,26 +111,26 @@ describe Jennifer::View::Base do
     end
   end
 
-  describe "::relations" do
+  describe ".relations" do
     pending "add" do
       # NOTE: now views don't support relations
     end
   end
 
-  describe "::where" do
+  describe ".where" do
     it "returns query" do
       res = MaleContact.where { _id == 1 }
       res.should be_a(::Jennifer::QueryBuilder::ModelQuery(MaleContact))
     end
   end
 
-  describe "::all" do
+  describe ".all" do
     it "returns empty query" do
       MaleContact.all.empty?.should be_true
     end
   end
 
-  describe "::views" do
+  describe ".views" do
     it "returns all model classes" do
       views = Jennifer::View::Base.views
       views.is_a?(Array).should be_true
@@ -145,7 +143,7 @@ describe Jennifer::View::Base do
     end
   end
 
-  describe "::build" do
+  describe ".build" do
     context "strict mapping" do
       it "raises exception if not all fields are described" do
         Factory.create_contact

--- a/spec/view/mapping_spec.cr
+++ b/spec/view/mapping_spec.cr
@@ -55,7 +55,7 @@ describe Jennifer::View::Mapping do
   end
 
   describe "%mapping" do
-    describe "::columns_tuple" do
+    describe ".columns_tuple" do
       it "returns named tuple with column metedata" do
         metadata = MaleContact.columns_tuple
         metadata.is_a?(NamedTuple).should be_true
@@ -88,8 +88,8 @@ describe Jennifer::View::Mapping do
     end
 
     describe "#initialize" do
-      context "from result set" do
-        it "properly creates object" do
+      describe "from result set" do
+        it "creates object" do
           Factory.create_contact(gender: "male", name: "John")
           count = 0
           MaleContact.all.each_result_set do |rs|
@@ -102,8 +102,8 @@ describe Jennifer::View::Mapping do
         end
       end
 
-      context "from result set with mapped columns" do
-        it "properly creates the object" do
+      describe "from result set with mapped columns" do
+        it "creates the object" do
           Article.create(
             name: "ItsNoFunTillSomeoneDies",
             version: 11235,
@@ -125,13 +125,13 @@ describe Jennifer::View::Mapping do
         end
       end
 
-      context "from hash" do
-        it "properly creates object" do
+      describe "from hash" do
+        it "creates object" do
           MaleContact.build({"name" => "Deepthi", "age" => 18, "gender" => "female"})
           MaleContact.build({:name => "Deepthi", :age => 18, :gender => "female"})
         end
 
-        it "properly maps aliased columns" do
+        it "maps aliased columns" do
           PrintPublication.build({
             "title"     => "OverthinkingOveranalying",
             "v"         => 4,
@@ -149,12 +149,12 @@ describe Jennifer::View::Mapping do
         end
       end
 
-      context "from named tuple" do
-        it "properly creates object" do
+      describe "from named tuple" do
+        it "creates object" do
           MaleContact.build({name: "Deepthi", age: 18, gender: "female"})
         end
 
-        it "properly maps aliased columns" do
+        it "maps aliased columns" do
           PrintPublication.build({
             title:     "AndTheWind",
             v:         2,
@@ -166,7 +166,7 @@ describe Jennifer::View::Mapping do
       end
     end
 
-    describe "::field_count" do
+    describe ".field_count" do
       it "returns correct number of model fields" do
         MaleContact.field_count.should eq(5)
       end
@@ -298,7 +298,7 @@ describe Jennifer::View::Mapping do
         end
       end
 
-      describe "::_{{attribute}}" do
+      describe "._{{attribute}}" do
         c = MaleContact._name
         pb = PrintPublication._v
         it { c.table.should eq(MaleContact.view_name) }
@@ -406,7 +406,7 @@ describe Jennifer::View::Mapping do
     end
   end
 
-  describe "::field_names" do
+  describe ".field_names" do
     it "returns array of defined fields" do
       MaleContact.field_names.should eq(%w(id name gender age created_at))
     end

--- a/spec/view/materialized_spec.cr
+++ b/spec/view/materialized_spec.cr
@@ -1,7 +1,7 @@
 require "../spec_helper"
 postgres_only do
   describe Jennifer::View::Materialized do
-    describe "::refresh" do
+    describe ".refresh" do
       it "refreshes view" do
         Factory.create_contact(gender: "female")
         FemaleContact.all.count.should eq(0)

--- a/spec/view/translation_spec.cr
+++ b/spec/view/translation_spec.cr
@@ -3,7 +3,7 @@ require "../spec_helper"
 # View and materialized view localization
 describe Jennifer::Model::Translation do
   describe "View" do
-    describe "::human_attribute_name" do
+    describe ".human_attribute_name" do
       context "when attributes has localication" do
         it { MaleContact.human_attribute_name(:id).should eq("tId") }
       end
@@ -17,19 +17,19 @@ describe Jennifer::Model::Translation do
       end
     end
 
-    describe "::human" do
+    describe ".human" do
       it { MaleContact.human.should eq("tMale contact") }
       it { FakeContactView.human.should eq("Fake contact view") }
     end
   end
 
   describe "Materialized view" do
-    describe "::human_attribute_name" do
-      context "when attributes has localication" do
+    describe ".human_attribute_name" do
+      context "when attributes has localization" do
         it { FemaleContact.human_attribute_name(:id).should eq("tId") }
       end
 
-      context "when attributes have no localication" do
+      context "when attributes have no localization" do
         it { FemaleContact.human_attribute_name(:age).should eq("Age") }
         it { FemaleContact.human_attribute_name(:created_at).should eq("Created at") }
       end
@@ -38,7 +38,7 @@ describe Jennifer::Model::Translation do
       end
     end
 
-    describe "::human" do
+    describe ".human" do
       it { FemaleContact.human.should eq("tFemale contact") }
       it { FakeFemaleContact.human.should eq("Fake female contact") }
     end

--- a/src/jennifer/adapter/mysql/schema_processor.cr
+++ b/src/jennifer/adapter/mysql/schema_processor.cr
@@ -35,6 +35,10 @@ module Jennifer
           end
           io << ") "
         end
+        if options[:generated]?
+          io << " AS (" << options[:as] << ')'
+          io << " STORED" if options[:stored]
+        end
         if options.has_key?(:null)
           io << " NOT" unless options[:null]
           io << " NULL"

--- a/src/jennifer/adapter/postgres/schema_processor.cr
+++ b/src/jennifer/adapter/postgres/schema_processor.cr
@@ -116,6 +116,11 @@ module Jennifer
       private def column_definition(name, options, io)
         io << name
         column_type_definition(options, io)
+        if options[:generated]?
+          raise ArgumentError.new("not stored generated columns are not supported yet") unless options[:stored]
+
+          io << " GENERATED ALWAYS AS (" << options[:as] << ") STORED"
+        end
         if options.has_key?(:null)
           io << " NOT" unless options[:null]
           io << " NULL"

--- a/src/jennifer/migration/table_builder/change_table.cr
+++ b/src/jennifer/migration/table_builder/change_table.cr
@@ -68,19 +68,22 @@ module Jennifer
         #
         # Available options are (none of these exists by default):
         # - `:array` - creates and array of given type;
-        # - `:serial` - makes column `SERIAL`;
-        # - `:sql_type` - allow to specify custom SQL data type;
         # - `:size` - requests a maximum column length; e.g. this is a number of characters in `string` column and
         # number of bytes for `text` or `integer`;
         # - `:null` - allows or disallows `NULL` values;
         # - `:primary` - adds primary key constraint to the column; ATM only one field may be a primary key;
         # - `:default` - the column's default value;
-        # - `:auto_increment` - add autoincrement to the column.
+        # - `:auto_increment` - add autoincrement to the column;
+        # - `:serial` - makes column `SERIAL`;
+        # - `:sql_type` - allow to specify custom SQL data type (use this only when really required);
+        # - `:as` - specify query for generated column;
+        # - `:
         #
         # ```
         # add_column :picture, :blob
         # add_column :status, :string, {:size => 20, :default => "draft", :null => false}
         # add_column :skills, :text, {:array => true}
+        # add_column :full_name, :string, {:generated => true, :as => "CONCAT(first_name, ' ', last_name)"}
         # ```
         def add_column(name : String | Symbol, type : Symbol? = nil,
                        options : Hash(Symbol, AAllowedTypes) = DbOptions.new)

--- a/src/jennifer/migration/table_builder/create_table.cr
+++ b/src/jennifer/migration/table_builder/create_table.cr
@@ -121,6 +121,32 @@ module Jennifer
           timestamp(:updated_at, {:null => null})
         end
 
+        # Defines generated column *name* of *type* type that will use *as_query* expression to generate.
+        #
+        # Supported options:
+        #
+        # * `null` - not null constraint (by default is omitted)
+        # * `stored` - whether column should be stored or generated on the fly (`false` by default)
+        #
+        # ```
+        # create_table :users do |t|
+        #   t.string :first_name
+        #   t.string :last_name
+        #   t.generated :full_name, :string, "first_name || ' ' || last_name", {:stored => true}
+        # end
+        # ```
+        def generated(name : String | Symbol, type : Symbol | String, as_query : String,
+                      options : Hash(Symbol, AAllowedTypes) = DbOptions.new)
+          @fields[name.to_s] = build_column_options(
+            type,
+            ({
+              :stored    => false,
+              :generated => true,
+              :as        => as_query,
+            } of Symbol => AAllowedTypes).merge(options)
+          )
+        end
+
         # Adds index.
         #
         # For more details see `Migration::Base#add_index`.

--- a/src/jennifer/model/base.cr
+++ b/src/jennifer/model/base.cr
@@ -292,7 +292,7 @@ module Jennifer
       abstract def arguments_to_insert
 
       # Hash of changed columns and their new values.
-      abstract def changes : Hash(String, Jennifer::DBAny)
+      abstract def changes_before_typecast : Hash(String, Jennifer::DBAny)
 
       abstract def destroy_without_transaction
 

--- a/src/jennifer/model/optimistic_locking.cr
+++ b/src/jennifer/model/optimistic_locking.cr
@@ -76,7 +76,7 @@ module Jennifer::Model
         this = self
         res = self.class.all
           .where { (this.class.primary == this.primary) & (this.class._lock_version == previous_lock_value) }
-          .update(changes)
+          .update(changes_before_typecast)
         __after_update_callback
         raise ::Jennifer::StaleObjectError.new(self) if !res.nil? && res.rows_affected != 1
 

--- a/src/jennifer/model/sti_mapping.cr
+++ b/src/jennifer/model/sti_mapping.cr
@@ -319,10 +319,10 @@ module Jennifer
         end
 
         # :nodoc:
-        def changes : Hash(String, ::Jennifer::DBAny)
+        def changes_before_typecast : Hash(String, ::Jennifer::DBAny)
           hash = super
           {% for attr, options in properties %}
-            {% unless options[:virtual] %}
+            {% unless options[:virtual] || options[:generated] %}
               hash[{{options[:column]}}] = attribute_before_typecast("{{attr}}") if @{{attr.id}}_changed
             {% end %}
           {% end %}

--- a/src/jennifer/query_builder/query.cr
+++ b/src/jennifer/query_builder/query.cr
@@ -287,8 +287,7 @@ module Jennifer
       end
 
       def empty?
-        @tree.nil? && @limit.nil? && @offset.nil? &&
-          @joins.nil? && @order.nil?
+        @tree.nil? && @limit.nil? && @offset.nil? && @joins.nil? && @order.nil?
       end
 
       # Allows executing a block in the query context.

--- a/src/jennifer/view/base.cr
+++ b/src/jennifer/view/base.cr
@@ -114,8 +114,7 @@ module Jennifer
 
         # :nodoc:
         def self.actual_table_field_count
-          # NOTE: override regular behavior - used fields count instead of
-          # querying db
+          # NOTE: override common behavior
           COLUMNS_METADATA.size
         end
 


### PR DESCRIPTION
# Release notes

**Model**

* rename `#changes` to `#changes_before_typecast`
* add `:generated` option to mapping

**SqlGenerator**

* add generated column support for mysql and postgres adapters

**Migration**

* add `TableBuilder::CreateTable#generated` method to define generated column