### PR TITLE
Add STI support to hash-based model initializer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,28 +56,36 @@ jobs:
             db_password: dbpassword
           - crystal_version: 1.5.1
             DB: mysql
-            integration: true
-            linter: true
             db_user: root
             db_password:
           - crystal_version: 1.5.1
             DB: postgres
+            db_user: dbuser
+            db_password: dbpassword
+          - crystal_version: 1.6.1
+            DB: mysql
+            integration: true
+            linter: true
+            db_user: root
+            db_password:
+          - crystal_version: 1.6.1
+            DB: postgres
             integration: true
             linter: true
             db_user: dbuser
             db_password: dbpassword
-          - crystal_version: 1.5.1
+          - crystal_version: 1.6.1
             DB: postgres
             db_user: dbuser
             db_password: dbpassword
             other: MT=1
-          - crystal_version: 1.5.1
+          - crystal_version: 1.6.1
             DB: postgres
             pair: true
             db_user: dbuser
             db_password: dbpassword
             other: PAIR_DB_USER=root PAIR_DB_PASSWORD=
-          - crystal_version: 1.5.1
+          - crystal_version: 1.6.1
             DB: mysql
             pair: true
             db_user: root
@@ -111,7 +119,7 @@ jobs:
       - name: Install dependencies
         run: |
           function version { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
-          if [ $(version '${{ matrix.crystal_version }}') -lt $(version '1.4.1') ]; then
+          if [ $(version '${{ matrix.crystal_version }}') -lt $(version '1.6.1') ]; then
             cp .github/shard_1_3_2.yml shard.yml
           fi
           shards install

--- a/shard.yml
+++ b/shard.yml
@@ -23,7 +23,7 @@ development_dependencies:
     version: "~> 0.4.1"
   ameba:
     github: crystal-ameba/ameba
-    version: "= 1.0.0"
+    version: "= 1.2.0"
   micrate:
     github: "amberframework/micrate"
     version: "= 0.12.0"

--- a/spec/model/sti_mapping_spec.cr
+++ b/spec/model/sti_mapping_spec.cr
@@ -136,6 +136,36 @@ describe Jennifer::Model::STIMapping do
         f.uid.should eq("uid")
       end
 
+      it "builds proper subclass from symbol hash" do
+        f = Profile.new({:login => "asd", :uid => "uid", :type => "FacebookProfile"})
+        f.should be_a(FacebookProfile)
+
+        f = f.as(FacebookProfile)
+        f.type.should eq("FacebookProfile")
+        f.login.should eq("asd")
+        f.uid.should eq("uid")
+      end
+
+      it "builds proper subclass from string hash" do
+        f = Profile.new({"login" => "asd", "uid" => "uid", "type" => "FacebookProfile"})
+        f.should be_a(FacebookProfile)
+
+        f = f.as(FacebookProfile)
+        f.type.should eq("FacebookProfile")
+        f.login.should eq("asd")
+        f.uid.should eq("uid")
+      end
+
+      it "builds proper subclass from named tuple" do
+        f = Profile.new({login: "asd", email: "test@email.co", type: "TwitterProfile"})
+        f.should be_a(TwitterProfile)
+
+        f = f.as(TwitterProfile)
+        f.type.should eq("TwitterProfile")
+        f.login.should eq("asd")
+        f.email.should eq("test@email.co")
+      end
+
       it "properly loads aliased columns in superclass" do
         b = Book.new({
           :name      => "HowToMapDbStuff?",

--- a/spec/models.cr
+++ b/spec/models.cr
@@ -138,7 +138,7 @@ end
 
 class FacebookProfile < Profile
   mapping(
-    uid: String?, # for testing purposes
+    uid: String?,
     virtual_child_field: {type: Int32?, virtual: true}
   )
 
@@ -157,7 +157,7 @@ end
 
 class TwitterProfile < Profile
   mapping(
-    email: {type: String, null: true} # for testing purposes
+    email: {type: String, null: true}
   )
 end
 
@@ -479,6 +479,7 @@ class ContactWithDependencies < Jennifer::Model::Base
   has_many :facebook_profiles, FacebookProfile, dependent: :nullify, foreign: :contact_id
   has_many :passports, Passport, dependent: :destroy, foreign: :contact_id
   has_many :twitter_profiles, TwitterProfile, dependent: :restrict_with_exception, foreign: :contact_id
+  has_many :profiles, Profile, foreign: :contact_id, dependent: :restrict_with_exception
   has_and_belongs_to_many :u_countries, Country, {where { _name.like("U%") }}, foreign: :contact_id
 
   validates_length :name, minimum: 2
@@ -563,12 +564,12 @@ class FacebookProfileWithDestroyNotable < Jennifer::Model::Base
   module Mapping
     macro included
       mapping({
-        id: Primary64,
-        login: String,
+        id:         Primary64,
+        login:      String,
         contact_id: Int64?,
-        type: String,
-        uid: String?
-    }, false)
+        type:       String,
+        uid:        String?,
+      }, false)
     end
   end
 

--- a/spec/query_builder/eager_loading_spec.cr
+++ b/spec/query_builder/eager_loading_spec.cr
@@ -249,6 +249,21 @@ describe Jennifer::QueryBuilder::EagerLoading do
       end
     end
 
+    it "loads STI record" do
+      c = ContactWithDependencies.create!({name: "test name", description: "description"})
+      profile1 = Factory.create_facebook_profile(contact_id: c.id)
+      profile2 = Factory.create_twitter_profile(contact_id: c.id)
+      ContactWithDependencies.eager_load(:profiles).order(Profile._id.asc).each do |contact|
+        contact.id.should eq(c.id)
+        contact.profiles.size.should eq(2)
+        contact.profiles[0].should be_a(FacebookProfile)
+        contact.profiles[0].as(FacebookProfile).uid.should eq(profile1.uid)
+
+        contact.profiles[1].should be_a(TwitterProfile)
+        contact.profiles[1].as(TwitterProfile).email.should eq(profile2.email)
+      end
+    end
+
     context "with defined inverse_of" do
       it "sets owner during building collection" do
         c = Factory.create_contact

--- a/src/jennifer/adapter/base.cr
+++ b/src/jennifer/adapter/base.cr
@@ -208,6 +208,10 @@ module Jennifer
         sql_generator.parse_query(q)
       end
 
+      def coerce_database_value(value, target_class)
+        value
+      end
+
       def max_bind_vars_count
         Config.instance.max_bind_vars_count || self.class.default_max_bind_vars_count
       end

--- a/src/jennifer/model/callback.cr
+++ b/src/jennifer/model/callback.cr
@@ -266,36 +266,36 @@ module Jennifer
         # :nodoc:
         CALLBACKS = {
           save: {
-            before: [] of String,
-            after: [] of String,
-            commit: [] of String,
-            rollback: [] of String
+            before:   [] of String,
+            after:    [] of String,
+            commit:   [] of String,
+            rollback: [] of String,
           },
           create: {
-            before: [] of String,
-            after: [] of String,
-            commit: [] of String,
-            rollback: [] of String
+            before:   [] of String,
+            after:    [] of String,
+            commit:   [] of String,
+            rollback: [] of String,
           },
           update: {
-            before: [] of String,
-            after: [] of String,
-            commit: [] of String,
-            rollback: [] of String
+            before:   [] of String,
+            after:    [] of String,
+            commit:   [] of String,
+            rollback: [] of String,
           },
           destroy: {
-            after: [] of String,
-            before: [] of String,
-            commit: [] of String,
-            rollback: [] of String
+            after:    [] of String,
+            before:   [] of String,
+            commit:   [] of String,
+            rollback: [] of String,
           },
           initialize: {
-            after: [] of String
+            after: [] of String,
           },
           validation: {
             before: [] of String,
-            after: [] of String
-          }
+            after:  [] of String,
+          },
         }
       end
 

