### PR TITLE
Set password digest when password was given to constructor

### DIFF
--- a/spec/model/authentication_spec.cr
+++ b/spec/model/authentication_spec.cr
@@ -4,6 +4,16 @@ describe Jennifer::Model::Authentication do
   describe "%with_authentication" do
     context "with default field names" do
       describe "validations" do
+        it "generates digest if password was set using constructor" do
+          user = User.new({
+            :name                  => "John",
+            :password              => "password",
+            :password_confirmation => "password",
+            :email                 => "test@gmail.com",
+          })
+          user.valid?.should be_true
+        end
+
         it do
           user = Factory.build_user
           user.password = "1" * 72

--- a/src/jennifer/model/authentication.cr
+++ b/src/jennifer/model/authentication.cr
@@ -25,6 +25,8 @@ module Jennifer
           validates_with_method :validate_{{password.id}}_presence
         {% end %}
 
+        after_initialize :initialize_{{password_hash.id}}
+
         def authenticate(given_password)
           self if Crypto::Bcrypt::Password.new({{password_hash.id}}).verify given_password
         end
@@ -52,6 +54,13 @@ module Jennifer
 
         private def validate_{{password.id}}_presence
           errors.add(:{{password.id}}, :blank) if {{password_hash.id}}.blank?
+        end
+
+        private def initialize_{{password_hash.id}}
+          return unless new_record? && {{password.id}}.present?
+
+          self.{{password.id}}= {{password.id}}
+          true
         end
       end
     end


### PR DESCRIPTION
# What does this PR do?

Fix #419

# Release notes

**Model**

* fix a bug when password digest wasn't generated when password was set by passing it to a constructor
