### PR TITLE
Use bigint as primary key of the migration_versions table

### DIFF
--- a/.github/run_integration_tests.sh
+++ b/.github/run_integration_tests.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -exo pipefail
+
+if [ $DB == 'postgres' ]
+then
+  sudo apt-get install postgresql-client -y
+fi
+
+crystal spec spec/integration/sam_test.cr &&
+  crystal spec spec/integration/concurrency_test.cr -Dpreview_mt

--- a/.github/shard_1_3_2.yml
+++ b/.github/shard_1_3_2.yml
@@ -1,3 +1,4 @@
+# NOTE: the only difference from 1.4.1 is missing ameba
 name: jennifer
 version: 0.12.0
 
@@ -21,9 +22,6 @@ development_dependencies:
   sam:
     github: imdrasil/sam.cr
     version: "~> 0.4.1"
-  ameba:
-    github: crystal-ameba/ameba
-    version: "= 1.0.0"
   micrate:
     github: "amberframework/micrate"
     version: "= 0.11.0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,38 +32,44 @@ jobs:
             db_password: dbpassword
           - crystal_version: 1.2.2
             DB: mysql
-            linter: true
             db_user: root
             db_password:
           - crystal_version: 1.2.2
             DB: postgres
-            linter: true
             db_user: dbuser
             db_password: dbpassword
           - crystal_version: 1.3.2
+            DB: mysql
+            db_user: root
+            db_password:
+          - crystal_version: 1.3.2
+            DB: postgres
+            db_user: dbuser
+            db_password: dbpassword
+          - crystal_version: 1.4.1
             DB: mysql
             integration: true
             linter: true
             db_user: root
             db_password:
-          - crystal_version: 1.3.2
+          - crystal_version: 1.4.1
             DB: postgres
             integration: true
             linter: true
             db_user: dbuser
             db_password: dbpassword
-          - crystal_version: 1.3.2
+          - crystal_version: 1.4.1
             DB: postgres
             db_user: dbuser
             db_password: dbpassword
             other: MT=1
-          - crystal_version: 1.3.2
+          - crystal_version: 1.4.1
             DB: postgres
             pair: true
             db_user: dbuser
             db_password: dbpassword
             other: PAIR_DB_USER=root PAIR_DB_PASSWORD=
-          - crystal_version: 1.3.2
+          - crystal_version: 1.4.1
             DB: mysql
             pair: true
             db_user: root
@@ -99,11 +105,16 @@ jobs:
         run: make format
 
       - name: Install dependencies
