### PR TITLE
Add ability to specify proc for validation message; add required option for belongs_to relation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,30 +54,30 @@ jobs:
             DB: postgres
             db_user: dbuser
             db_password: dbpassword
-          - crystal_version: 1.5.0
+          - crystal_version: 1.5.1
             DB: mysql
             integration: true
             linter: true
             db_user: root
             db_password:
-          - crystal_version: 1.5.0
+          - crystal_version: 1.5.1
             DB: postgres
             integration: true
             linter: true
             db_user: dbuser
             db_password: dbpassword
-          - crystal_version: 1.5.0
+          - crystal_version: 1.5.1
             DB: postgres
             db_user: dbuser
             db_password: dbpassword
             other: MT=1
-          - crystal_version: 1.5.0
+          - crystal_version: 1.5.1
             DB: postgres
             pair: true
             db_user: dbuser
             db_password: dbpassword
             other: PAIR_DB_USER=root PAIR_DB_PASSWORD=
-          - crystal_version: 1.5.0
+          - crystal_version: 1.5.1
             DB: mysql
             pair: true
             db_user: root

--- a/spec/model/mapping_spec.cr
+++ b/spec/model/mapping_spec.cr
@@ -903,7 +903,6 @@ describe Jennifer::Model::Mapping do
     describe "#initialize" do
       it "reads generated column" do
         Author.create!({:name1 => "First", :name2 => "Last"})
-        puts Author.all.pluck(:full_name)
         Author.all.last!.full_name.should eq("First Last")
       end
     end

--- a/spec/model/validation_spec.cr
+++ b/spec/model/validation_spec.cr
@@ -104,6 +104,35 @@ class CustomValidatorModel < ApplicationRecord
   validates_with ValidatorWithOptions, field: :name, message: "Custom Message"
 end
 
+class SymbolMessageValidationModel < ApplicationRecord
+  mapping({
+    id:   Primary64,
+    name: String,
+  })
+
+  validates_format :name, /qwe/, message: :present
+end
+
+class StringMessageValidationModel < ApplicationRecord
+  mapping({
+    id:   Primary64,
+    name: String,
+  })
+
+  validates_length :name, is: 3, message: "String message"
+end
+
+class ProcMessageValidationModel < ApplicationRecord
+  mapping({
+    id:   Primary64,
+    name: String,
+  })
+
+  validates_length :name, is: 3, message: ->(record : Jennifer::Model::Translation, _field : String) do
+    record.as(ProcMessageValidationModel).name
+  end
+end
+
 describe Jennifer::Model::Validation do
   describe "if option" do
     context "with negative response" do
@@ -122,6 +151,23 @@ describe Jennifer::Model::Validation do
         c.age = 14
         c.should_not be_valid
       end
+    end
+  end
+
+  describe "message option" do
+    it "uses string value as a complete message" do
+      record = StringMessageValidationModel.new({name: "1234"})
+      record.should validate(:name).with("String message")
+    end
+
+    it "uses symbol message as a key for message translation lookup" do
+      record = SymbolMessageValidationModel.new({name: "1234"})
+      record.should validate(:name).with("must be blank")
+    end
+
+    it "uses proc message to generate message dynamically" do
+      record = ProcMessageValidationModel.new({name: "1234"})
+      record.should validate(:name).with("1234")
     end
   end
 

--- a/spec/models.cr
+++ b/spec/models.cr
@@ -1,5 +1,9 @@
 require "./views"
 require "../src/jennifer/model/authentication"
+# NOTE: some models are moved to the separate files to simulate common usage
+require "./support/models/application_record"
+require "./support/models/contact"
+require "./support/models/address"
 
 class JohnyQuery < Jennifer::QueryBuilder::QueryObject
   def call
@@ -53,23 +57,6 @@ end
 # models
 # ===========
 
-abstract class ApplicationRecord < Jennifer::Model::Base
-  getter super_class_callback_called = false
-
-  before_create :before_abstract_create
-
-  def before_abstract_create
-    @super_class_callback_called = true
-  end
-
-  EmptyString = {
-    type:    String,
-    default: "",
-  }
-
-  {% TYPES << "EmptyString" %}
-end
-
 class User < ApplicationRecord
   include Jennifer::Model::Authentication
 
@@ -91,105 +78,6 @@ class User < ApplicationRecord
 
   def self.password_digest_cost
     4
-  end
-end
-
-class Contact < ApplicationRecord
-  module Mapping
-    include Jennifer::Model::Mapping
-
-    {% if env("DB") == "postgres" || env("DB") == nil %}
-      mapping(
-        id: Primary64,
-        name: String,
-        ballance: PG::Numeric?,
-        age: {type: Int32, default: 10},
-        gender: {type: String?, default: "male", converter: Jennifer::Model::PgEnumConverter},
-        description: String?,
-        created_at: Time?,
-        updated_at: Time?,
-        user_id: Int64?,
-        tags: {type: Array(Int32)?},
-        email: String?
-      )
-    {% else %}
-      mapping(
-        id: Primary64,
-        name: String,
-        ballance: Float64?,
-        age: {type: Int32, default: 10},
-        gender: {type: String?, default: "male"},
-        description: String?,
-        created_at: Time?,
-        updated_at: Time?,
-        user_id: Int64?,
-        email: String?
-      )
-    {% end %}
-  end
-
-  include Mapping
-
-  with_timestamps
-  mapping
-
-  has_many :addresses, Address, inverse_of: :contact
-  has_many :facebook_profiles, FacebookProfile, inverse_of: :contact
-  has_and_belongs_to_many :countries, Country
-  has_and_belongs_to_many :facebook_many_profiles, FacebookProfile, association_foreign: :profile_id
-  has_one :main_address, Address, {where { _main }}, inverse_of: :contact
-  has_one :passport, Passport, inverse_of: :contact
-  belongs_to :user, User
-
-  validates_inclusion :age, 13..75
-  validates_length :name, minimum: 1
-  # NOTE: only for testing purposes - this is a bad practice; prefer to use `in`
-  validates_length :name, maximum: 15
-  validates_with_method :name_check
-
-  scope :main { where { _age > 18 } }
-  scope :older { |age| where { _age >= age } }
-  scope :ordered { order(name: :asc) }
-  scope :with_main_address { relation(:addresses).where { _addresses__main } }
-  scope :johny, JohnyQuery
-  scope :by_gender, WithOwnArguments
-
-  def name_check
-    if @description && @description.not_nil!.size > 10
-      errors.add(:description, "Too large description")
-    end
-  end
-end
-
-class Address < Jennifer::Model::Base
-  with_timestamps
-
-  mapping(
-    id: {type: Int64, primary: true},
-    main: Bool,
-    street: String,
-    contact_id: Int64?,
-    details: JSON::Any?,
-    created_at: Time?,
-    updated_at: Time?
-  )
-
-  validates_format :street, /st\.|street/
-
-  belongs_to :contact, Contact
-
-  scope :main { where { _main } }
-
-  after_destroy :increment_destroy_counter
-
-  @@destroy_counter = 0
-
-  def self.destroy_counter
-    @@destroy_counter
-  end
-
-  def increment_destroy_counter
-    @@destroy_counter += 1
   end
 end
 

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -72,15 +72,27 @@ end
 UTC    = Time::Location.load("UTC")
 BERLIN = Time::Location.load("Europe/Berlin")
 
-macro validated_by_record(type, value, field = :age, allow_blank = true)
-  Factory.build_contact.tap do |record|
+macro validated_by_record(field, value, opts = {} of Void => Void)
+  begin
+    allow_blank = {{opts[:allow_blank]}} || true
+    __record__ =
+      {% if !opts[:record] %}
+        Factory.build_contact
+      {% else %}
+        {{opts[:record]}}
+      {% end %}
     described_class.instance.validate(
-      record,
+      __record__,
       field: {{field}},
       value: {{value}},
-      allow_blank: {{allow_blank}},
-      {{type.stringify[1...-1].id}}
+      allow_blank: allow_blank,
+      {% for key, value in opts %}
+        {% if key != :allow_blank && key != :record %}
+          {{key.id}}: {{value}},
+        {% end %}
+      {% end %}
     )
+    __record__
   end
 end
 