--- a/src/jennifer/model/mapping.cr
+++ b/src/jennifer/model/mapping.cr
@@ -419,7 +419,7 @@ module Jennifer
                 {% if value[:converter] %}
                   {{value[:converter]}}.from_hash(values, {{column1}}, self.class.columns_tuple[:{{key.id}}])
                 {% else %}
-                  values[{{column1}}]
+                  {{@type}}.read_adapter.coerce_database_value(values[{{column1}}], {{value[:type]}})
                 {% end %}
             {% if column2 %}
               elsif values.has_key?({{column2}})
@@ -427,7 +427,7 @@ module Jennifer
                   {% if value[:converter] %}
                     {{value[:converter]}}.from_hash(values, {{column2}}, self.class.columns_tuple[:{{key.id}}])
                   {% else %}
-                    values[{{column2}}]
+                    {{@type}}.read_adapter.coerce_database_value(values[{{column2}}], {{value[:type]}})
                   {% end %}
             {% end %}
             end

--- a/src/jennifer/model/timestamp.cr
+++ b/src/jennifer/model/timestamp.cr
@@ -5,6 +5,7 @@ module Jennifer::Model
 
     macro included
       def track_timestamps_on_update; end
+
       def track_timestamps_on_create; end
     end
 


### PR DESCRIPTION
# What does this PR do?

Besides fixing STI model initializing using hash constructor this PR also adds extra layer of database column value coercing. This means that when a result set is read as a hash based on the received data types specification from the database model adapter is used to coerce them based on the attribute desired type.

Fix #403 

# Release notes

**Model**

* add missing STI initialization to constructors accepting a hash or named tuple
* use `Adapter::Base.coerce_database_value` in constructors accepting a hash or named tuple to coerce values for columns that don't have specified converter 

**Adapter**

* add `Base.coerce_database_value` method to provide interface to perform coercing from default database type used to read column to hash to a desired model attribute type