### PR TITLE
Count returns Int64 and offset accepts Int32 or Int64

### DIFF
--- a/docs/pagination_and_ordering.md
+++ b/docs/pagination_and_ordering.md
@@ -3,9 +3,12 @@
 ## Pagination
 
 For now you can only specify `limit` and `offset`:
+`limit` only accepts an Int32 while you can pass an Int32 or Int64 number to the `offset`.
 
 ```crystal
 Contact.all.limit(10).offset(10)
+# Or an offset in Int64
+Contact.all.limit(10).offset(10_i64)
 ```
 
 ## Order

--- a/src/jennifer/adapter/base.cr
+++ b/src/jennifer/adapter/base.cr
@@ -111,7 +111,7 @@ module Jennifer
       end
 
       def count(query : QueryBuilder::Query)
-        scalar(*parse_query(sql_generator.count(query), query.sql_args)).as(Int64).to_i
+        scalar(*parse_query(sql_generator.count(query), query.sql_args)).as(Int64)
       end
 
       def bulk_insert(collection : Array(Model::Base))

--- a/src/jennifer/model/base.cr
+++ b/src/jennifer/model/base.cr
@@ -82,7 +82,7 @@ module Jennifer
       # If somewhy you define model with custom table name after the place where adapter is used the first time -
       # manually invoke this method anywhere after table name definition.
       def self.actual_table_field_count
-        @@actual_table_field_count ||= read_adapter.table_column_count(table_name)
+        @@actual_table_field_count ||= read_adapter.table_column_count(table_name).to_i
       end
 
       # :nodoc:

--- a/src/jennifer/query_builder/aggregations.cr
+++ b/src/jennifer/query_builder/aggregations.cr
@@ -7,7 +7,7 @@ module Jennifer
       # ```
       # Jennifer::Query["contacts"].count # => 123
       # ```
-      def count : Int32
+      def count : Int64
         adapter.count(self)
       end
 

--- a/src/jennifer/query_builder/aggregations.cr
+++ b/src/jennifer/query_builder/aggregations.cr
@@ -2,7 +2,7 @@ module Jennifer
   module QueryBuilder
     # Contains aggregation query functions.
     module Aggregations
-      # Returns result row count.
+      # Returns result row count in `Int64`.
       #
       # ```
       # Jennifer::Query["contacts"].count # => 123

--- a/src/jennifer/query_builder/executables.cr
+++ b/src/jennifer/query_builder/executables.cr
@@ -391,13 +391,13 @@ module Jennifer
         end
         request = clone.reorder.limit(batch_size)
 
-        records = request.offset(start * batch_size).to_a
+        records = request.offset(start.to_i64 * batch_size.to_i64).to_a
         while !records.empty?
           records_size = records.size
           yield records
           break if records_size < batch_size
           start += 1
-          records = request.offset(start * batch_size).to_a
+          records = request.offset(start.to_i64 * batch_size.to_i64).to_a
         end
       end
 

--- a/src/jennifer/query_builder/query.cr
+++ b/src/jennifer/query_builder/query.cr
@@ -46,7 +46,7 @@ module Jennifer
       @having : Condition | LogicOperator?
       @limit : Int32?
       @distinct : Bool = false
-      @offset : Int64?
+      @offset : Int32 | Int64 | Nil
       @raw_select : String?
       @from : String | Query?
       @lock : String | Bool?
@@ -543,11 +543,15 @@ module Jennifer
       end
 
       # Specifies the number of rows to skip before returning rows.
+      # The offset could be Int32 or Int64.
       #
       # ```
+      # Offset in Int32
       # Jennifer::Query["contacts"].offset(10)
+      # Or in Int64
+      # Jennifer::Query["contacts"].offset(10_i64)
       # ```
-      def offset(count : Int64)
+      def offset(count : Int32 | Int64)
         @offset = count
         self
       end

--- a/src/jennifer/query_builder/query.cr
+++ b/src/jennifer/query_builder/query.cr
@@ -46,7 +46,7 @@ module Jennifer
       @having : Condition | LogicOperator?
       @limit : Int32?
       @distinct : Bool = false
-      @offset : Int32?
+      @offset : Int64?
       @raw_select : String?
       @from : String | Query?
       @lock : String | Bool?
@@ -547,7 +547,7 @@ module Jennifer
       # ```
       # Jennifer::Query["contacts"].offset(10)
       # ```
-      def offset(count : Int32)
+      def offset(count : Int64)
         @offset = count
         self
       end


### PR DESCRIPTION
# What does this PR do?
Change Query.count to return `Int64` instead of `Int32`
Change Query.offset to accept `Int32` or `Int64` as input instead of only `Int32`
# Any background context you want to provide?
https://github.com/imdrasil/jennifer.cr/issues/399
# Release notes

**QueryBuilder**
**Breaking change**: Query.count returns `Int64` instead of `Int32`
**Breaking change**: Query.offset accepts `Int32` or `Int64` as input instead of only `Int32`
**Model**
**Breaking change**: Model.count returns `Int64` instead of `Int32`
