### PR TITLE
Add ssl related crystal-pg config options: `auth_methods`, `sslmode`, `sslcert`, `sslkey`, `sslrootcert`

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -105,6 +105,11 @@ Take into account - some configs can't be initialized using URI or yaml file but
 * `pool_size` - count of simultaneously alive database connection; default: `1`
 * `retry_attempts` - count of attempts to connect to the database before raising an exception; default: `1`
 * `retry_delay` - amount of seconds to wait between connection retries; default: `1.0`
+* `auth_methods` - comma separated list of auth methods; optional; default: `""`; available methods: `cleartext,md5,scram-sha-256,scram-sha-256-plus`; `crystal-pg` uses `scram-sha-256-plus,scram-sha-256,md5` if not provided
+* `sslmode` - determines whether or with what priority a secure SSL TCP/IP connection will be negotiated with the server; optional; default `""`; There are six modes: `disable`, `allow`, `prefer`, `require`, `verify-ca`, `verify-full`; `crystal-pg` uses `prefer` if not provided
+* `sslcert` - file path to client SSL certificate; optional; default: `""`
+* `sslkey` - file path to secret key used for the client certificate; optional; default: `""`
+* `sslrootcert` - file path to SSL certificate authority (CA) certificate(s) which is used to verify the server's certificate; optional; default: `""`
 * `checkout_timeout` - amount of seconds to be wait for connection; default: `5.0`
 * `local_time_zone_name` - local time zone name; automatically taken from `Time::Location.local.name`
 * `skip_dumping_schema_sql` - skip dumping database structure if set to `true`; default: `false`

--- a/spec/adapter/base_spec.cr
+++ b/spec/adapter/base_spec.cr
@@ -396,6 +396,64 @@ describe Jennifer::Adapter::Base do
       end
     end
 
+    context "with defined auth_methods" do
+      it "generates proper connection string" do
+        config.port = -1
+        config.password = ""
+        config.auth_methods = "cleartext,md5,scram-sha-256"
+        connection_string = "#{adapter.class.protocol}://#{config.user}@#{config.host}?" \
+                            "max_pool_size=1&initial_pool_size=1&max_idle_pool_size=1&retry_attempts=1&checkout_timeout=5.0&retry_delay=1.0&auth_methods=cleartext%2Cmd5%2Cscram-sha-256"
+        adapter.connection_string(:root).should eq(connection_string)
+      end
+    end
+
+    context "with defined sslmode" do
+      it "generates proper connection string" do
+        config.port = -1
+        config.password = ""
+        config.sslmode = "verify-full"
+        connection_string = "#{adapter.class.protocol}://#{config.user}@#{config.host}?" \
+                            "max_pool_size=1&initial_pool_size=1&max_idle_pool_size=1&retry_attempts=1&checkout_timeout=5.0&retry_delay=1.0&sslmode=verify-full"
+        adapter.connection_string(:root).should eq(connection_string)
+      end
+    end
+
+    context "with defined sslmode and sslcert" do
+      it "generates proper connection string" do
+        config.port = -1
+        config.password = ""
+        config.sslmode = "verify-full"
+        config.sslcert = "/path/to/ssl.crt"
+        connection_string = "#{adapter.class.protocol}://#{config.user}@#{config.host}?" \
+                            "max_pool_size=1&initial_pool_size=1&max_idle_pool_size=1&retry_attempts=1&checkout_timeout=5.0&retry_delay=1.0&sslmode=verify-full&sslcert=%2Fpath%2Fto%2Fssl.crt"
+        adapter.connection_string(:root).should eq(connection_string)
+      end
+    end
+
+    context "with defined sslmode and sslkey" do
+      it "generates proper connection string" do
+        config.port = -1
+        config.password = ""
+        config.sslmode = "verify-full"
+        config.sslkey = "/path/to/ssl.key"
+        connection_string = "#{adapter.class.protocol}://#{config.user}@#{config.host}?" \
+                            "max_pool_size=1&initial_pool_size=1&max_idle_pool_size=1&retry_attempts=1&checkout_timeout=5.0&retry_delay=1.0&sslmode=verify-full&sslkey=%2Fpath%2Fto%2Fssl.key"
+        adapter.connection_string(:root).should eq(connection_string)
+      end
+    end
+
+    context "with defined sslmode and sslrootcert" do
+      it "generates proper connection string" do
+        config.port = -1
+        config.password = ""
+        config.sslmode = "verify-full"
+        config.sslrootcert = "/path/to/sslroot.crt"
+        connection_string = "#{adapter.class.protocol}://#{config.user}@#{config.host}?" \
+                            "max_pool_size=1&initial_pool_size=1&max_idle_pool_size=1&retry_attempts=1&checkout_timeout=5.0&retry_delay=1.0&sslmode=verify-full&sslrootcert=%2Fpath%2Fto%2Fsslroot.crt"
+        adapter.connection_string(:root).should eq(connection_string)
+      end
+    end
+
     context "without password" do
       it do
         config.password = ""

