### PR TITLE
Render a proper connection string without username or password

### DIFF
--- a/spec/adapter/base_spec.cr
+++ b/spec/adapter/base_spec.cr
@@ -461,6 +461,15 @@ describe Jennifer::Adapter::Base do
         adapter.connection_string(:root).should match(connection_string)
       end
     end
+
+    context "without username or password" do
+      it do
+        config.user = ""
+        config.password = ""
+        connection_string = /^#{adapter.class.protocol}\:\/\/#{config.host}/
+        adapter.connection_string(:root).should match(connection_string)
+      end
+    end
   end
 
   describe "#query_array" do

--- a/src/jennifer/adapter/base.cr
+++ b/src/jennifer/adapter/base.cr
@@ -264,7 +264,7 @@ module Jennifer
           config.port.try(&.>(0)) ? config.port : nil,
           type.db? ? config.db : "",
           connection_query,
-          config.user,
+          config.user.blank? ? nil : config.user,
           config.password && !config.password.empty? ? config.password : nil
         ).to_s
       end


### PR DESCRIPTION
Allows Adapter::Base#connection_string to render a connection string such as postgres://localhost/db_name

previously, when given no username or password, it would render postgres://@localhost/db_name, which is an invalid connection string.

# Any background context you want to provide?

Re my issues getting started at #444 -- the first thing I tried to do was to connect to my local database without a username or password.

I ran into this with posgresql, but I did not have a local mysql installation available for testing.

# Release notes

**Config**
[BUGFIX] Now connection strings can be rendered without username or password.