### PR TITLE
Add missing port arg. into load_schema cmd

### DIFF
--- a/src/jennifer/adapter/mysql/command_interface.cr
+++ b/src/jennifer/adapter/mysql/command_interface.cr
@@ -17,7 +17,8 @@ module Jennifer
 
       def generate_schema
         options = ["-u", config.user, "--no-data", "-h", config.host, "--skip-lock-tables", config.db]
-        options += ["--password=#{config.password}"] if !config.password.empty?
+        options += ["--port=#{config.port}"]
+        options += ["--password='#{config.password}'"] if !config.password.empty?
         command = Command.new(
           executable: "mysqldump",
           options: options,
@@ -27,8 +28,8 @@ module Jennifer
       end
 
       def load_schema
-        options = ["-u", config.user, "-h", config.host, config.db, "-B", "-s", "-e"]
-        options += ["--password=#{config.password}"] if !config.password.empty?
+        options = ["-u", config.user, "-h", config.host, "-P", "#{config.port}", config.db, "-B", "-s"]
+        options += ["--password='#{config.password}'"] if !config.password.empty?
         command = Command.new(
           executable: "mysql",
           options: options,

--- a/src/jennifer/adapter/mysql/command_interface.cr
+++ b/src/jennifer/adapter/mysql/command_interface.cr
@@ -17,8 +17,8 @@ module Jennifer
 
       def generate_schema
         options = ["-u", config.user, "--no-data", "-h", config.host, "--skip-lock-tables", config.db]
-        options += ["--port=#{config.port}"]
-        options += ["--password='#{config.password}'"] if !config.password.empty?
+        options += ["--password='#{config.password}'"] unless config.password.empty?
+        options += ["--port=#{config.port}"] unless config.port.empty?
         command = Command.new(
           executable: "mysqldump",
           options: options,
@@ -28,8 +28,9 @@ module Jennifer
       end
 
       def load_schema
-        options = ["-u", config.user, "-h", config.host, "-P", "#{config.port}", config.db, "-B", "-s"]
-        options += ["--password='#{config.password}'"] if !config.password.empty?
+        options = ["-u", config.user, "-h", config.host, config.db, "-B", "-s"]
+        options += ["--password='#{config.password}'"] unless config.password.empty?
+        options += ["--port=#{config.port}"] unless config.port.empty?
         command = Command.new(
           executable: "mysql",
           options: options,

--- a/src/jennifer/adapter/mysql/command_interface.cr
+++ b/src/jennifer/adapter/mysql/command_interface.cr
@@ -18,7 +18,7 @@ module Jennifer
       def generate_schema
         options = ["-u", config.user, "--no-data", "-h", config.host, "--skip-lock-tables", config.db]
         options += ["--password='#{config.password}'"] unless config.password.empty?
-        options += ["--port=#{config.port}"] unless config.port.empty?
+        options += ["--port=#{config.port}"] unless config.port.zero?
         command = Command.new(
           executable: "mysqldump",
           options: options,
@@ -30,7 +30,7 @@ module Jennifer
       def load_schema
         options = ["-u", config.user, "-h", config.host, config.db, "-B", "-s"]
         options += ["--password='#{config.password}'"] unless config.password.empty?
-        options += ["--port=#{config.port}"] unless config.port.empty?
+        options += ["--port=#{config.port}"] unless config.port.zero?
         command = Command.new(
           executable: "mysql",
           options: options,

--- a/src/jennifer/adapter/mysql/command_interface.cr
+++ b/src/jennifer/adapter/mysql/command_interface.cr
@@ -18,7 +18,7 @@ module Jennifer
       def generate_schema
         options = ["-u", config.user, "--no-data", "-h", config.host, "--skip-lock-tables", config.db]
         options += ["--password='#{config.password}'"] unless config.password.empty?
-        options += ["--port=#{config.port}"] unless config.port.zero?
+        options += ["--port=#{config.port}"] if config.port > -1
         command = Command.new(
           executable: "mysqldump",
           options: options,
@@ -30,7 +30,7 @@ module Jennifer
       def load_schema
         options = ["-u", config.user, "-h", config.host, config.db, "-B", "-s"]
         options += ["--password='#{config.password}'"] unless config.password.empty?
-        options += ["--port=#{config.port}"] unless config.port.zero?
+        options += ["--port=#{config.port}"] if config.port > -1
         command = Command.new(
           executable: "mysql",
           options: options,


### PR DESCRIPTION
# What does this PR do?
Add the --port argument to mysql command in order to correctly execute the `sam.cr db:schema:load`

# Any background context you want to provide?
In case the DB is not hosted on the default MySQL port (3306) 