--- a/spec/support/matchers.cr
+++ b/spec/support/matchers.cr
@@ -173,6 +173,24 @@ module Spec
     end
   end
 
+  struct ValidationMessageExpectation
+    def initialize(@field : Symbol, @message : String?)
+    end
+
+    def match(record)
+      errors = (record.errors[@field]? || %w[])
+      @message.nil? ? !errors.empty? : errors.includes?(@message)
+    end
+
+    def failure_message(record)
+      "Expected record to have validation message `#{@message}` for `#{@field}` in `#{record.errors[@field]}`"
+    end
+
+    def negative_failure_message(record)
+      "Expected record not to have validation message `#{@message}` for `#{@field}` in `#{record.errors[@field]}`"
+    end
+  end
+
   module Expectations
     macro expect_queries_to_be_executed(amount)
       %count = query_count
@@ -219,6 +237,10 @@ module Spec
 
     def match_array(expected)
       MatchArrayExpectation.new(expected)
+    end
+
+    def has_error_message(field : Symbol, message : String? = nil)
+      ValidationMessageExpectation.new(field, message)
     end
   end
 end

--- a/spec/support/models/address.cr
+++ b/spec/support/models/address.cr
@@ -1,0 +1,31 @@
+class Address < Jennifer::Model::Base
+  with_timestamps
+
+  mapping(
+    id: {type: Int64, primary: true},
+    main: Bool,
+    street: String,
+    contact_id: Int64?,
+    details: JSON::Any?,
+    created_at: Time?,
+    updated_at: Time?
+  )
+
+  validates_format :street, /st\.|street/
+
+  belongs_to :contact, Contact
+
+  scope :main { where { _main } }
+
+  after_destroy :increment_destroy_counter
+
+  @@destroy_counter = 0
+
+  def self.destroy_counter
+    @@destroy_counter
+  end
+
+  def increment_destroy_counter
+    @@destroy_counter += 1
+  end
+end

--- a/spec/support/models/application_record.cr
+++ b/spec/support/models/application_record.cr
@@ -1,0 +1,16 @@
+abstract class ApplicationRecord < Jennifer::Model::Base
+  getter super_class_callback_called = false
+
+  before_create :before_abstract_create
+
+  def before_abstract_create
+    @super_class_callback_called = true
+  end
+
+  EmptyString = {
+    type:    String,
+    default: "",
+  }
+
+  {% TYPES << "EmptyString" %}
+end

--- a/spec/support/models/contact.cr
+++ b/spec/support/models/contact.cr
@@ -1,0 +1,66 @@
+class Contact < ApplicationRecord
+  module Mapping
+    include Jennifer::Model::Mapping
+
+    {% if env("DB") == "postgres" || env("DB") == nil %}
+      mapping(
+        id: Primary64,
+        name: String,
+        ballance: PG::Numeric?,
+        age: {type: Int32, default: 10},
+        gender: {type: String?, default: "male", converter: Jennifer::Model::PgEnumConverter},
+        description: String?,
+        created_at: Time?,
+        updated_at: Time?,
+        user_id: Int64?,
+        tags: {type: Array(Int32)?},
+        email: String?
+      )
+    {% else %}
+      mapping(
+        id: Primary64,
+        name: String,
+        ballance: Float64?,
+        age: {type: Int32, default: 10},
+        gender: {type: String?, default: "male"},
+        description: String?,
+        created_at: Time?,
+        updated_at: Time?,
+        user_id: Int64?,
+        email: String?
+      )
+    {% end %}
+  end
+
+  include Mapping
+
+  with_timestamps
+  mapping
+
+  has_many :addresses, Address, inverse_of: :contact
+  has_many :facebook_profiles, FacebookProfile, inverse_of: :contact
+  has_and_belongs_to_many :countries, Country
+  has_and_belongs_to_many :facebook_many_profiles, FacebookProfile, association_foreign: :profile_id
+  has_one :main_address, Address, {where { _main }}, inverse_of: :contact
+  has_one :passport, Passport, inverse_of: :contact
+  belongs_to :user, User
+
+  validates_inclusion :age, 13..75
+  validates_length :name, minimum: 1
+  # NOTE: only for testing purposes - this is a bad practice; prefer to use `in`
+  validates_length :name, maximum: 15
+  validates_with_method :name_check
+
+  scope :main { where { _age > 18 } }
+  scope :older { |age| where { _age >= age } }
+  scope :ordered { order(name: :asc) }
+  scope :with_main_address { relation(:addresses).where { _addresses__main } }
+  scope :johny, JohnyQuery
+  scope :by_gender, WithOwnArguments
+
+  def name_check
+    if @description && @description.not_nil!.size > 10
+      errors.add(:description, "Too large description")
+    end
+  end
+end

--- a/spec/validations/absence_spec.cr
+++ b/spec/validations/absence_spec.cr
@@ -2,8 +2,20 @@ require "../spec_helper"
 
 describe Jennifer::Validations::Absence do
   # ameba:disable Lint/UselessAssign
-  described_class = Jennifer::Validations::Inclusion
+  described_class = Jennifer::Validations::Absence
 
-  pending "add #validate"
+  describe "#validate" do
+    it { validated_by_record(:description, "John").should has_error_message(:description, "must be blank") }
+    it { validated_by_record(:description, nil).should_not has_error_message(:description) }
+
+    describe "message" do
+      it do
+        proc = ->(record : Jennifer::Model::Translation, field : String) { "#{record.as(Address).attribute(field).inspect} #{field} invalid" }
+        validated_by_record(:contact_id, 1, {message: proc, record: Factory.build_address})
+          .should has_error_message(:contact_id, "nil contact_id invalid")
+      end
+    end
+  end
+
   pending "test allow_blank"
 end

--- a/spec/validations/acceptance_spec.cr
+++ b/spec/validations/acceptance_spec.cr
@@ -4,6 +4,19 @@ describe Jennifer::Validations::Acceptance do
   # ameba:disable Lint/UselessAssign
   described_class = Jennifer::Validations::Acceptance
 
-  pending "add #validate"
-  pending "test allow_blank"
+  describe "#validate" do
+    it { validated_by_record(:name, "yes", {accept: %w[yes]}).should_not has_error_message(:name) }
+    it { validated_by_record(:name, nil, {accept: %w[yes]}).should_not has_error_message(:name) }
+    it { validated_by_record(:name, "no", {accept: %w[yes]}).should has_error_message(:name, "must be accepted") }
+
+    describe "message" do
+      it do
+        proc = ->(record : Jennifer::Model::Translation, field : String) do
+          "#{record.as(Contact).attribute(field)} #{field} invalid"
+        end
+        validated_by_record(:name, "no", {message: proc, accept: %w[yes]})
+          .should has_error_message(:name, "Deepthi name invalid")
+      end
+    end
+  end
 end

--- a/spec/validations/confirmation_spec.cr
+++ b/spec/validations/confirmation_spec.cr
@@ -4,6 +4,25 @@ describe Jennifer::Validations::Confirmation do
   # ameba:disable Lint/UselessAssign
   described_class = Jennifer::Validations::Confirmation
 
-  pending "add #validate"
+  describe "#validate" do
+    it { validated_by_record(:name, "John", {confirmation: "Joh", case_sensitive: true}).should has_error_message(:name, "doesn't match tName") }
+    it { validated_by_record(:name, nil, {case_sensitive: true}).should_not has_error_message(:name) }
+
+    it do
+      validated_by_record(:name, "John", {confirmation: "John", case_sensitive: true}).should_not has_error_message(:name)
+    end
+
+    describe "message" do
+      it do
+        proc = ->(record : Jennifer::Model::Translation, field : String) do
+          "#{record.as(Contact).attribute(field)} #{field} invalid"
+        end
+        validated_by_record(:name, "John", {message: proc, confirmation: "Joh", case_sensitive: true})
+          .should has_error_message(:name, "Deepthi name invalid")
+      end
+    end
+  end
+
   pending "test allow_blank"
+  pending "test case_sensitive"
 end

--- a/spec/validations/exclusion_spec.cr
+++ b/spec/validations/exclusion_spec.cr
@@ -6,21 +6,31 @@ describe Jennifer::Validations::Exclusion do
 
   describe "#validate" do
     describe "String" do
