### PR TITLE
Rename override methods arguments to be consistent with original name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,37 +48,41 @@ jobs:
             db_password: dbpassword
           - crystal_version: 1.4.1
             DB: mysql
-            integration: true
-            linter: true
             db_user: root
             db_password:
           - crystal_version: 1.4.1
             DB: postgres
+            db_user: dbuser
+            db_password: dbpassword
+          - crystal_version: 1.5.0
+            DB: mysql
+            integration: true
+            linter: true
+            db_user: root
+            db_password:
+          - crystal_version: 1.5.0
+            DB: postgres
             integration: true
             linter: true
             db_user: dbuser
             db_password: dbpassword
-          - crystal_version: 1.4.1
+          - crystal_version: 1.5.0
             DB: postgres
             db_user: dbuser
             db_password: dbpassword
             other: MT=1
-          - crystal_version: 1.4.1
+          - crystal_version: 1.5.0
             DB: postgres
             pair: true
             db_user: dbuser
             db_password: dbpassword
             other: PAIR_DB_USER=root PAIR_DB_PASSWORD=
-          - crystal_version: 1.4.1
+          - crystal_version: 1.5.0
             DB: mysql
             pair: true
             db_user: root
             db_password:
             other: PAIR_DB_USER=dbuser PAIR_DB_PASSWORD=dbpassword
-          - DB: postgres
-            db_user: dbuser
-            db_password: dbpassword
-            crystal_version: nightly
 
     runs-on: ubuntu-latest
 

--- a/src/jennifer/adapter/postgres.cr
+++ b/src/jennifer/adapter/postgres.cr
@@ -174,7 +174,7 @@ module Jennifer
           .exists?
       end
 
-      def index_exists?(_table, name : String)
+      def index_exists?(table, name : String)
         Query["pg_class", self]
           .join("pg_namespace") { _oid == _pg_class__relnamespace }
           .where { (_pg_class__relname == name) & (_pg_namespace__nspname == config.schema) }

--- a/src/jennifer/adapter/postgres/numeric.cr
+++ b/src/jennifer/adapter/postgres/numeric.cr
@@ -8,12 +8,12 @@ module PG
       new(*args)
     end
 
-    def <=>(v : Float64)
-      to_f <=> v
+    def <=>(other : Float64)
+      to_f <=> other
     end
 
-    def <=>(v : Int32)
-      to_f <=> v
+    def <=>(other : Int32)
+      to_f <=> other
     end
   end
 end

--- a/src/jennifer/model/common_mapping.cr
+++ b/src/jennifer/model/common_mapping.cr
@@ -45,12 +45,12 @@ module Jennifer::Model
       end
 
       # :nodoc:
-      def self.new(pull : DB::ResultSet)
+      def self.new(values : DB::ResultSet)
         {% verbatim do %}
         {% begin %}
           {% klasses = @type.all_subclasses.select { |s| s.constant("STI") == true } %}
           {% if !klasses.empty? %}
-            hash = adapter.result_to_hash(pull)
+            hash = adapter.result_to_hash(values)
             case hash["type"]
             when "", nil, "{{@type}}"
               new(hash, false)
@@ -63,7 +63,7 @@ module Jennifer::Model
             end
           {% else %}
             instance = allocate
-            instance.initialize(pull)
+            instance.initialize(values)
             instance.__after_initialize_callback
             instance
           {% end %}

--- a/src/jennifer/model/sti_mapping.cr
+++ b/src/jennifer/model/sti_mapping.cr
@@ -152,9 +152,9 @@ module Jennifer
           {% end %}
         end
 
-        def self.new(pull : DB::ResultSet)
+        def self.new(values : DB::ResultSet)
           instance = allocate
-          instance.initialize(pull)
+          instance.initialize(values)
           instance.__after_initialize_callback
           instance
         end

--- a/src/jennifer/model/translation.cr
+++ b/src/jennifer/model/translation.cr
@@ -5,18 +5,18 @@ module Jennifer
     # Depends of parent class `::lookup_ancestors` and `::i18n_scope` methods.
     module Translation
       module ClassMethods
-        # Search translation for given attribute.
-        def human_attribute_name(attribute : String | Symbol)
+        # Search translation for given attribute name.
+        def human_attribute_name(name : String | Symbol)
           prefix = "#{GLOBAL_SCOPE}.attributes."
 
           lookup_ancestors do |ancestor|
-            path = "#{prefix}#{ancestor.i18n_key}.#{attribute}"
+            path = "#{prefix}#{ancestor.i18n_key}.#{name}"
             return I18n.translate(path) if I18n.exists?(path)
           end
 
-          path = "#{prefix}.#{attribute}"
+          path = "#{prefix}.#{name}"
           return I18n.translate(path) if I18n.exists?(path)
-          Inflector.humanize(attribute)
+          Inflector.humanize(name)
         end
 
         # Returns localized model name.
@@ -66,8 +66,8 @@ module Jennifer
       end
 
       # Delegates the call to `self.class`.
-      def human_attribute_name(attribute : String | Symbol)
-        self.class.human_attribute_name(attribute)
+      def human_attribute_name(name : String | Symbol)
+        self.class.human_attribute_name(name)
       end
 
       def class_name : String