-        run: shards install
+        run: |
+          function version { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
+          if [ $(version '${{ matrix.crystal_version }}') -lt $(version '1.4.1') ]; then
+            cp .github/shard_1_3_2.yml shard.yml
+          fi
+          shards install
 
       - name: Run linter
         if: ${{ matrix.linter }}
-        run: ./bin/ameba
+        run: make lint
 
       - name: 'Install MySQL'
         if: ${{ matrix.DB == 'mysql' || matrix.pair }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,9 @@ jobs:
             db_password: dbpassword
           - crystal_version: 1.3.2
             DB: postgres
-            mt: true
             db_user: dbuser
             db_password: dbpassword
+            other: MT=1
           - crystal_version: 1.3.2
             DB: postgres
             pair: true
@@ -111,11 +111,11 @@ jobs:
 
       - name: Install PostgreSQL
         if: ${{ matrix.DB == 'postgres' || matrix.pair }}
-        uses: harmon758/postgresql-action@v1
+        uses: Daniel-Marynicz/postgresql-action@master
         with:
-          postgresql version: '12.0'
-          postgresql user: ${{ env.DB_USER }}
-          postgresql password: ${{ env.DB_PASSWORD }}
+          postgres_image_tag: '12'
+          postgres_user: ${{ env.DB_USER }}
+          postgres_password: ${{ env.DB_PASSWORD }}
 
       - name: Create configuration file
         run: bash ./scripts/setup.sh .github/database.yml
@@ -125,7 +125,7 @@ jobs:
 
       - name: Run specs
         run: |
-          if [ "MT" == '1' ]
+          if [ $MT == '1' ]
           then
             crystal spec -Dpreview_mt
           else
@@ -134,6 +134,4 @@ jobs:
 
       - name: Run integration specs
         if: ${{ matrix.integration }}
-        run: |
-          crystal spec spec/integration/sam_test.cr &&
-            crystal spec spec/integration/concurrency_test.cr -Dpreview_mt
+        run: bash .github/run_integration_tests.sh

--- a/Makefile
+++ b/Makefile
@@ -12,5 +12,11 @@ sam:
 db-reset:
 	make sam db:drop @ db:setup
 
+lint:
+	./bin/ameba
+
 format:
 	crystal tool format --check -e"./scripts"
+
+fix-format:
+	crystal tool format -e"./scripts"

--- a/scripts/migrations/20170119011451314_create_contacts.cr
+++ b/scripts/migrations/20170119011451314_create_contacts.cr
@@ -25,6 +25,8 @@ class CreateContacts < Jennifer::Migration::Base
 
   def down
     drop_table :contacts
-    drop_enum(:gender_enum)
+    {% if env("DB") == "postgres" || env("DB") == nil %}
+      drop_enum(:gender_enum)
+    {% end %}
   end
 end

--- a/scripts/migrations/20170407022844409_create_profile.cr
+++ b/scripts/migrations/20170407022844409_create_profile.cr
@@ -1,7 +1,7 @@
 class CreateProfile20170407022844409 < Jennifer::Migration::Base
   def up
     create_table(:profiles) do |t|
-      t.integer :contact_id
+      t.bigint :contact_id
       t.string :type, { :null => false }
       t.string :uid
       t.string :login

--- a/scripts/migrations/20170815112803321_add_model_with_one_field.cr
+++ b/scripts/migrations/20170815112803321_add_model_with_one_field.cr
@@ -1,7 +1,7 @@
 class AddModelWithOneField20170815112803321 < Jennifer::Migration::Base
   def up
     create_table(:one_field_models, false) do |t|
-      t.bigint :id, { :primary => true, :auto_increment => true }
+      t.integer :id, { :primary => true, :auto_increment => true }
     end
   end
 

--- a/scripts/migrations/20180221164419175_add_city.cr
+++ b/scripts/migrations/20180221164419175_add_city.cr
@@ -2,7 +2,7 @@ class AddCity20180221164419175 < Jennifer::Migration::Base
   def up
     create_table :cities do |t|
       t.string :name, { :null => false }
-      t.integer :country_id, { :null => false }
+      t.bigint :country_id, { :null => false }
       t.integer :optimistic_lock, {:default => 0}
     end
   end

--- a/scripts/migrations/20180909200027509_create_notes.cr
+++ b/scripts/migrations/20180909200027509_create_notes.cr
@@ -5,7 +5,7 @@ class CreateNotes < Jennifer::Migration::Base
     create_table :notes do |t|
       t.string :text
 
-      t.integer :notable_id
+      t.bigint :notable_id
       t.string :notable_type
 
       t.timestamps

--- a/spec/factories.cr
+++ b/spec/factories.cr
@@ -77,11 +77,11 @@ end
 
 class ContactFactory < Factory::Jennifer::Base
   postgres_only do
-    argument_type (Array(Int32) | Int32 | PG::Numeric | String?)
+    argument_type(Array(Int32) | Int32 | Int64 | PG::Numeric | String?)
   end
 
   mysql_only do
-    argument_type (Array(Int32) | Int32 | Float64 | String?)
+    argument_type(Array(Int32) | Int32 | Int64 | Float64 | String?)
   end
 
   attr :name, "Deepthi"
@@ -94,13 +94,13 @@ end
 class AddressFactory < Factory::Jennifer::Base
   attr :main, false
   sequence(:street) { |i| "Ant st. #{i}" }
-  attr :contact_id, nil, Int32?
+  attr :contact_id, nil, Int64?
   attr :details, nil, JSON::Any?
 end
 
 class PassportFactory < Factory::Jennifer::Base
   attr :enn, "dsa"
-  attr :contact_id, nil, Int32?
+  attr :contact_id, nil, Int64?
 end
 
 class CountryFactory < Factory::Jennifer::Base
@@ -109,14 +109,14 @@ end
 
 class CityFactory < Factory::Jennifer::Base
   attr :name, "Guda"
-  attr :country_id, ->{ Factory.create_country.id }, Int32
+  attr :country_id, ->{ Factory.create_country.id }, Int64
   attr :optimistic_lock, 0
 end
 
 class ProfileFactory < Factory::Jennifer::Base
   attr :login, "some_login"
   attr :type, Profile.to_s
-  attr :contact_id, nil, Int32?
+  attr :contact_id, nil, Int64?
 end
 
 class FacebookProfileFactory < ProfileFactory
@@ -133,7 +133,7 @@ end
 
 class MaleContactFactory < Factory::Jennifer::Base
   postgres_only do
-    argument_type (Array(Int32) | Int32 | PG::Numeric | String? | Time)
+    argument_type(Array(Int32) | Int32 | Int64 | PG::Numeric | String? | Time)
   end
 
   attr :name, "Raphael"
@@ -150,12 +150,12 @@ class NoteFactory < Factory::Jennifer::Base
   attr :notable_type, nil
 
   trait :with_user do
-    attr :notable_id, ->{ Factory.create_user([:with_valid_password]).id }, Int32
+    attr :notable_id, ->{ Factory.create_user([:with_valid_password]).id }, Int64
     attr :notable_type, "User"
   end
 
   trait :with_contact do
-    attr :notable_id, ->{ Factory.create_contact.id }, Int32
+    attr :notable_id, ->{ Factory.create_contact.id }, Int64
     attr :notable_type, "Contact"
   end
 end

--- a/spec/fixtures/generators/model.cr
+++ b/spec/fixtures/generators/model.cr
@@ -2,7 +2,7 @@ class Article < Jennifer::Model::Base
   with_timestamps
 
   mapping(
-    id: Primary32,
+    id: Primary64,
     title: String,
     text: String?,
     created_at: Time?,

--- a/spec/fixtures/generators/model_with_references.cr
+++ b/spec/fixtures/generators/model_with_references.cr
@@ -2,10 +2,10 @@ class Article < Jennifer::Model::Base
   with_timestamps
 
   mapping(
-    id: Primary32,
+    id: Primary64,
     title: String,
     text: String?,
-    author_id: Int32?,
+    author_id: Int64?,
     created_at: Time?,
     updated_at: Time?,
   )

--- a/spec/generators/field_set_spec.cr
+++ b/spec/generators/field_set_spec.cr
@@ -7,7 +7,7 @@ describe Jennifer::Generators::FieldSet do
   describe ".new" do
     context "without id definition" do
       it do
-        described_class.new(%w(name:string)).id.should eq(field_class.new("id", "integer", true))
+        described_class.new(%w(name:string)).id.should eq(field_class.new("id", "bigint", true))
       end
     end
   end

--- a/spec/generators/field_spec.cr
+++ b/spec/generators/field_spec.cr
@@ -58,7 +58,7 @@ describe Jennifer::Generators::Field do
 
     describe "reference" do
       it do
-        described_class.new("name", "reference", false).cr_type.should eq("Int32?")
+        described_class.new("name", "reference", false).cr_type.should eq("Int64?")
       end
     end
 

--- a/spec/integration/spec_helper.cr
+++ b/spec/integration/spec_helper.cr
@@ -68,7 +68,7 @@ class DatabaseSeeder
   private def self.docker_drop_db_command
     case Spec.adapter
     # when POSTGRES_DB
-    #   "PGPASSWORD=#{password} dropdb #{db} -U#{user}"
+    #   "PGPASSWORD=#{db_password} dropdb #{db} -U#{user}"
     when MYSQL_DB
       common_command = "echo \"drop database #{db};\" | sudo docker exec -i #{DEFAULT_DOCKER_CONTAINER} mysql -u#{db_user}"
       common_command += " -p#{db_password}" unless db_password.empty?
@@ -81,7 +81,7 @@ class DatabaseSeeder
   private def self.bash_drop_db_command
     case Spec.adapter
     when "postgres"
-      "PGPASSWORD=#{db_password} dropdb #{db} -U#{db_user}"
+      "PGPASSWORD=#{db_password} dropdb #{db} -U#{db_user} -hlocalhost"
     when "mysql"
       common_command = "echo \"drop database #{db};\" | mysql -u#{db_user}"
       common_command += " -p#{db_password}" unless db_password.empty?
@@ -107,7 +107,7 @@ class DatabaseSeeder
   private def self.bash_create_db_command
     case Spec.adapter
     when POSTGRES_DB
-      "PGPASSWORD=#{db_password} createdb #{db} -U#{db_user}"
+      "PGPASSWORD=#{db_password} createdb #{db} -U#{db_user} -hlocalhost"
     when MYSQL_DB
       common_command = "mysql -u#{db_user} -e\"create database #{db}\""
       common_command += " -p#{db_password}" unless db_password.empty?

--- a/spec/migration/table_builder/change_table_spec.cr
+++ b/spec/migration/table_builder/change_table_spec.cr
@@ -127,7 +127,7 @@ describe Jennifer::Migration::TableBuilder::ChangeTable do
     it "creates column based on given field" do
       table = change_table_expr
       table.add_reference(:user)
-      table.@new_columns["user_id"].should eq({:type => :integer, :null => true})
+      table.@new_columns["user_id"].should eq({:type => :bigint, :null => true})
 
       command = table.@commands[0].as(Jennifer::Migration::TableBuilder::CreateForeignKey)
       command.from_table.should eq(DEFAULT_TABLE)
@@ -151,7 +151,7 @@ describe Jennifer::Migration::TableBuilder::ChangeTable do
       it "adds foreign and polymorphic columns" do
         table = change_table_expr
         table.add_reference(:user, options: {:polymorphic => true})
-        table.@new_columns["user_id"].should eq({:polymorphic => true, :type => :integer, :null => true})
+        table.@new_columns["user_id"].should eq({:polymorphic => true, :type => :bigint, :null => true})
         table.@new_columns["user_type"].should eq({:type => :string, :null => true})
         table.@commands.should be_empty
       end

--- a/spec/migration/table_builder/create_table_spec.cr
+++ b/spec/migration/table_builder/create_table_spec.cr
@@ -41,7 +41,7 @@ describe Jennifer::Migration::TableBuilder::CreateTable do
     it "creates column based on given field" do
       table = create_table_expr
       table.reference(:user)
-      table.fields["user_id"].should eq({:type => :integer, :null => true})
+      table.fields["user_id"].should eq({:type => :bigint, :null => true})
 
       command = table.@commands[0].as(Jennifer::Migration::TableBuilder::CreateForeignKey)
       command.from_table.should eq(DEFAULT_TABLE)
@@ -55,7 +55,7 @@ describe Jennifer::Migration::TableBuilder::CreateTable do
       it "adds foreign and polymorphic columns" do
         table = create_table_expr
         table.reference(:user, options: {:polymorphic => true})
-        table.fields["user_id"].should eq({:polymorphic => true, :type => :integer, :null => true})
+        table.fields["user_id"].should eq({:polymorphic => true, :type => :bigint, :null => true})
         table.fields["user_type"].should eq({:type => :string, :null => true})
         table.@commands.should be_empty
       end

--- a/spec/model/base_spec.cr
+++ b/spec/model/base_spec.cr
@@ -2,18 +2,18 @@ require "../spec_helper"
 
 class ModelWithIntName < Jennifer::Model::Base
   mapping({
-    id:   Primary32,
+    id:   Primary64,
     name: Int32,
   })
 end
 
 module SomeModule
   class SomeModel < Jennifer::Model::Base
-    mapping(id: Primary32)
+    mapping(id: Primary64)
   end
 
   class AnotherModel < Jennifer::Model::Base
-    mapping(id: Primary32)
+    mapping(id: Primary64)
 
     def self.table_prefix
       "custom_table_prefix_"
@@ -194,7 +194,7 @@ describe Jennifer::Model::Base do
 
     context "with non-auto primary key" do
       it do
-        NoteWithManualId.create(id: 1)
+        NoteWithManualId.create(id: 1) # ?
         NoteWithManualId.all.where { _id == 1 }.exists?.should be_true
       end
     end
@@ -595,7 +595,7 @@ describe Jennifer::Model::Base do
 
   describe "::destroy" do
     it "deletes from db by given ids" do
-      c = [] of Int32?
+      c = [] of Int64?
       3.times { c << Factory.create_contact.id }
       Contact.destroy(c[0..1])
       Contact.all.count.should eq(1)
@@ -611,7 +611,7 @@ describe Jennifer::Model::Base do
 
   describe "::delete" do
     it "deletes from db by given ids" do
-      c = [] of Int32?
+      c = [] of Int64?
       3.times { c << Factory.create_contact.id }
       Contact.delete(c[0..1])
       Contact.all.count.should eq(1)

--- a/spec/model/enum_converter_spec.cr
+++ b/spec/model/enum_converter_spec.cr
@@ -10,7 +10,7 @@ class NoteWithEnumText < Jennifer::Model::Base
   with_timestamps
 
   mapping({
-    id:         Primary32,
+    id:         Primary64,
     text:       {type: Category?, converter: Jennifer::Model::EnumConverter(Category)},
     created_at: Time?,
     updated_at: Time?,

--- a/spec/model/json_serializable_converter_spec.cr
+++ b/spec/model/json_serializable_converter_spec.cr
@@ -19,7 +19,7 @@ class AddressWithSerializable < Jennifer::Model::Base
   with_timestamps
 
   mapping({
-    id:         Primary32,
+    id:         Primary64,
     details:    {type: Location?, converter: Jennifer::Model::JSONSerializableConverter(Location)},
     created_at: Time?,
     updated_at: Time?,

--- a/spec/model/sti_mapping_spec.cr
+++ b/spec/model/sti_mapping_spec.cr
@@ -2,7 +2,7 @@ require "../spec_helper"
 
 class SimplifiedProfile < ApplicationRecord
   mapping({
-    id:   Primary32,
+    id:   Primary64,
     type: String,
   }, false)
 end
@@ -29,8 +29,8 @@ describe Jennifer::Model::STIMapping do
       it "copies data from superclass" do
         id = FacebookProfile::COLUMNS_METADATA[:id]
         id.is_a?(NamedTuple).should be_true
-        id[:type].should eq(Int32)
-        id[:parsed_type].should eq("Int32?")
+        id[:type].should eq(Int64?)
+        id[:parsed_type].should eq("::Union(Int64, ::Nil)")
       end
 
       it "copies column aliases fro superclass" do

--- a/spec/model/validation_spec.cr
+++ b/spec/model/validation_spec.cr
@@ -22,7 +22,7 @@ postgres_only do
     table_name "contacts"
 
     mapping({
-      id:       Primary32,
+      id:       Primary64,
       ballance: {type: BigDecimal, converter: Jennifer::Model::BigDecimalConverter(PG::Numeric), scale: 2},
     }, false)
 
@@ -34,7 +34,7 @@ class GTNContact < Jennifer::Model::Base
   table_name "contacts"
 
   mapping({
-    id:          Primary32,
+    id:          Primary64,
     age:         Int32?,
     validatable: {type: Bool, default: true, virtual: true},
   }, false)
@@ -45,7 +45,7 @@ end
 
 class AcceptanceContact < ApplicationRecord
   mapping({
-    id:               Primary32,
+    id:               Primary64,
     name:             String,
     terms_of_service: {type: Bool, default: false, virtual: true},
     eula:             {type: String?, virtual: true},
@@ -57,7 +57,7 @@ end
 
 class ConfirmationContact < ApplicationRecord
   mapping({
-    id:                                 Primary32,
+    id:                                 Primary64,
     name:                               String?,
     case_insensitive_name:              String?,
     name_confirmation:                  {type: String?, virtual: true},
@@ -70,7 +70,7 @@ end
 
 class PresenceContact < ApplicationRecord
   mapping({
-    id:          Primary32,
+    id:          Primary64,
     name:        String?,
     address:     String?,
     confirmable: {type: Bool, virtual: true, default: true},
@@ -97,7 +97,7 @@ end
 
 class CustomValidatorModel < ApplicationRecord
   mapping({
-    id:   Primary32,
+    id:   Primary64,
     name: String,
   })
 

--- a/spec/models.cr
+++ b/spec/models.cr
@@ -74,7 +74,7 @@ class User < ApplicationRecord
   include Jennifer::Model::Authentication
 
   mapping(
-    id: Primary32,
+    id: Primary64,
     name: String?,
     password_digest: EmptyString,
     email: {type: EmptyString},
@@ -100,7 +100,7 @@ class Contact < ApplicationRecord
 
     {% if env("DB") == "postgres" || env("DB") == nil %}
       mapping(
-        id: Primary32,
+        id: Primary64,
         name: String,
         ballance: PG::Numeric?,
         age: {type: Int32, default: 10},
@@ -108,13 +108,13 @@ class Contact < ApplicationRecord
         description: String?,
         created_at: Time?,
         updated_at: Time?,
-        user_id: Int32?,
+        user_id: Int64?,
         tags: {type: Array(Int32)?},
         email: String?
       )
     {% else %}
       mapping(
-        id: Primary32,
+        id: Primary64,
         name: String,
         ballance: Float64?,
         age: {type: Int32, default: 10},
@@ -122,7 +122,7 @@ class Contact < ApplicationRecord
         description: String?,
         created_at: Time?,
         updated_at: Time?,
-        user_id: Int32?,
+        user_id: Int64?,
         email: String?
       )
     {% end %}
@@ -165,10 +165,10 @@ class Address < Jennifer::Model::Base
   with_timestamps
 
   mapping(
-    id: {type: Int32, primary: true},
+    id: {type: Int64, primary: true},
     main: Bool,
     street: String,
-    contact_id: Int32?,
+    contact_id: Int64?,
     details: JSON::Any?,
     created_at: Time?,
     updated_at: Time?
@@ -196,7 +196,7 @@ end
 class Passport < Jennifer::Model::Base
   mapping(
     enn: {type: String, primary: true},
-    contact_id: Int32?
+    contact_id: Int64?
   )
 
   validates_with EnnValidator
@@ -219,9 +219,9 @@ end
 
 class Profile < ApplicationRecord
   mapping(
-    id: Primary32,
+    id: Primary64,
     login: String,
-    contact_id: Int32?,
+    contact_id: Int64?,
     type: String,
     virtual_parent_field: {type: String?, virtual: true}
   )
@@ -275,7 +275,7 @@ end
 
 class Country < Jennifer::Model::Base
   mapping(
-    id: Primary32,
+    id: Primary64,
     name: String?
   )
 
@@ -301,15 +301,11 @@ class Country < Jennifer::Model::Base
   before_update :test_skip
 
   def test_skip
-    if name == "not create"
-      raise ::Jennifer::Skip.new
-    end
+    raise ::Jennifer::Skip.new if name == "not create"
   end
 
   def before_destroy_check
-    if name == "not kill"
-      errors.add(:name, "Cant destroy")
-    end
+    errors.add(:name, "Cant destroy") if name == "not kill"
     @before_destroy_attr = true
   end
 end
@@ -318,10 +314,10 @@ class City < ApplicationRecord
   with_optimistic_lock :optimistic_lock
 
   mapping(
-    id: Primary32,
+    id: Primary64,
     name: String,
     optimistic_lock: {type: Int32, default: 0},
-    country_id: Int32
+    country_id: Int64
   )
 
   belongs_to :country, Country
@@ -331,9 +327,9 @@ class Note < ApplicationRecord
   module Mapping
     macro included
       mapping(
-        id: Primary32,
+        id: Primary64,
         text: String?,
-        notable_id: Int32?,
+        notable_id: Int64?,
         notable_type: String?,
         created_at: Time?,
         updated_at: Time?
@@ -350,7 +346,7 @@ end
 
 class OneFieldModel < Jennifer::Model::Base
   mapping(
-    id: Primary64
+    id: Primary32
   )
 end
 
@@ -387,7 +383,7 @@ class AllTypeModel < ApplicationRecord
   table_name "all_types"
 
   mapping(
-    id: Primary32,
+    id: Primary64,
     bool_f: Bool?,
     bigint_f: Int64?,
     integer_f: Int32?,
@@ -415,7 +411,7 @@ end
     table_name "addresses"
 
     mapping(
-      id: Primary32,
+      id: Primary64,
       street: String?,
       details: JSON::Any?,
       number: Int32?
@@ -425,7 +421,7 @@ end
 
 class Author < Jennifer::Model::Base
   mapping({
-    id:    Primary32,
+    id:    Primary64,
     name1: {type: String, column: :first_name},
     name2: {type: String, column: :last_name},
   })
@@ -434,7 +430,7 @@ end
 class Publication < Jennifer::Model::Base
   {% if env("DB") == "postgres" || env("DB") == nil %}
     mapping(
-      id: Primary32,
+      id: Primary64,
       name: {type: String, column: :title},
       version: Int32,
       publisher: String,
@@ -442,7 +438,7 @@ class Publication < Jennifer::Model::Base
     )
   {% else %}
     mapping(
-      id: Primary32,
+      id: Primary64,
       name: {type: String, column: :title},
       version: Int32,
       publisher: String,
@@ -478,7 +474,7 @@ class CountryWithTransactionCallbacks < ApplicationRecord
   table_name "countries"
 
   mapping({
-    id:   Primary32,
+    id:   Primary64,
     name: String,
   }, false)
 
@@ -501,7 +497,7 @@ class CountryWithValidationCallbacks < ApplicationRecord
   table_name "countries"
 
   mapping({
-    id:   Primary32,
+    id:   Primary64,
     name: String,
   })
 
@@ -536,7 +532,7 @@ class JohnPassport < Jennifer::Model::Base
 
   mapping(
     enn: {type: String, primary: true},
-    contact_id: Int32?
+    contact_id: Int64?
   )
 
   belongs_to :contact, Contact, {where { _name == "John" }}
@@ -546,7 +542,7 @@ class OneFieldModelWithExtraArgument < Jennifer::Model::Base
   table_name "one_field_models"
 
   mapping(
-    id: Primary64,
+    id: Primary32,
     missing_field: String
   )
 end
@@ -555,7 +551,7 @@ class ContactWithNotAllFields < Jennifer::Model::Base
   table_name "contacts"
 
   mapping(
-    id: Primary32,
+    id: Primary64,
     name: String?,
   )
 end
@@ -564,7 +560,7 @@ class ContactWithNotStrictMapping < Jennifer::Model::Base
   table_name "contacts"
 
   mapping({
-    id:   Primary32,
+    id:   Primary64,
     name: String?,
   }, false)
 end
@@ -574,7 +570,7 @@ class ContactWithDependencies < Jennifer::Model::Base
 
   {% if env("DB") == "postgres" || env("DB") == nil %}
     mapping({
-      id:          Primary32,
+      id:          Primary64,
       name:        String?,
       description: String?,
       age:         {type: Int32, default: 10},
@@ -582,7 +578,7 @@ class ContactWithDependencies < Jennifer::Model::Base
     }, false)
   {% else %}
     mapping({
-      id:          Primary32,
+      id:          Primary64,
       name:        String?,
       description: String?,
       age:         {type: Int32, default: 10},
@@ -603,7 +599,7 @@ end
 class ContactWithCustomField < Jennifer::Model::Base
   table_name "contacts"
   mapping({
-    id:   Primary32,
+    id:   Primary64,
     name: String,
   }, false)
 end
@@ -611,7 +607,7 @@ end
 class ContactWithInValidation < Jennifer::Model::Base
   table_name "contacts"
   mapping({
-    id:   Primary64,
+    id:   Primary32,
     name: String?,
   }, false)
 
@@ -621,7 +617,7 @@ end
 class ContactWithNillableName < Jennifer::Model::Base
   table_name "contacts"
   mapping({
-    id:   Primary32,
+    id:   Primary64,
     name: String?,
   }, false)
 end
@@ -629,7 +625,7 @@ end
 class AbstractContactModel < Jennifer::Model::Base
   table_name "contacts"
   mapping({
-    id:   Primary32,
+    id:   Primary64,
     name: String?,
     age:  Int32,
   }, false)
@@ -640,7 +636,7 @@ end
     table_name "contacts"
 
     mapping({
-      id:       Primary32,
+      id:       Primary64,
       ballance: {type: Float64?, converter: Jennifer::Model::NumericToFloat64Converter},
     }, false)
   end
@@ -648,7 +644,7 @@ end
 
 class CountryWithDefault < Jennifer::Model::Base
   mapping(
-    id: Primary32,
+    id: Primary64,
     virtual: {type: Bool, default: true, virtual: true},
     name: String?
   )
@@ -657,7 +653,7 @@ end
 class NoteWithCallback < ApplicationRecord
   include Note::Mapping
 
-  self.table_name "notes"
+  table_name "notes"
 
   belongs_to :notable, Union(User | FacebookProfileWithDestroyNotable), polymorphic: true
 
@@ -678,9 +674,9 @@ class FacebookProfileWithDestroyNotable < Jennifer::Model::Base
   module Mapping
     macro included
       mapping({
-        id: Primary32,
+        id: Primary64,
         login: String,
-        contact_id: Int32?,
+        contact_id: Int64?,
         type: String,
         uid: String?
     }, false)
@@ -718,7 +714,7 @@ class AddressWithNilableBool < Jennifer::Model::Base
   with_timestamps
 
   mapping({
-    id:   {type: Int32, primary: true},
+    id:   {type: Int64, primary: true},
     main: Bool?,
   }, false)
 end
@@ -728,7 +724,7 @@ class NoteWithManualId < Jennifer::Model::Base
   with_timestamps
 
   mapping(
-    id: {type: Primary32, auto: false},
+    id: {type: Primary64, auto: false},
     text: {type: String?},
     created_at: Time?,
     updated_at: Time?
@@ -738,7 +734,7 @@ end
 class OrderItem < ApplicationRecord
   table_name "all_types"
 
-  mapping(id: Primary32)
+  mapping(id: Primary64)
 end
 
 class PolymorphicNote < ApplicationRecord
@@ -756,7 +752,7 @@ class PolymorphicNoteWithConverter < Jennifer::Model::Base
 
   mapping(
     id: Primary32,
-    notable_id: {type: String, converter: InspectConverter(Int32)},
+    notable_id: {type: String, converter: InspectConverter(Int64)},
     notable_type: {type: String, converter: InspectConverter(String)}
   )
 

--- a/spec/query_builder/executables_spec.cr
+++ b/spec/query_builder/executables_spec.cr
@@ -339,7 +339,7 @@ describe Jennifer::QueryBuilder::Executables do
     it "returns array of ids" do
       id = Factory.create_contact.id
       ids = Contact.all.ids
-      ids.should be_a(Array(Int32))
+      ids.should be_a(Array(Int64))
       ids.should eq([id])
     end
 
@@ -470,9 +470,9 @@ describe Jennifer::QueryBuilder::Executables do
 
         it "use 'start' argument as start primary key value" do
           ids = Factory.create_contact(3).map(&.id)
-          buff = [] of Int32
+          buff = [] of Int64
           query.find_each(pk, 2, ids[1]) do |record|
-            buff << record.id(Int32)
+            buff << record.id(Int64)
           end
           buff.should eq(ids[1..2])
         end

--- a/spec/query_builder/model_query_spec.cr
+++ b/spec/query_builder/model_query_spec.cr
@@ -5,7 +5,7 @@ pair_only do
     table_name "addresses"
 
     mapping({
-      id:      Primary32,
+      id:      Primary64,
       details: JSON::Any?,
       street:  String,
       main:    Bool,
@@ -298,7 +298,7 @@ describe Jennifer::QueryBuilder::ModelQuery do
   describe "#find_each" do
     it "loads each in batches without specifying primary key" do
       ids = Factory.create_contact(3).map(&.id)
-      buff = [] of Int32
+      buff = [] of Int64
       Contact.all.find_each(2, ids[1]) do |record|
         buff << record.id!
       end

--- a/spec/relation/polymorphic_belongs_to_spec.cr
+++ b/spec/relation/polymorphic_belongs_to_spec.cr
@@ -180,7 +180,7 @@ describe Jennifer::Relation::IPolymorphicBelongsTo do
       it "uses attributes before typecast for foreign and type fields" do
         c = Factory.create_contact
         n = PolymorphicNoteWithConverter.new({notable_type: contact_class.to_s, notable_id: c.id})
-        n.notable_id.should eq("Int32: #{c.id}")
+        n.notable_id.should eq("Int64: #{c.id}")
         n.notable_type.should eq("String: #{contact_class}")
 
         count = contact_class.all.count

--- a/spec/view/mapping_spec.cr
+++ b/spec/view/mapping_spec.cr
@@ -4,21 +4,21 @@ class ViewWithArray < Jennifer::View::Base
   view_name "contacts"
 
   mapping({
-    id:   Primary32,
+    id:   Primary64,
     tags: Array(Int32),
   }, false)
 end
 
 class ViewWithBool < Jennifer::View::Base
   mapping({
-    id:   Primary32,
+    id:   Primary64,
     bool: Bool,
   }, false)
 end
 
 class ViewWithNilableBool < Jennifer::View::Base
   mapping({
-    id:   Primary32,
+    id:   Primary64,
     bool: Bool?,
   }, false)
 end
@@ -56,12 +56,12 @@ describe Jennifer::View::Mapping do
 
   describe "%mapping" do
     describe "::columns_tuple" do
-      it "returns named tuple with column metedata" do
+      it "returns named tuple with column metadata" do
         metadata = MaleContact.columns_tuple
         metadata.is_a?(NamedTuple).should be_true
         metadata[:id].is_a?(NamedTuple).should be_true
-        metadata[:id][:type].should eq(Int32)
-        metadata[:id][:parsed_type].should eq("Int32?")
+        metadata[:id][:type].should eq(Int64?)
+        metadata[:id][:parsed_type].should eq("::Union(Int64, ::Nil)")
       end
 
       it "correctly maps column aliases" do

--- a/spec/views.cr
+++ b/spec/views.cr
@@ -9,7 +9,7 @@ end
 
 class FemaleContact < BaseView
   mapping({
-    id:   Primary32,
+    id:   Primary64,
     name: BlankString,
   }, false)
 end
@@ -17,7 +17,7 @@ end
 class MaleContact < Jennifer::View::Base
   {% if env("DB") == "postgres" || env("DB") == nil %}
     mapping({
-      id:         Primary32,
+      id:         Primary64,
       name:       String,
       gender:     {type: String, converter: Jennifer::Model::PgEnumConverter},
       age:        Int32,
@@ -25,7 +25,7 @@ class MaleContact < Jennifer::View::Base
     }, false)
   {% else %}
     mapping({
-      id:         Primary32,
+      id:         Primary64,
       name:       String,
       gender:     String,
       age:        Int32,
@@ -47,7 +47,7 @@ class FakeFemaleContact < Jennifer::View::Base
 
   {% if env("DB") == "postgres" || env("DB") == nil %}
     mapping({
-      id:         Primary32,
+      id:         Primary64,
       name:       String,
       gender:     {type: String, converter: Jennifer::Model::PgEnumConverter},
       age:        Int32,
@@ -55,7 +55,7 @@ class FakeFemaleContact < Jennifer::View::Base
     }, false)
   {% else %}
     mapping({
-      id:         Primary32,
+      id:         Primary64,
       name:       String,
       gender:     String,
       age:        Int32,
@@ -68,7 +68,7 @@ class FakeContactView < Jennifer::View::Base
   view_name "male_contacs"
 
   mapping({
-    id: Primary32,
+    id: Primary64,
   }, false)
 end
 
@@ -76,7 +76,7 @@ class StrictBrokenMaleContact < Jennifer::View::Base
   view_name "male_contacts"
 
   mapping({
-    id:   Primary32,
+    id:   Primary64,
     name: String,
   })
 end
@@ -84,7 +84,7 @@ end
 class StrictMaleContactWithExtraField < Jennifer::View::Base
   view_name "male_contacts"
   mapping({
-    id:            Primary64,
+    id:            Primary32,
     missing_field: String,
   })
 end
@@ -92,7 +92,7 @@ end
 class MaleContactWithDescription < Jennifer::View::Base
   view_name "male_contacts"
   mapping({
-    id:          Primary32,
+    id:          Primary64,
     description: String,
   }, false)
 end
@@ -100,7 +100,7 @@ end
 class PrintPublication < Jennifer::View::Base
   {% if env("DB") == "postgres" || env("DB") == nil %}
     mapping(
-      id: Primary32,
+      id: Primary64,
       title: String,
       v: {type: Int32, column: :version},
       publisher: String,
@@ -110,7 +110,7 @@ class PrintPublication < Jennifer::View::Base
     )
   {% else %}
     mapping(
-      id: Primary32,
+      id: Primary64,
       title: String,
       v: {type: Int32, column: :version},
       publisher: String,

--- a/src/jennifer/adapter/base.cr
+++ b/src/jennifer/adapter/base.cr
@@ -284,7 +284,6 @@ module Jennifer
         return if table_exists?(Migration::Version.table_name)
 
         tb = Migration::TableBuilder::CreateTable.new(self, Migration::Version.table_name)
-        tb.bigint(:id, {:primary => true, :auto_increment => true})
         tb.string(:version, {:size => 17, :null => false})
         tb.process
       end

--- a/src/jennifer/adapter/base.cr
+++ b/src/jennifer/adapter/base.cr
@@ -284,7 +284,7 @@ module Jennifer
         return if table_exists?(Migration::Version.table_name)
 
         tb = Migration::TableBuilder::CreateTable.new(self, Migration::Version.table_name)
-        tb.integer(:id, {:primary => true, :auto_increment => true})
+        tb.bigint(:id, {:primary => true, :auto_increment => true})
         tb.string(:version, {:size => 17, :null => false})
         tb.process
       end

--- a/src/jennifer/generators/field.cr
+++ b/src/jennifer/generators/field.cr
@@ -24,7 +24,7 @@ module Jennifer
 
         "json" => "JSON::Any",
 
-        REFERENCE_TYPE => "Int32",
+        REFERENCE_TYPE => "Int64",
       }
 
       getter name : String, type : String, nilable : Bool

--- a/src/jennifer/generators/field_set.cr
+++ b/src/jennifer/generators/field_set.cr
@@ -10,7 +10,7 @@ module Jennifer
         args.each do |definition|
           @fields << Field.new(*parse_field_definition(definition))
         end
-        @id = @fields.find(&.id?) || Field.new("id", "integer", true)
+        @id = @fields.find(&.id?) || Field.new("id", "bigint", true)
       end
 
       def references

--- a/src/jennifer/macros.cr
+++ b/src/jennifer/macros.cr
@@ -8,14 +8,16 @@ module Jennifer
 
     # Mapping type for `Int32` primary key.
     Primary32 = {
-      type:    Int32,
+      type:    Int32?,
       primary: true,
+      auto:    true,
     }
 
     # Mapping type for `Int64` primary key.
     Primary64 = {
-      type:    Int64,
+      type:    Int64?,
       primary: true,
+      auto:    true,
     }
   end
 end

--- a/src/jennifer/migration/base.cr
+++ b/src/jennifer/migration/base.cr
@@ -226,7 +226,7 @@ module Jennifer
       # For more details about new  table definition see `TableBuilder::CreateTable`.
       def create_table(name : String | Symbol, id : Bool = true)
         tb = TableBuilder::CreateTable.new(adapter, name)
-        tb.integer(:id, {:primary => true, :auto_increment => true}) if id
+        tb.bigint(:id, {:primary => true, :auto_increment => true}) if id
         yield tb
         process_builder(tb)
       end
@@ -241,8 +241,8 @@ module Jennifer
       # ```
       def create_join_table(table1 : String | Symbol, table2 : String | Symbol, table_name : String? = nil)
         create_table(table_name || adapter.class.join_table_name(table1, table2), false) do |tb|
-          tb.integer(Inflector.foreign_key(Inflector.singularize(table1.to_s)))
-          tb.integer(Inflector.foreign_key(Inflector.singularize(table2.to_s)))
+          tb.bigint(Inflector.foreign_key(Inflector.singularize(table1.to_s)))
+          tb.bigint(Inflector.foreign_key(Inflector.singularize(table2.to_s)))
           yield tb
         end
       end

--- a/src/jennifer/migration/runner.cr
+++ b/src/jennifer/migration/runner.cr
@@ -159,7 +159,7 @@ module Jennifer
       private def self.assert_outdated_pending_migrations
         return if !Version.all.exists? || Config.config.allow_outdated_pending_migration
 
-        db_version = Version.all.order(version: :desc).limit(1).pluck(:version)[0].as(String)
+        db_version = Version.all.order(version: :desc).first!.version
         broken = pending_versions.select { |version| version < db_version }
         return if broken.empty?
 

--- a/src/jennifer/migration/table_builder/change_table.cr
+++ b/src/jennifer/migration/table_builder/change_table.cr
@@ -96,7 +96,7 @@ module Jennifer
 
         # Adds a reference.
         #
-        # The reference column is an `integer` by default, *type* argument can be used to specify a different type.
+        # The reference column is an `bigint` by default, *type* argument can be used to specify a different type.
         #
         # If *polymorphic* option is `true` - additional string field `"#{name}_type"` is created and foreign key is
         # not added.
@@ -106,10 +106,10 @@ module Jennifer
         #
         # ```
         # add_reference :user
-        # add_reference :order, :bigint
+        # add_reference :order, :integer
         # add_reference :taggable, {:polymorphic => true}
         # ```
-        def add_reference(name, type : Symbol = :integer, options : Hash(Symbol, AAllowedTypes) = DbOptions.new)
+        def add_reference(name, type : Symbol = :bigint, options : Hash(Symbol, AAllowedTypes) = DbOptions.new)
           column = Inflector.foreign_key(name)
           is_null = options.has_key?(:null) ? options[:null] : true
           field_internal_type = options.has_key?(:sql_type) ? nil : type

--- a/src/jennifer/migration/table_builder/create_table.cr
+++ b/src/jennifer/migration/table_builder/create_table.cr
@@ -77,7 +77,7 @@ module Jennifer
 
         # Adds a reference.
         #
-        # The reference column is an `integer` by default, *type* argument can be used to specify a different type.
+        # The reference column is an `bigint` by default, *type* argument can be used to specify a different type.
         #
         # If *polymorphic* option is `true` - additional string field `"#{name}_type"` is created and foreign key is
         # not added.
@@ -87,10 +87,10 @@ module Jennifer
         #
         # ```
         # reference :user
-        # reference :order, :bigint
+        # reference :order, :integer
         # reference :taggable, {:polymorphic => true}
         # ```
-        def reference(name, type : Symbol = :integer, options : Hash(Symbol, AAllowedTypes) = DbOptions.new)
+        def reference(name, type : Symbol = :bigint, options : Hash(Symbol, AAllowedTypes) = DbOptions.new)
           column = Inflector.foreign_key(name)
           is_null = options.has_key?(:null) ? options[:null] : true
 

--- a/src/jennifer/migration/version.cr
+++ b/src/jennifer/migration/version.cr
@@ -5,7 +5,7 @@ module Jennifer
       table_name "migration_versions"
 
       mapping(
-        id: Primary32,
+        id: Primary64,
         version: String
       )
 

--- a/src/jennifer/migration/version.cr
+++ b/src/jennifer/migration/version.cr
@@ -4,10 +4,9 @@ module Jennifer
     class Version < Model::Base
       table_name "migration_versions"
 
-      mapping(
-        id: Primary64,
-        version: String
-      )
+      mapping({
+        version: {type: String, primary: true, auto: false, null: false},
+      }, false)
 
       def self.has_table?
         false

--- a/src/jennifer/model/common_mapping.cr
+++ b/src/jennifer/model/common_mapping.cr
@@ -5,7 +5,11 @@ module Jennifer::Model
     macro common_mapping(strict)
       {%
         primary = COLUMNS_METADATA.keys.find { |field| COLUMNS_METADATA[field][:primary] }
-        primary_auto_incrementable = primary && AUTOINCREMENTABLE_STR_TYPES.includes?(COLUMNS_METADATA[primary][:type].stringify)
+        primary_auto_incrementable = false
+        if primary
+          primary_options = COLUMNS_METADATA[primary]
+          primary_auto_incrementable = AUTOINCREMENTABLE_STR_TYPES.any? { |type| primary_options[:parsed_type].includes?(type) }
+        end
         properties = COLUMNS_METADATA
         nonvirtual_attrs = properties.keys.select { |attr| !properties[attr][:virtual] }
       %}

--- a/src/jennifer/model/field_declaration.cr
+++ b/src/jennifer/model/field_declaration.cr
@@ -30,10 +30,16 @@ module Jennifer::Model
             self.{{key.id}} = _{{key.id}}.as({{value[:parsed_type].id}})
           end
 
-          {% unless value[:parsed_type] =~ /String/ %}
+          {% if !value[:parsed_type].includes?("String") %}
             def {{key.id}}=(_{{key.id}} : String)
               self.{{key.id}} = self.class.coerce_{{key.id}}(_{{key.id}})
             end
+
+            {% if value[:parsed_type].includes?("Int64") %}
+              def {{key.id}}=(_{{key.id}} : Int32)
+                self.{{key.id}} = _{{key.id}}.to_i64
+              end
+            {% end %}
           {% end %}
         {% end %}
 
@@ -83,13 +89,13 @@ module Jennifer::Model
               "{{key.id}}"
             end
 
-            # :nodoc:
-            def init_primary_field(value : Int)
-              {% if primary_auto_incrementable %}
+            {% if primary_auto_incrementable %}
+              # :nodoc:
+              def init_primary_field(value : Int)
                 raise ::Jennifer::AlreadyInitialized.new(@{{key.id}}, value) if @{{key.id}}
                 @{{key.id}} = value{% if value[:parsed_type] =~ /32/ %}.to_i{% else %}.to_i64{% end %}
-              {% end %}
-            end
+              end
+            {% end %}
 
             # :nodoc:
             def init_primary_field(value); end

--- a/src/jennifer/model/sti_mapping.cr
+++ b/src/jennifer/model/sti_mapping.cr
@@ -27,7 +27,7 @@ module Jennifer
             super_properties.keys.all? do |field|
               options = super_properties[field]
 
-              options[:primary] || options[:null] || options.keys.includes?(:default.id) || field == :type
+              options[:null] || options.keys.includes?(:default.id) || field == :type
             end &&
               COLUMNS_METADATA.keys.all? do |field|
                 options = COLUMNS_METADATA[field]

--- a/src/jennifer/query_builder/executables.cr
+++ b/src/jennifer/query_builder/executables.cr
@@ -313,9 +313,9 @@ module Jennifer
 
       # Returns array of record ids.
       #
-      # This method requires model to have field `id : Int32`.
+      # This method requires model to have field named `id` with type `Int64`.
       def ids
-        pluck(:id).map(&.as(Int32))
+        pluck(:id).map(&.as(Int64))
       end
 
       # Yields each matched record to a block.

--- a/src/jennifer/query_builder/i_model_query.cr
+++ b/src/jennifer/query_builder/i_model_query.cr
@@ -8,7 +8,7 @@ module Jennifer
 
       private delegate :write_adapter, :read_adapter, to: model_class
 
-      # NOTE: improperly detects source of #abstract_class if run sam with only Version model
+      # NOTE: improperly detects source of #abstract_class if run Sam with only Version model
       def model_class
         raise AbstractMethod.new(:model_class, {{@type}})
       end


### PR DESCRIPTION
# What does this PR do?
Change the type of `id` column of `migration_versions` to `Int64/bigint` from `Int32/int`

# Any background context you want to provide?
https://github.com/imdrasil/jennifer.cr/issues/398

# Release notes

**Model**

* change default `id` attribute type from `Int32` to `Int64`
* generate a setter method for a `Int64` attribute that calls `#to_i64` on `Int32` value
* in mapping automatically assign `null: true` if `null` property is missing and field is primary
* enhance type coercion on initializing instance from hash
* change return type of `.ids` to `Array(Int64)`

**Adapter**

* remove `id` column from the `versions` table schema
* change default `id` column type from `int` to `bigint`