-      it { validated_by_record({collection: ["Sam"]}, "John", :name).should_not be_invalid }
-      it { validated_by_record({collection: ["Sam"]}, "Sam", :name).should be_invalid }
-      it { validated_by_record({collection: ["Sam"]}, nil, :name).should_not be_invalid }
+      it { validated_by_record(:name, "Sam", {collection: ["Sam"]}).should has_error_message(:name, "is reserved") }
+      it { validated_by_record(:name, "John", {collection: ["Sam"]}).should_not has_error_message(:name) }
+      it { validated_by_record(:name, nil, {collection: ["Sam"]}).should_not has_error_message(:name) }
     end
 
     describe "Float32" do
-      it { validated_by_record({collection: [1.2]}, 2.5, :name).should_not be_invalid }
-      it { validated_by_record({collection: [1.2]}, 1.2, :name).should be_invalid }
-      it { validated_by_record({collection: [1.2]}, nil, :name).should_not be_invalid }
+      it { validated_by_record(:name, 1.2, {collection: [1.2]}).should has_error_message(:name, "is reserved") }
+      it { validated_by_record(:name, 2.5, {collection: [1.2]}).should_not has_error_message(:name) }
+      it { validated_by_record(:name, nil, {collection: [1.2]}).should_not has_error_message(:name) }
     end
 
     describe "Int32" do
-      it { validated_by_record({collection: [1]}, 2, :name).should_not be_invalid }
-      it { validated_by_record({collection: [1]}, 1, :name).should be_invalid }
-      it { validated_by_record({collection: [1]}, nil, :name).should_not be_invalid }
+      it { validated_by_record(:name, 1, {collection: [1]}).should has_error_message(:name, "is reserved") }
+      it { validated_by_record(:name, 2, {collection: [1]}).should_not has_error_message(:name) }
+      it { validated_by_record(:name, nil, {collection: [1]}).should_not has_error_message(:name) }
+    end
+
+    describe "message" do
+      it do
+        proc = ->(record : Jennifer::Model::Translation, field : String) do
+          "#{record.as(Contact).attribute(field)} #{field} invalid"
+        end
+        validated_by_record(:name, 1, {message: proc, collection: [1]})
+          .should has_error_message(:name, "Deepthi name invalid")
+      end
     end
   end
 

--- a/spec/validations/format_spec.cr
+++ b/spec/validations/format_spec.cr
@@ -4,6 +4,23 @@ describe Jennifer::Validations::Format do
   # ameba:disable Lint/UselessAssign
   described_class = Jennifer::Validations::Format
 
-  pending "add #validate"
+  describe "#validate" do
+    it { validated_by_record(:name, "John", {format: /jon/}).should has_error_message(:name, "is invalid") }
+    it { validated_by_record(:name, nil, {format: /jon/}).should_not has_error_message(:name) }
+
+    it { validated_by_record(:name, "John", {format: /John/}).should_not has_error_message(:name) }
+
+    describe "message" do
+      it do
+        proc = ->(record : Jennifer::Model::Translation, field : String) do
+          "#{record.as(Contact).attribute(field)} #{field} invalid"
+        end
+        validated_by_record(:name, "John", {message: proc, format: /jon/})
+          .should has_error_message(:name, "Deepthi name invalid")
+      end
+    end
+  end
+
   pending "test allow_blank"
+  pending "test case_sensitive"
 end

--- a/spec/validations/inclusion_spec.cr
+++ b/spec/validations/inclusion_spec.cr
@@ -3,24 +3,35 @@ require "../spec_helper"
 describe Jennifer::Validations::Inclusion do
   # ameba:disable Lint/UselessAssign
   described_class = Jennifer::Validations::Inclusion
+  message = "is not included in the list"
 
   describe "#validate" do
     describe "String" do
-      it { validated_by_record({collection: ["Sam"]}, "John", :name).should be_invalid }
-      it { validated_by_record({collection: ["Sam"]}, "Sam", :name).should_not be_invalid }
-      it { validated_by_record({collection: ["Sam"]}, nil, :name).should_not be_invalid }
+      it { validated_by_record(:name, "John", {collection: ["Sam"]}).should has_error_message(:name, message) }
+      it { validated_by_record(:name, "Sam", {collection: ["Sam"]}).should_not has_error_message(:name) }
+      it { validated_by_record(:name, nil, {collection: ["Sam"]}).should_not has_error_message(:name) }
     end
 
     describe "Float32" do
-      it { validated_by_record({collection: [1.2]}, 2.5, :name).should be_invalid }
-      it { validated_by_record({collection: [1.2]}, 1.2, :name).should_not be_invalid }
-      it { validated_by_record({collection: [1.2]}, nil, :name).should_not be_invalid }
+      it { validated_by_record(:name, 2.5, {collection: [1.2]}).should has_error_message(:name, message) }
+      it { validated_by_record(:name, 1.2, {collection: [1.2]}).should_not has_error_message(:name) }
+      it { validated_by_record(:name, nil, {collection: [1.2]}).should_not has_error_message(:name) }
     end
 
     describe "Int32" do
-      it { validated_by_record({collection: [1]}, 2, :name).should be_invalid }
-      it { validated_by_record({collection: [1]}, 1, :name).should_not be_invalid }
-      it { validated_by_record({collection: [1]}, nil, :name).should_not be_invalid }
+      it { validated_by_record(:name, 2, {collection: [1]}).should has_error_message(:name, message) }
+      it { validated_by_record(:name, 1, {collection: [1]}).should_not has_error_message(:name) }
+      it { validated_by_record(:name, nil, {collection: [1]}).should_not has_error_message(:name) }
+    end
+
+    describe "message" do
+      it do
+        proc = ->(record : Jennifer::Model::Translation, field : String) do
+          "#{record.as(Contact).attribute(field)} #{field} invalid"
+        end
+        validated_by_record(:name, 2, {collection: [1], message: proc})
+          .should has_error_message(:name, "Deepthi name invalid")
+      end
     end
   end
 

--- a/spec/validations/length_spec.cr
+++ b/spec/validations/length_spec.cr
@@ -7,62 +7,112 @@ describe Jennifer::Validations::Length do
   describe "#validate" do
     describe "in" do
       describe "String" do
-        it { validated_by_record({in: 2..3}, "Joh", :name).should_not be_invalid }
-        it { validated_by_record({in: 2..3}, "Jo", :name).should_not be_invalid }
-        it { validated_by_record({in: 2...3}, "Sam", :name).should be_invalid }
-        it { validated_by_record({in: 2...3}, "S", :name).should be_invalid }
+        it { validated_by_record(:name, "Joh", {in: 2..3}).should_not has_error_message(:name) }
+        it { validated_by_record(:name, "Jo", {in: 2..3}).should_not has_error_message(:name) }
+
+        it do
+          validated_by_record(:name, "Sam", {in: 2...3})
+            .should has_error_message(:name, "is too long (maximum is 2 characters)")
+        end
+
+        it do
+          validated_by_record(:name, "S", {in: 2...3})
+            .should has_error_message(:name, "is too short (minimum is 2 characters)")
+        end
       end
 
       describe "Array" do
-        it { validated_by_record({in: 2..3}, [1, 2, 3], :name).should_not be_invalid }
-        it { validated_by_record({in: 2..3}, [1, 2], :name).should_not be_invalid }
-        it { validated_by_record({in: 2...3}, [1, 2, 3], :name).should be_invalid }
-        it { validated_by_record({in: 2...3}, [1], :name).should be_invalid }
+        it { validated_by_record(:name, [1, 2, 3], {in: 2..3}).should_not has_error_message(:name) }
+        it { validated_by_record(:name, [1, 2], {in: 2..3}).should_not has_error_message(:name) }
+
+        it do
+          validated_by_record(:name, [1, 2, 3], {in: 2...3})
+            .should has_error_message(:name, "is too long (maximum is 2 characters)")
+        end
+
+        it do
+          validated_by_record(:name, [1], {in: 2...3})
+            .should has_error_message(:name, "is too short (minimum is 2 characters)")
+        end
       end
 