--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -51,7 +51,7 @@ describe Jennifer::Config do
     end
 
     it "should parse connection params from the uri" do
-      db_uri = "mysql://root@somehost/some_database?max_pool_size=111&initial_pool_size=222&max_idle_pool_size=333&retry_attempts=444&checkout_timeout=555&retry_delay=666"
+      db_uri = "mysql://root@somehost/some_database?max_pool_size=111&initial_pool_size=222&max_idle_pool_size=333&retry_attempts=444&checkout_timeout=555&retry_delay=666&auth_methods=cleartext,md5,scram-sha-256&sslmode=verify-full&sslcert=/path/to/ssl.crt&sslkey=/path/to/ssl.key&sslrootcert=/path/to/sslroot.crt"
       config.from_uri(db_uri)
       config.max_pool_size.should eq(111)
       config.initial_pool_size.should eq(222)
@@ -59,6 +59,11 @@ describe Jennifer::Config do
       config.retry_attempts.should eq(444)
       config.checkout_timeout.should eq(555)
       config.retry_delay.should eq(666)
+      config.auth_methods.should eq("cleartext,md5,scram-sha-256")
+      config.sslmode.should eq("verify-full")
+      config.sslcert.should eq("/path/to/ssl.crt")
+      config.sslkey.should eq("/path/to/ssl.key")
+      config.sslrootcert.should eq("/path/to/sslroot.crt")
     end
   end
 end

--- a/src/jennifer/adapter/base.cr
+++ b/src/jennifer/adapter/base.cr
@@ -362,15 +362,13 @@ module Jennifer
       # private ===========================
 
       private def connection_query
-        URI::Params.encode(
+        URI::Params.build do |form|
           {% begin %}
-            {
-              {% for arg in Config::CONNECTION_URI_PARAMS %}
-                "{{arg.id}}": config.{{arg.id}}.to_s,
-              {% end %}
-            }
+            {% for arg in Config::CONNECTION_URI_PARAMS %}
+              form.add("{{arg.id}}", config.{{arg.id}}.to_s) unless config.{{arg.id}}.to_s.empty?
+            {% end %}
           {% end %}
-        )
+        end
       end
 
       private def model_escaped_bulk_insert(collection : Array, klass, fields : Array)

--- a/src/jennifer/config.cr
+++ b/src/jennifer/config.cr
@@ -65,12 +65,13 @@ module Jennifer
     CONNECTION_URI_PARAMS = {
       :max_pool_size, :initial_pool_size, :max_idle_pool_size,
       :retry_attempts, :checkout_timeout, :retry_delay,
+      :auth_methods, :sslmode, :sslcert, :sslkey, :sslrootcert,
     }
     # :nodoc:
     STRING_FIELDS = {
       :user, :password, :db, :host, :adapter, :migration_files_path, :schema,
       :structure_folder, :local_time_zone_name, :command_shell, :docker_container, :docker_source_location,
-      :model_files_path,
+      :model_files_path, :auth_methods, :sslmode, :sslcert, :sslkey, :sslrootcert,
     }
     # :nodoc:
     INT_FIELDS = {:port, :max_pool_size, :initial_pool_size, :max_idle_pool_size, :retry_attempts}
@@ -166,6 +167,12 @@ module Jennifer
 
       @checkout_timeout = 5.0
       @retry_delay = 1.0
+
+      @auth_methods = ""
+      @sslmode = ""
+      @sslcert = ""
+      @sslkey = ""
+      @sslrootcert = ""
 
       @command_shell = "bash"
       @migration_failure_handler_method = MigrationFailureHandler::None

--- a/src/jennifer/config.cr
+++ b/src/jennifer/config.cr
@@ -25,6 +25,11 @@ module Jennifer
   # * `retry_attempts = 1`
   # * `checkout_timeout = 5.0`
   # * `retry_delay = 1.0`
+  # * `auth_methods = ""`
+  # * `sslmode = ""`
+  # * `sslcert = ""`
+  # * `sslkey = ""`
+  # * `sslrootcert = ""`
   # * `local_time_zone_name` default time zone name
   # * `skip_dumping_schema_sql = false`
   # * `command_shell = "bash"`


### PR DESCRIPTION
# What does this PR do?
Add ssl related crystal-pg config options: `auth_methods`, `sslmode`, `sslcert`, `sslkey`, `sslrootcert`
# Any background context you want to provide?
Postgres compatible databases hosted by Azure and CockroachLabs require `cleartext` auth method with ssl verification, but crystal-pg by default does not allow `cleartext`.
One needs to override accepted auth methods with option `auth_methods`.
When `cleartext` auth is used, it's better to fully verify the server's certificate, thus adding several ssl related options.
See related crystal-pg issues:
[#237](https://github.com/will/crystal-pg/issues/237)
[#192](https://github.com/will/crystal-pg/issues/192)
[#220](https://github.com/will/crystal-pg/pull/220)

# Release notes

**Config**

Add `crystal-pg` connection config options `auth_methods`, `sslmode`, `sslcert`, `sslkey`, `sslrootcert`.
