### PR TITLE
Docs: fix logger level configuration

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -57,7 +57,7 @@ APP_ENV = ENV["APP_ENV"]? || "development"
 Jennifer::Config.configure do |conf|
   conf.read("config/database.yml", APP_ENV)
   conf.from_uri(ENV["DATABASE_URI"]) if ENV.has_key?("DATABASE_URI")
-  conf.logger.level = APP_ENV == "development" ? :debug : :error
+  conf.logger.level = APP_ENV == "development" ? Log::Severity::Debug : Log::Severity::Error
 end
 
 Log.setup "db", :debug, Log::IOBackend.new(formatter: Jennifer::Adapter::DBFormatter)


### PR DESCRIPTION
Hi!

### What does this PR do?

Without fix it throws an error on fresh projects, like:
```
In config/initializers/database.cr:9:15

 9 | conf.logger.level = APP_ENV == "development" ? :debug : :error
                 ^----
Error: no overload matches 'Log#level=' with type Symbol

Overloads are:
 - Log#level=(value : Severity)
```

### Any background context you want to provide?

```yaml
jennifer:
  git: https://github.com/imdrasil/jennifer.cr.git
  version: 0.12.0
```

```bash
$ amber --version
Amber CLI (amberframework.org) - v1.2.2

$ crystal --version
Crystal 1.5.0 (2022-07-06)

LLVM: 14.0.6
Default target: x86_64-apple-macosx

$ shards --version
Shards 0.17.0 (2022-03-24)
```

### Release notes

Actualize documentation for crystal version 1.5 to avoid "no overload matches" error