-      it { validated_by_record({in: 2..3}, nil, :name).should_not be_invalid }
+      it { validated_by_record(:name, nil, {in: 2..3}).should_not has_error_message(:name) }
     end
 
     describe "is" do
       describe "String" do
-        it { validated_by_record({is: 3}, "Joh", :name).should_not be_invalid }
-        it { validated_by_record({is: 3}, "Jo", :name).should be_invalid }
+        it { validated_by_record(:name, "Joh", {is: 3}).should_not has_error_message(:name) }
+
+        it do
+          validated_by_record(:name, "Jo", {is: 3})
+            .should has_error_message(:name, "is the wrong length (should be 3 characters)")
+        end
       end
 
       describe "Array" do
-        it { validated_by_record({is: 3}, [1, 2, 3], :name).should_not be_invalid }
-        it { validated_by_record({is: 3}, [1, 2], :name).should be_invalid }
+        it { validated_by_record(:name, [1, 2, 3], {is: 3}).should_not has_error_message(:name) }
+
+        it do
+          validated_by_record(:name, [1, 2], {is: 3})
+            .should has_error_message(:name, "is the wrong length (should be 3 characters)")
+        end
       end
 
-      it { validated_by_record({is: 3}, nil, :name).should_not be_invalid }
+      it { validated_by_record(:name, nil, {is: 3}).should_not has_error_message(:name) }
     end
 
     describe "minimum" do
       describe "String" do
-        it { validated_by_record({minimum: 3}, "Joh", :name).should_not be_invalid }
-        it { validated_by_record({minimum: 3}, "Jo", :name).should be_invalid }
+        it { validated_by_record(:name, "Joh", {minimum: 3}).should_not has_error_message(:name) }
+
+        it do
+          validated_by_record(:name, "Jo", {minimum: 3})
+            .should has_error_message(:name, "is too short (minimum is 3 characters)")
+        end
       end
 
       describe "Array" do
-        it { validated_by_record({minimum: 3}, [1, 2, 3], :name).should_not be_invalid }
-        it { validated_by_record({minimum: 3}, [1, 2], :name).should be_invalid }
+        it { validated_by_record(:name, [1, 2, 3], {minimum: 3}).should_not has_error_message(:name) }
+
+        it do
+          validated_by_record(:name, [1, 2], {minimum: 3})
+            .should has_error_message(:name, "is too short (minimum is 3 characters)")
+        end
       end
 
-      it { validated_by_record({minimum: 3}, nil, :name).should_not be_invalid }
+      it { validated_by_record(:name, nil, {minimum: 3}).should_not has_error_message(:name) }
     end
 
     describe "maximum" do
       describe "String" do
-        it { validated_by_record({maximum: 3}, "Joh", :name).should_not be_invalid }
-        it { validated_by_record({maximum: 3}, "John", :name).should be_invalid }
+        it { validated_by_record(:name, "Joh", {maximum: 3}).should_not has_error_message(:name) }
+
+        it do
+          validated_by_record(:name, "John", {maximum: 3})
+            .should has_error_message(:name, "is too long (maximum is 3 characters)")
+        end
       end
 
       describe "Array" do
-        it { validated_by_record({maximum: 3}, [1, 2, 3], :name).should_not be_invalid }
-        it { validated_by_record({maximum: 3}, [1, 2, 3, 4], :name).should be_invalid }
+        it { validated_by_record(:name, [1, 2, 3], {maximum: 3}).should_not has_error_message(:name) }
+
+        it do
+          validated_by_record(:name, [1, 2, 3, 4], {maximum: 3})
+            .should has_error_message(:name, "is too long (maximum is 3 characters)")
+        end
       end
 
-      it { validated_by_record({maximum: 3}, nil, :name).should_not be_invalid }
+      it { validated_by_record(:name, nil, {maximum: 3}).should_not has_error_message(:name) }
+    end
+
+    describe "message" do
+      it do
+        proc = ->(record : Jennifer::Model::Translation, field : String) do
+          "#{record.as(Contact).attribute(field)} #{field} invalid"
+        end
+        validated_by_record(:name, [1, 2, 3, 4], {maximum: 3, message: proc})
+          .should has_error_message(:name, "Deepthi name invalid")
+      end
     end
   end
 

--- a/spec/validations/numericality_spec.cr
+++ b/spec/validations/numericality_spec.cr
@@ -10,27 +10,27 @@ describe Jennifer::Validations::Numericality do
       {% definition = {greater_than: 12} %}
 
       describe "Int32" do
-        it { validated_by_record({{definition}}, 13).should_not be_invalid }
-        it { validated_by_record({{definition}}, 12).should be_invalid }
+        it { validated_by_record(:age, 13, {{definition}}).should_not be_invalid }
+        it { validated_by_record(:age, 12, {{definition}}).should be_invalid }
       end
 
       describe "Int16" do
-        it { validated_by_record({{definition}}, 13i64).should_not be_invalid }
-        it { validated_by_record({{definition}}, 12i64).should be_invalid }
+        it { validated_by_record(:age, 13i64, {{definition}}).should_not be_invalid }
+        it { validated_by_record(:age, 12i64, {{definition}}).should be_invalid }
       end
 
       describe "Float64" do
-        it { validated_by_record({{definition}}, 13.0).should_not be_invalid }
-        it { validated_by_record({{definition}}, 12.0).should be_invalid }
+        it { validated_by_record(:age, 13.0, {{definition}}).should_not be_invalid }
+        it { validated_by_record(:age, 12.0, {{definition}}).should be_invalid }
       end
 
       describe "Float32" do
-        it { validated_by_record({{definition}}, 13.0f32).should_not be_invalid }
-        it { validated_by_record({{definition}}, 12.0f32).should be_invalid }
+        it { validated_by_record(:age, 13.0f32, {{definition}}).should_not be_invalid }
+        it { validated_by_record(:age, 12.0f32, {{definition}}).should be_invalid }
       end
 
       describe "Nil" do
-        it { validated_by_record({{definition}}, nil).should_not be_invalid }
+        it { validated_by_record(:age, nil, {{definition}}).should_not be_invalid }
       end
     end
 
@@ -38,27 +38,27 @@ describe Jennifer::Validations::Numericality do
       {% definition = {greater_than_or_equal_to: 12} %}
 
       describe "Int32" do
-        it { validated_by_record({{definition}}, 12).should_not be_invalid }
-        it { validated_by_record({{definition}}, 11).should be_invalid }
+        it { validated_by_record(:age, 12, {{definition}}).should_not be_invalid }
+        it { validated_by_record(:age, 11, {{definition}}).should be_invalid }
       end
 
       describe "Int16" do
-        it { validated_by_record({{definition}}, 12i64).should_not be_invalid }
-        it { validated_by_record({{definition}}, 11i64).should be_invalid }
+        it { validated_by_record(:age, 12i64, {{definition}}).should_not be_invalid }
+        it { validated_by_record(:age, 11i64, {{definition}}).should be_invalid }
       end
 
       describe "Float64" do
-        it { validated_by_record({{definition}}, 12.0).should_not be_invalid }
-        it { validated_by_record({{definition}}, 11.0).should be_invalid }
+        it { validated_by_record(:age, 12.0, {{definition}}).should_not be_invalid }
+        it { validated_by_record(:age, 11.0, {{definition}}).should be_invalid }
       end
 
       describe "Float32" do
-        it { validated_by_record({{definition}}, 12.0f32).should_not be_invalid }
-        it { validated_by_record({{definition}}, 11.0f32).should be_invalid }
+        it { validated_by_record(:age, 12.0f32, {{definition}}).should_not be_invalid }
+        it { validated_by_record(:age, 11.0f32, {{definition}}).should be_invalid }
       end
 
       describe "Nil" do
-        it { validated_by_record({{definition}}, nil).should_not be_invalid }
+        it { validated_by_record(:age, nil, {{definition}}).should_not be_invalid }
       end
     end
 
@@ -66,31 +66,31 @@ describe Jennifer::Validations::Numericality do
       {% definition = {equal_to: 12} %}
 
       describe "Int32" do
-        it { validated_by_record({{definition}}, 12).should_not be_invalid }
-        it { validated_by_record({{definition}}, 11).should be_invalid }
-        it { validated_by_record({{definition}}, 13).should be_invalid }
+        it { validated_by_record(:age, 12, {{definition}}).should_not be_invalid }
+        it { validated_by_record(:age, 11, {{definition}}).should be_invalid }
+        it { validated_by_record(:age, 13, {{definition}}).should be_invalid }
       end
 
       describe "Int16" do
