### PR TITLE
Add jsonb type support for model/migration generator

### DIFF
--- a/src/jennifer/generators/field.cr
+++ b/src/jennifer/generators/field.cr
@@ -22,7 +22,8 @@ module Jennifer
         "timestamp" => "Time",
         "date_time" => "Time",
 
-        "json" => "JSON::Any",
+        "json"  => "JSON::Any",
+        "jsonb" => "JSON::Any",
 
         REFERENCE_TYPE => "Int64",
       }


### PR DESCRIPTION
# What does this PR do?

Address #417 

# Release notes

**General**

* add `jsonb` type support for model and migration generators