--- a/src/jennifer/query_builder/function.cr
+++ b/src/jennifer/query_builder/function.cr
@@ -19,8 +19,8 @@ module Jennifer
         end
       end
 
-      def definition(sql_generator)
-        identifier = as_sql(sql_generator)
+      def definition(generator)
+        identifier = as_sql(generator)
         @alias ? "#{identifier} AS #{@alias}" : identifier
       end
 

--- a/src/jennifer/query_builder/order_expression.cr
+++ b/src/jennifer/query_builder/order_expression.cr
@@ -66,8 +66,8 @@ module Jennifer
         self
       end
 
-      def as_sql(sql_generator)
-        sql_generator.order_expression(self)
+      def as_sql(generator)
+        generator.order_expression(self)
       end
 
       def sql_args : Array(DBAny)

--- a/src/jennifer/query_builder/statement.cr
+++ b/src/jennifer/query_builder/statement.cr
@@ -1,8 +1,8 @@
 module Jennifer
   module QueryBuilder
     module Statement
-      # Converts node to SQL using *sql_generator* SQLGenerator.
-      abstract def as_sql(sql_generator)
+      # Converts node to SQL using *generator* SQLGenerator.
+      abstract def as_sql(generator)
 
       # Returns array of SQL query arguments.
       abstract def sql_args : Array(DBAny)

--- a/src/jennifer/query_builder/values.cr
+++ b/src/jennifer/query_builder/values.cr
@@ -12,8 +12,8 @@ module Jennifer::QueryBuilder
       end
     {% end %}
 
-    def as_sql(sql_generator)
-      sql_generator.values_expression(@field)
+    def as_sql(generator)
+      generator.values_expression(@field)
     end
 
     def sql_args : Array(DBAny)

--- a/src/jennifer/relation/i_relation.cr
+++ b/src/jennifer/relation/i_relation.cr
@@ -5,10 +5,10 @@ module Jennifer
       abstract def table_name
       abstract def model_class
       abstract def join_query
-      abstract def join_condition(a, b)
+      abstract def join_condition(query, type)
 
       # Returns query for given primary field values
-      abstract def query(primary_value)
+      abstract def query(primary_value_or_array)
 
       # Preloads relation into *collection* from *out_collection* depending on keys from *pk_repo*.
       abstract def preload_relation(collection, out_collection : Array(Model::Resource), pk_repo)

--- a/src/jennifer/relation/many_to_many.cr
+++ b/src/jennifer/relation/many_to_many.cr
@@ -37,9 +37,9 @@ module Jennifer
         rel
       end
 
-      def query(primary_value)
+      def query(primary_value_or_array)
         afk = association_foreign_key
-        _primary_value = primary_value
+        _primary_value = primary_value_or_array
         mfk = foreign_field
         q = T.all.join(join_table!) do
           (c(afk) == T.primary) &

--- a/src/jennifer/relation/polymorphic_belongs_to.cr
+++ b/src/jennifer/relation/polymorphic_belongs_to.cr
@@ -76,8 +76,8 @@ module Jennifer
         related_model(polymorphic_type).new(opts, false)
       end
 
-      private def related_model(obj : Model::Base)
-        related_model(obj.attribute_before_typecast(foreign_type).as(String))
+      private def related_model(arg : Model::Base)
+        related_model(arg.attribute_before_typecast(foreign_type).as(String))
       end
 
       private def table_name(type : String)
@@ -87,14 +87,14 @@ module Jennifer
       macro define_relation_class(name, klass, related_class, types, request)
         # :nodoc:
         class {{name.id.camelcase}}Relation < ::Jennifer::Relation::IPolymorphicBelongsTo
-          private def related_model(type : String)
-            case type
+          private def related_model(arg : String)
+            case arg
             {% for type in types %}
             when {{type}}.to_s
               {{type}}
             {% end %}
             else
-              raise ::Jennifer::BaseException.new("Unknown polymorphic type #{type}")
+              raise ::Jennifer::BaseException.new("Unknown polymorphic type #{arg}")
             end
           end
 
@@ -160,7 +160,7 @@ module Jennifer
         raise AbstractMethod.new("join_query", self)
       end
 
-      def query(a)
+      def query(primary_value_or_array)
         raise AbstractMethod.new("query", self)
       end
 

--- a/src/jennifer/relation/relation_stub.cr
+++ b/src/jennifer/relation/relation_stub.cr
@@ -11,15 +11,15 @@ module Jennifer
       raise "stubbed relation"
     end
 
-    def join_condition(a, b)
+    def join_condition(query, type)
       raise "stubbed relation"
     end
 
-    def join_condition(a, b, &block)
+    def join_condition(query, type, &block)
       raise "stubbed relation"
     end
 
-    def query(a)
+    def query(primary_value_or_array)
       raise "stubbed relation"
     end
 


### PR DESCRIPTION
# What does this PR do?

Addresses warnings from the crystal 1.5.0
Fix #412 

# Release notes

**General**

* address "positional parameter of the overridden method, which has a different name and may affect named argument passing" crystal `1.5.0` warning (for full list see [MR](https://github.com/imdrasil/jennifer.cr/pull/413))