-        it { validated_by_record({{definition}}, 12i64).should_not be_invalid }
-        it { validated_by_record({{definition}}, 11i64).should be_invalid }
-        it { validated_by_record({{definition}}, 13i64).should be_invalid }
+        it { validated_by_record(:age, 12i64, {{definition}}).should_not be_invalid }
+        it { validated_by_record(:age, 11i64, {{definition}}).should be_invalid }
+        it { validated_by_record(:age, 13i64, {{definition}}).should be_invalid }
       end
 
       describe "Float64" do
-        it { validated_by_record({{definition}}, 12.0).should_not be_invalid }
-        it { validated_by_record({{definition}}, 11.0).should be_invalid }
-        it { validated_by_record({{definition}}, 13.0).should be_invalid }
+        it { validated_by_record(:age, 12.0, {{definition}}).should_not be_invalid }
+        it { validated_by_record(:age, 11.0, {{definition}}).should be_invalid }
+        it { validated_by_record(:age, 13.0, {{definition}}).should be_invalid }
       end
 
       describe "Float32" do
-        it { validated_by_record({{definition}}, 12.0f32).should_not be_invalid }
-        it { validated_by_record({{definition}}, 11.0f32).should be_invalid }
-        it { validated_by_record({{definition}}, 13.0f32).should be_invalid }
+        it { validated_by_record(:age, 12.0f32, {{definition}}).should_not be_invalid }
+        it { validated_by_record(:age, 11.0f32, {{definition}}).should be_invalid }
+        it { validated_by_record(:age, 13.0f32, {{definition}}).should be_invalid }
       end
 
       describe "Nil" do
-        it { validated_by_record({{definition}}, nil).should_not be_invalid }
+        it { validated_by_record(:age, nil, {{definition}}).should_not be_invalid }
       end
     end
 
@@ -98,31 +98,31 @@ describe Jennifer::Validations::Numericality do
       {% definition = {other_than: 12} %}
 
       describe "Int32" do
-        it { validated_by_record({{definition}}, 12).should be_invalid }
-        it { validated_by_record({{definition}}, 11).should_not be_invalid }
-        it { validated_by_record({{definition}}, 13).should_not be_invalid }
+        it { validated_by_record(:age, 12, {{definition}}).should be_invalid }
+        it { validated_by_record(:age, 11, {{definition}}).should_not be_invalid }
+        it { validated_by_record(:age, 13, {{definition}}).should_not be_invalid }
       end
 
       describe "Int16" do
-        it { validated_by_record({{definition}}, 12i64).should be_invalid }
-        it { validated_by_record({{definition}}, 11i64).should_not be_invalid }
-        it { validated_by_record({{definition}}, 13i64).should_not be_invalid }
+        it { validated_by_record(:age, 12i64, {{definition}}).should be_invalid }
+        it { validated_by_record(:age, 11i64, {{definition}}).should_not be_invalid }
+        it { validated_by_record(:age, 13i64, {{definition}}).should_not be_invalid }
       end
 
       describe "Float64" do
-        it { validated_by_record({{definition}}, 12.0).should be_invalid }
-        it { validated_by_record({{definition}}, 11.0).should_not be_invalid }
-        it { validated_by_record({{definition}}, 13.0).should_not be_invalid }
+        it { validated_by_record(:age, 12.0, {{definition}}).should be_invalid }
+        it { validated_by_record(:age, 11.0, {{definition}}).should_not be_invalid }
+        it { validated_by_record(:age, 13.0, {{definition}}).should_not be_invalid }
       end
 
       describe "Float32" do
-        it { validated_by_record({{definition}}, 12.0f32).should be_invalid }
-        it { validated_by_record({{definition}}, 11.0f32).should_not be_invalid }
-        it { validated_by_record({{definition}}, 13.0f32).should_not be_invalid }
+        it { validated_by_record(:age, 12.0f32, {{definition}}).should be_invalid }
+        it { validated_by_record(:age, 11.0f32, {{definition}}).should_not be_invalid }
+        it { validated_by_record(:age, 13.0f32, {{definition}}).should_not be_invalid }
       end
 
       describe "Nil" do
-        it { validated_by_record({{definition}}, nil).should_not be_invalid }
+        it { validated_by_record(:age, nil, {{definition}}).should_not be_invalid }
       end
     end
 
@@ -130,27 +130,27 @@ describe Jennifer::Validations::Numericality do
       {% definition = {less_than: 12} %}
 
       describe "Int32" do
-        it { validated_by_record({{definition}}, 11).should_not be_invalid }
-        it { validated_by_record({{definition}}, 12).should be_invalid }
+        it { validated_by_record(:age, 11, {{definition}}).should_not be_invalid }
+        it { validated_by_record(:age, 12, {{definition}}).should be_invalid }
       end
 
       describe "Int16" do
-        it { validated_by_record({{definition}}, 11i64).should_not be_invalid }
-        it { validated_by_record({{definition}}, 12i64).should be_invalid }
+        it { validated_by_record(:age, 11i64, {{definition}}).should_not be_invalid }
+        it { validated_by_record(:age, 12i64, {{definition}}).should be_invalid }
       end
 
       describe "Float64" do
-        it { validated_by_record({{definition}}, 11.0).should_not be_invalid }
-        it { validated_by_record({{definition}}, 12.0).should be_invalid }
+        it { validated_by_record(:age, 11.0, {{definition}}).should_not be_invalid }
+        it { validated_by_record(:age, 12.0, {{definition}}).should be_invalid }
       end
 
       describe "Float32" do
-        it { validated_by_record({{definition}}, 11.0f32).should_not be_invalid }
-        it { validated_by_record({{definition}}, 12.0f32).should be_invalid }
+        it { validated_by_record(:age, 11.0f32, {{definition}}).should_not be_invalid }
+        it { validated_by_record(:age, 12.0f32, {{definition}}).should be_invalid }
       end
 
       describe "Nil" do
-        it { validated_by_record({{definition}}, nil).should_not be_invalid }
+        it { validated_by_record(:age, nil, {{definition}}).should_not be_invalid }
       end
     end
 
@@ -158,27 +158,27 @@ describe Jennifer::Validations::Numericality do
       {% definition = {less_than_or_equal_to: 12} %}
 
       describe "Int32" do
-        it { validated_by_record({{definition}}, 12).should_not be_invalid }
-        it { validated_by_record({{definition}}, 13).should be_invalid }
+        it { validated_by_record(:age, 12, {{definition}}).should_not be_invalid }
+        it { validated_by_record(:age, 13, {{definition}}).should be_invalid }
       end
 
       describe "Int16" do
-        it { validated_by_record({{definition}}, 12i64).should_not be_invalid }
-        it { validated_by_record({{definition}}, 13i64).should be_invalid }
+        it { validated_by_record(:age, 12i64, {{definition}}).should_not be_invalid }
+        it { validated_by_record(:age, 13i64, {{definition}}).should be_invalid }
       end
 
       describe "Float64" do
-        it { validated_by_record({{definition}}, 12.0).should_not be_invalid }
-        it { validated_by_record({{definition}}, 13.0).should be_invalid }
+        it { validated_by_record(:age, 12.0, {{definition}}).should_not be_invalid }
+        it { validated_by_record(:age, 13.0, {{definition}}).should be_invalid }
       end
 
       describe "Float32" do
-        it { validated_by_record({{definition}}, 12.0f32).should_not be_invalid }
-        it { validated_by_record({{definition}}, 13.0f32).should be_invalid }
+        it { validated_by_record(:age, 12.0f32, {{definition}}).should_not be_invalid }
+        it { validated_by_record(:age, 13.0f32, {{definition}}).should be_invalid }
       end
 
       describe "Nil" do
-        it { validated_by_record({{definition}}, nil).should_not be_invalid }
+        it { validated_by_record(:age, nil, {{definition}}).should_not be_invalid }
       end
     end
 
@@ -186,69 +186,79 @@ describe Jennifer::Validations::Numericality do
       {% definition = {odd: true} %}
 
       describe "Int32" do
-        it { validated_by_record({{definition}}, 13).should_not be_invalid }
-        it { validated_by_record({{definition}}, 14).should be_invalid }
+        it { validated_by_record(:age, 13, {{definition}}).should_not be_invalid }
+        it { validated_by_record(:age, 14, {{definition}}).should be_invalid }
       end
 
       describe "Int16" do
-        it { validated_by_record({{definition}}, 13i64).should_not be_invalid }
-        it { validated_by_record({{definition}}, 14i64).should be_invalid }
+        it { validated_by_record(:age, 13i64, {{definition}}).should_not be_invalid }
+        it { validated_by_record(:age, 14i64, {{definition}}).should be_invalid }
       end
 
       describe "Float64" do
-        it { validated_by_record({{definition}}, 13.0).should_not be_invalid }
-        it { validated_by_record({{definition}}, 14.0).should be_invalid }
+        it { validated_by_record(:age, 13.0, {{definition}}).should_not be_invalid }
+        it { validated_by_record(:age, 14.0, {{definition}}).should be_invalid }
       end
 
       describe "Float32" do
-        it { validated_by_record({{definition}}, 13.0f32).should_not be_invalid }
-        it { validated_by_record({{definition}}, 14.0f32).should be_invalid }
+        it { validated_by_record(:age, 13.0f32, {{definition}}).should_not be_invalid }
+        it { validated_by_record(:age, 14.0f32, {{definition}}).should be_invalid }
       end
 
       describe "String" do
         it do
           expect_raises(ArgumentError) do
-            validated_by_record({{definition}}, "13").should_not be_invalid
+            validated_by_record(:age, "13", {{definition}}).should_not be_invalid
           end
         end
       end
 
       describe "Nil" do
-        it { validated_by_record({{definition}}, nil).should_not be_invalid }
+        it { validated_by_record(:age, nil, {{definition}}).should_not be_invalid }
       end
     end
 
     describe "even" do
       describe "Int32" do
-        it { validated_by_record({even: true}, 14).should_not be_invalid }
-        it { validated_by_record({even: true}, 13).should be_invalid }
+        it { validated_by_record(:age, 14, {even: true}).should_not be_invalid }
+        it { validated_by_record(:age, 13, {even: true}).should be_invalid }
       end
 
       describe "Int16" do
-        it { validated_by_record({even: true}, 14i64).should_not be_invalid }
-        it { validated_by_record({even: true}, 13i64).should be_invalid }
+        it { validated_by_record(:age, 14i64, {even: true}).should_not be_invalid }
+        it { validated_by_record(:age, 13i64, {even: true}).should be_invalid }
       end
 
       describe "Float64" do
-        it { validated_by_record({even: true}, 14.0).should_not be_invalid }
-        it { validated_by_record({even: true}, 13.0).should be_invalid }
+        it { validated_by_record(:age, 14.0, {even: true}).should_not be_invalid }
+        it { validated_by_record(:age, 13.0, {even: true}).should be_invalid }
       end
 
       describe "Float32" do
-        it { validated_by_record({even: true}, 14.0f32).should_not be_invalid }
-        it { validated_by_record({even: true}, 13.0f32).should be_invalid }
+        it { validated_by_record(:age, 14.0f32, {even: true}).should_not be_invalid }
+        it { validated_by_record(:age, 13.0f32, {even: true}).should be_invalid }
       end
 
       describe "String" do
         it do
           expect_raises(ArgumentError) do
-            validated_by_record({even: true}, "14").should_not be_invalid
+            validated_by_record(:age, "14", {even: true}).should_not be_invalid
           end
         end
       end
 
       describe "Nil" do
-        it { validated_by_record({even: true}, nil).should_not be_invalid }
+        it { validated_by_record(:age, nil, {even: true}).should_not be_invalid }
+      end
+    end
+
+    describe "message" do
+      it do
+        proc = ->(record : Jennifer::Model::Translation, field : String) do
+          "#{record.as(Contact).attribute(field)} #{field} invalid"
+        end
+        validated_by_record(:age, 11, {less_than: 3, message: proc})
+          .should has_error_message(:age, "28 age invalid")
       end
     end
 

--- a/spec/validations/presence_spec.cr
+++ b/spec/validations/presence_spec.cr
@@ -4,6 +4,18 @@ describe Jennifer::Validations::Presence do
   # ameba:disable Lint/UselessAssign
   described_class = Jennifer::Validations::Presence
 
-  pending "add #validate"
+  describe "#validate" do
+    it { validated_by_record(:description, nil).should has_error_message(:description, "can't be blank") }
+    it { validated_by_record(:description, "John").should_not has_error_message(:description) }
+
+    describe "message" do
+      it do
+        proc = ->(record : Jennifer::Model::Translation, field : String) { "#{record.as(Address).attribute(field).inspect} #{field} invalid" }
+        validated_by_record(:contact_id, nil, {message: proc, record: Factory.build_address})
+          .should has_error_message(:contact_id, "nil contact_id invalid")
+      end
+    end
+  end
+
   pending "test allow_blank"
 end

--- a/spec/validations/uniqueness_spec.cr
+++ b/spec/validations/uniqueness_spec.cr
@@ -4,6 +4,30 @@ describe Jennifer::Validations::Uniqueness do
   # ameba:disable Lint/UselessAssign
   described_class = Jennifer::Validations::Uniqueness
 
-  pending "add #validate"
+  describe "#validate" do
+    it do
+      Factory.create_contact(description: "test")
+      validated_by_record(:description, "test", {query: Contact.where { _description == "test" }}).should has_error_message(:description, "has already been taken")
+    end
+
+    it do
+      validated_by_record(:description, nil, {query: Contact.where { _description == "test" }}).should_not has_error_message(:description)
+    end
+
+    it { validated_by_record(:description, "John", {query: Contact.where { _description == "test" }}).should_not has_error_message(:description) }
+
+    describe "message" do
+      it do
+        Factory.create_contact(description: "test")
+        proc = ->(record : Jennifer::Model::Translation, field : String) do
+          "#{record.as(Contact).attribute(field).inspect} #{field} invalid"
+        end
+        validated_by_record(:description, "test", {message: proc, query: Contact.where { _description == "test" }})
+          .should has_error_message(:description, "nil description invalid")
+      end
+    end
+  end
+
   pending "test allow_blank"
+  pending "test query"
 end

--- a/src/jennifer/locale/en.yml
+++ b/src/jennifer/locale/en.yml
@@ -7,7 +7,7 @@ jennifer:
       exclusion: "is reserved"
       invalid: "is invalid"
       taken: "has already been taken"
-      # required: "must exist"
+      required: "must exist"
       confirmation: "doesn't match %{attribute}"
       accepted: "must be accepted"
       empty: "can't be empty"

--- a/src/jennifer/model/relation_definition.cr
+++ b/src/jennifer/model/relation_definition.cr
@@ -395,9 +395,10 @@ module Jennifer
       # - *primary* - specify the name of the column to use as the primary key for the relation
       # - *dependent* - specify the destroy strategy of the associated objects when their owner is destroyed;
       # available options are: `destroy`, `delete`, `nullify` (exception is polymorphic relation), `restrict_with_exception`
-      # - *polymorphic* - specifies that this relation is a polymorphic
-      # - *foreign_type* - specify the column used to store  the associated object's type,
+      # - *polymorphic* - passing `true` indicates that this is a polymorphic association
+      # - *foreign_type* - specify the column used to store the associated object's type,
       # if this is a polymorphic relation
+      # - *required* - passing `true` will validate presence of related object; by default it is `false`
       #
       # Methods will be added for retrieval and query for a single associated object, for which this object holds an id:
       #
@@ -416,9 +417,14 @@ module Jennifer
       #
       # - `#association_class_name` - returns casted related object to `ClassName`
       # - `#association_class_name?` - returns whether related object is a `ClassName`
-      macro belongs_to(name, klass, request = nil, foreign = nil, primary = nil, dependent = :none, polymorphic = false, foreign_type = nil)
+      macro belongs_to(name, klass, request = nil, foreign = nil, primary = nil, dependent = :none, polymorphic = false, foreign_type = nil, required = false)
         {{"{% RELATION_NAMES << #{name.id.stringify} %}".id}}
         ::Jennifer::Model::RelationDefinition.declare_dependent({{name}}, {{dependent}}, :belongs_to, {{polymorphic}})
+
+        {% if required %}
+          {% message = required.is_a?(BoolLiteral) ? :required : required %}
+          validates_presence :{{name.id}}, message: {{message}}
+        {% end %}
 
         @[JSON::Field(ignore: true)]
         @{{name.id}} : {{klass}}?
@@ -510,14 +516,14 @@ module Jennifer
       # - *request* - extra request scope to retrieve a specific set of records when access the associated collection
       # (ATM only `WHERE` conditions are respected)
       # - *foreign* - specify the foreign key used for the association
-      # - *foreign_type* - specify the column used to store  the associated object's type,
+      # - *foreign_type* - specify the column used to store the associated object's type,
       # if this is a polymorphic relation
       # - *primary* - specify the name of the column to use as the primary key for the relation
       # - *dependent* - specify the destroy strategy of the associated objects when their owner is destroyed;
       # available options are: `destroy`, `delete`, `nullify`, `restrict_with_exception`
       # - *inverse_of* - specifies the name of the `belongs_to` relation on the associated object that is the inverse of this relation;
       # required for polymorphic relation
-      # - *polymorphic* - specifies that this relation is a polymorphic
+      # - *polymorphic* - passing `true` indicates that this is a polymorphic association
       #
       # The following methods for retrieval and query of a single associated object will be added:
       #

--- a/src/jennifer/query_builder/expression_builder.cr
+++ b/src/jennifer/query_builder/expression_builder.cr
@@ -151,7 +151,7 @@ module Jennifer
         Values.new(field)
       end
 
-      # Cases *expression* to the given *type*.
+      # Casts *expression* to the given *type*.
       #
       # *type* field is pasted as-is.
       #

--- a/src/jennifer/validations/absence.cr
+++ b/src/jennifer/validations/absence.cr
@@ -5,7 +5,7 @@ module Jennifer
     # For more details see `Macros.validates_absence`.
     class Absence < Validator
       def validate(record, **opts)
-        record.errors.add(opts[:field], :present) if opts[:value].present?
+        record.errors.add(opts[:field], opts[:message]? || :present) if opts[:value].present?
       end
     end
   end

--- a/src/jennifer/validations/acceptance.cr
+++ b/src/jennifer/validations/acceptance.cr
@@ -16,7 +16,7 @@ module Jennifer
           else
             !accept.not_nil!.includes?(value)
           end
-        record.errors.add(opts[:field], :accepted) if invalid
+        record.errors.add(opts[:field], opts[:message]? || :accepted) if invalid
       end
     end
   end

--- a/src/jennifer/validations/confirmation.cr
+++ b/src/jennifer/validations/confirmation.cr
@@ -13,9 +13,10 @@ module Jennifer
         value = opts[:value]
         with_blank_validation(record, field, value, false) do
           return true if value.not_nil!.compare(confirmation.not_nil!, !opts[:case_sensitive]?.not_nil!) == 0
+
           record.errors.add(
             field,
-            :confirmation,
+            opts[:message]? || :confirmation,
             options: {:attribute => record.class.human_attribute_name(field)}
           )
         end

--- a/src/jennifer/validations/exclusion.cr
+++ b/src/jennifer/validations/exclusion.cr
@@ -9,7 +9,9 @@ module Jennifer
         value = opts[:value]
         allow_blank = opts[:allow_blank]
         with_blank_validation(record, field, value, allow_blank) do
-          record.errors.add(field, :exclusion) if opts[:collection]?.not_nil!.includes?(value.not_nil!)
+          if opts[:collection]?.not_nil!.includes?(value.not_nil!)
+            record.errors.add(field, opts[:message]? || :exclusion)
+          end
         end
       end
     end

--- a/src/jennifer/validations/format.cr
+++ b/src/jennifer/validations/format.cr
@@ -9,7 +9,7 @@ module Jennifer
         value = opts[:value]
         allow_blank = opts[:allow_blank]
         with_blank_validation(record, field, value, allow_blank) do
-          record.errors.add(field, :invalid) unless opts[:format]?.not_nil! =~ value
+          record.errors.add(field, opts[:message]? || :invalid) unless opts[:format]?.not_nil! =~ value
         end
       end
     end

--- a/src/jennifer/validations/inclusion.cr
+++ b/src/jennifer/validations/inclusion.cr
@@ -9,7 +9,9 @@ module Jennifer
         value = opts[:value]
         allow_blank = opts[:allow_blank]
         with_blank_validation(record, field, value, allow_blank) do
-          record.errors.add(field, :inclusion) unless opts[:collection]?.not_nil!.includes?(value.not_nil!)
+          unless opts[:collection]?.not_nil!.includes?(value.not_nil!)
+            record.errors.add(field, opts[:message]? || :inclusion)
+          end
         end
       end
     end

--- a/src/jennifer/validations/length.cr
+++ b/src/jennifer/validations/length.cr
@@ -4,7 +4,7 @@ module Jennifer
     #
     # For more details see `Macros.validates_length`.
     class Length < Validator
-      def validate(record, **opts)
+      def validate(record, **opts) # ameba:disable Metrics/CyclomaticComplexity
         field = opts[:field]
         value = opts[:value]
         allow_blank = opts[:allow_blank]
@@ -18,16 +18,16 @@ module Jennifer
           errors = record.errors
           if in_value
             if in_value.max < size
-              errors.add(field, :too_long, in_value.max)
+              errors.add(field, opts[:message]? || :too_long, in_value.max)
             elsif in_value.min > size
-              errors.add(field, :too_short, in_value.min)
+              errors.add(field, opts[:message]? || :too_short, in_value.min)
             end
           elsif is && is != size
-            errors.add(field, :wrong_length, is)
+            errors.add(field, opts[:message]? || :wrong_length, is)
           elsif minimum && minimum > size
-            errors.add(field, :too_short, minimum)
+            errors.add(field, opts[:message]? || :too_short, minimum)
           elsif maximum && maximum < size
-            errors.add(field, :too_long, maximum)
+            errors.add(field, opts[:message]? || :too_long, maximum)
           end
         end
       end

--- a/src/jennifer/validations/macros.cr
+++ b/src/jennifer/validations/macros.cr
@@ -63,7 +63,7 @@ module Jennifer
       #   validates_inclusion :code, in: Country::KNOWN_COUNTRIES
       # end
       # ```
-      macro validates_inclusion(field, in in_value, allow_blank = false, if if_value = nil)
+      macro validates_inclusion(field, in in_value, allow_blank = false, if if_value = nil, message = nil)
         validates_with_method(%validate_method, if: {{if_value}})
 
         # :nodoc:
@@ -73,7 +73,8 @@ module Jennifer
             field: {{field}},
             value: {{field.id}},
             allow_blank: {{allow_blank}},
-            collection: {{in_value}}
+            collection: {{in_value}},
+            message: {{message}}
           )
         end
       end
@@ -90,7 +91,7 @@ module Jennifer
       #   validates_exclusion :code, in: %w(AA DD)
       # end
       # ```
-      macro validates_exclusion(field, in in_value, allow_blank = false, if if_value = nil)
+      macro validates_exclusion(field, in in_value, allow_blank = false, if if_value = nil, message = nil)
         validates_with_method(%validate_method, if: {{if_value}})
 
         # :nodoc:
@@ -100,7 +101,8 @@ module Jennifer
             field: {{field}},
             value: {{field.id}},
             allow_blank: {{allow_blank}},
-            collection: {{in_value}}
+            collection: {{in_value}},
+            message: {{message}}
           )
         end
       end
@@ -118,7 +120,7 @@ module Jennifer
       #   validates_format :street, /st\.|street/i
       # end
       # ```
-      macro validates_format(field, value, allow_blank = false, if if_value = nil)
+      macro validates_format(field, value, allow_blank = false, if if_value = nil, message = nil)
         validates_with_method(%validate_method, if: {{if_value}})
 
         # :nodoc:
@@ -128,7 +130,8 @@ module Jennifer
             field: {{field}},
             value: {{field.id}},
             allow_blank: {{allow_blank}},
-            format: {{value}}
+            format: {{value}},
+            message: {{message}}
           )
         end
       end
@@ -151,7 +154,7 @@ module Jennifer
       #   validates_length :uid, is: 16
       # end
       # ```
-      macro validates_length(field, if if_value = nil, **options)
+      macro validates_length(field, if if_value = nil, message = nil, **options)
         {% options[:allow_blank] = options[:allow_blank] == nil ? false : options[:allow_blank] %}
         validates_with_method(%validate_method, if: {{if_value}})
 
@@ -161,6 +164,7 @@ module Jennifer
             self,
             field: {{field}},
             value: {{field.id}},
+            message: {{message}},
             {{**options}}
           )
         end
@@ -181,7 +185,7 @@ module Jennifer
       #   validate_uniqueness :code
       # end
       # ```
-      macro validates_uniqueness(*fields, allow_blank allow_blank_value = false, if if_value = nil)
+      macro validates_uniqueness(*fields, allow_blank allow_blank_value = false, if if_value = nil, message = nil)
         # raise a compile time error if a uniqueness validator is specified
         # that does not define any properties
         {% raise "A uniqueness check requires at least one field" if fields.empty? %}
@@ -207,6 +211,7 @@ module Jennifer
             # pass on nil here to signal nil values in record
             value: {{normalized_fields}}.all?(&.nil?) ? nil : {{normalized_fields}},
             allow_blank: {{allow_blank_value}},
+            message: {{message}},
             query: self.class{{fields_condition.id}}
           )
         end
@@ -224,12 +229,17 @@ module Jennifer
       #   validates_presence :email
       # end
       # ```
-      macro validates_presence(field, if if_value = nil)
+      macro validates_presence(field, if if_value = nil, message = nil)
         validates_with_method(%validate_method, if: {{if_value}})
 
         # :nodoc:
         def %validate_method
-          ::Jennifer::Validations::Presence.instance.validate(self, field: {{field}}, value: {{field.id}})
+          ::Jennifer::Validations::Presence.instance.validate(
+            self,
+            field: {{field}},
+            value: {{field.id}},
+            message: {{message}}
+          )
         end
       end
 
@@ -243,12 +253,17 @@ module Jennifer
       #   validates_absence :title
       # end
       # ```
-      macro validates_absence(field, if if_value = nil)
+      macro validates_absence(field, if if_value = nil, message = nil)
         validates_with_method(%validate_method, if: {{if_value}})
 
         # :nodoc:
         def %validate_method
-          ::Jennifer::Validations::Absence.instance.validate(self, field: {{field}}, value: {{field.id}})
+          ::Jennifer::Validations::Absence.instance.validate(
+            self,
+            field: {{field}},
+            value: {{field.id}},
+            message: {{message}}
+          )
         end
       end
 
@@ -273,7 +288,7 @@ module Jennifer
       #   validates_numericality :health, greater_than: 0
       # end
       # ```
-      macro validates_numericality(field, if if_value = nil, **options)
+      macro validates_numericality(field, if if_value = nil, message = nil, **options)
         {% options[:allow_blank] = options[:allow_blank] == nil ? false : options[:allow_blank] %}
         validates_with_method(%validate_method, if: {{if_value}})
 
@@ -283,6 +298,7 @@ module Jennifer
             self,
             field: {{field}},
             value: {{field.id}},
+            message: {{message}},
             {{**options}}
           )
         end
@@ -305,7 +321,7 @@ module Jennifer
       #   validates_acceptance :eula, accept: %w(true accept yes)
       # end
       # ```
-      macro validates_acceptance(field, accept = nil, if if_value = nil)
+      macro validates_acceptance(field, accept = nil, if if_value = nil, message = nil)
         validates_with_method(%validate_method, if: {{if_value}})
 
         # :nodoc:
@@ -314,7 +330,8 @@ module Jennifer
             self,
             field: {{field}},
             value: {{field.id}},
-            accept: {{accept}}
+            accept: {{accept}},
+            message: {{message}}
           )
         end
       end
@@ -335,7 +352,7 @@ module Jennifer
       #   validates_confirmation :address, case_insensitive: true
       # end
       # ```
-      macro validates_confirmation(field, case_sensitive = true, if if_value = nil)
+      macro validates_confirmation(field, case_sensitive = true, if if_value = nil, message = nil)
         validates_with_method(%validate_method, if: {{if_value}})
 
         # :nodoc:
@@ -345,7 +362,8 @@ module Jennifer
             field: {{field}},
             value: {{field.id}},
             confirmation: {{field.id}}_confirmation,
-            case_sensitive: {{case_sensitive}}
+            case_sensitive: {{case_sensitive}},
+            message: {{message}}
           )
         end
       end

--- a/src/jennifer/validations/numericality.cr
+++ b/src/jennifer/validations/numericality.cr
@@ -21,25 +21,25 @@ module Jennifer
           value = value.not_nil!
           errors = record.errors
 
-          errors.add(field, :greater_than, {:value => greater_than}) if greater_than.try(&.>= value)
+          errors.add(field, opts[:message]? || :greater_than, {:value => greater_than}) if greater_than.try(&.>= value)
 
           if greater_than_or_equal_to.try(&.> value)
-            errors.add(field, :greater_than_or_equal_to, {:value => greater_than_or_equal_to})
+            errors.add(field, opts[:message]? || :greater_than_or_equal_to, {:value => greater_than_or_equal_to})
           end
 
-          errors.add(field, :equal_to, {:value => equal_to}) if equal_to.try(&.!= value)
+          errors.add(field, opts[:message]? || :equal_to, {:value => equal_to}) if equal_to.try(&.!= value)
 
-          errors.add(field, :less_than, {:value => less_than}) if less_than.try(&.<= value)
+          errors.add(field, opts[:message]? || :less_than, {:value => less_than}) if less_than.try(&.<= value)
 
           if less_than_or_equal_to.try(&.< value)
-            errors.add(field, :less_than_or_equal_to, {:value => less_than_or_equal_to})
+            errors.add(field, opts[:message]? || :less_than_or_equal_to, {:value => less_than_or_equal_to})
           end
 
-          errors.add(field, :other_than, {:value => other_than}) if other_than.try(&.== value)
+          errors.add(field, opts[:message]? || :other_than, {:value => other_than}) if other_than.try(&.== value)
 
-          errors.add(field, :odd) if odd && even?(value)
+          errors.add(field, opts[:message]? || :odd) if odd && even?(value)
 
-          errors.add(field, :even) if even && odd?(value)
+          errors.add(field, opts[:message]? || :even) if even && odd?(value)
         end
       end
 

--- a/src/jennifer/validations/presence.cr
+++ b/src/jennifer/validations/presence.cr
@@ -5,7 +5,7 @@ module Jennifer
     # For more details see `Macros.validates_presence`.
     class Presence < Validator
       def validate(record, **opts)
-        record.errors.add(opts[:field], :blank) if opts[:value].blank?
+        record.errors.add(opts[:field], opts[:message]? || :blank) if opts[:value].blank?
       end
     end
   end

--- a/src/jennifer/validations/uniqueness.cr
+++ b/src/jennifer/validations/uniqueness.cr
@@ -13,7 +13,7 @@ module Jennifer
           _query = opts[:query]?.not_nil!.clone
           _query.where { primary != record.primary } unless record.new_record?
 
-          record.errors.add(field, :taken) if _query.exists?
+          record.errors.add(field, opts[:message]? || :taken) if _query.exists?
         end
       end
     end


### PR DESCRIPTION
# What does this PR do?

Extends ability to customize model validation error message. Also improve some docs.

# Release notes

**Validation**

- add `jennifer.errors.messages.required` message in locale yaml file
- `Jennifer::Model::Errors#add` accepts `String | Symbol | Proc(Translation, String, String)` for `message` argument
- `validates_inclusion`, `validates_exclusion`, `validates_format`, `validates_length`, `validates_uniqueness`, `validates_presence`, `validates_absence`, `validates_numericality`, `validates_acceptance` & `validates_confirmation` validation macros accepts `message` option that allows to specify validation message

**Relation**

- `belongs_to` relation macro accepts `required` option to validate existence of relation on save