### PR TITLE
Rely on global log level setup instead of waiting for custom logger to be assigned

### DIFF
--- a/.github/run_integration_tests.sh
+++ b/.github/run_integration_tests.sh
@@ -7,7 +7,16 @@ then
   sudo apt-get install postgresql-client -y
 fi
 
-crystal spec spec/integration/sam_test.cr &&
-  # TODO: fix concurrency tests
-  # crystal spec spec/integration/concurrency_test.cr -Dpreview_mt &&
-  crystal spec spec/integration/micrate_test.cr
+# === general tests ===
+
+crystal spec spec/integration/sam_test.cr
+  # TODO: fix tests
+  # && crystal spec spec/integration/concurrency_test.cr -Dpreview_mt
+
+# === micrate tests ===
+
+cp ./.github/shard_micrate.yml ./shard.yml
+
+shards
+
+crystal spec spec/integration/micrate_test.cr

--- a/.github/setup_mysql.sh
+++ b/.github/setup_mysql.sh
@@ -2,7 +2,7 @@
 
 set -exo pipefail
 
-MYSQL="mysql:8.0.30"
+MYSQL="mysql:8.0.35"
 tries=0
 
 sudo service mysql stop

--- a/.github/shard.override.yml
+++ b/.github/shard.override.yml
@@ -1,0 +1,4 @@
+dependencies:
+  db:
+    github: crystal-lang/crystal-db
+    version: ~> 0.11.0

--- a/.github/shard_micrate.yml
+++ b/.github/shard_micrate.yml
@@ -1,0 +1,40 @@
+# Differences from a shard.yml:
+# - missing ameba
+# - uncommetned micrate
+# - crystal-mysql and crystal-pg have lower versions to support micrate
+name: jennifer
+version: 0.13.0
+
+authors:
+  - Roman Kalnytskyi <moranibaca@gmail.com>
+
+crystal: ">= 0.36.0"
+
+license: MIT
+
+development_dependencies:
+  mysql:
+    github: crystal-lang/crystal-mysql
+    version: "= 0.14.0"
+  pg:
+    github: will/crystal-pg
+    version: "= 0.26.0"
+  factory:
+    github: imdrasil/factory
+    version: "~> 0.1.5"
+  sam:
+    github: imdrasil/sam.cr
+    version: "~> 0.5.0"
+  micrate:
+    github: "amberframework/micrate"
+    version: "= 0.15.1"
+dependencies:
+  wordsmith:
+    github: luckyframework/wordsmith
+    version: ">= 0.3.0"
+  ifrit:
+    github: imdrasil/ifrit
+    version: "= 0.1.3"
+  i18n:
+    github: crimson-knight/i18n.cr
+    version: "~> 0.4.1"

--- a/.github/shard_simple.yml
+++ b/.github/shard_simple.yml
@@ -1,4 +1,7 @@
-# NOTE: the only difference from 1.4.1 is missing ameba
+# Differences from a shard.yml:
+# - missing ameba
+# - crystal-pg has a fixed version as older one isn't supported by older crystal
+# - crystal-mysql has a fixed version
 name: jennifer
 version: 0.13.0
 
@@ -21,10 +24,7 @@ development_dependencies:
     version: "~> 0.1.5"
   sam:
     github: imdrasil/sam.cr
-    version: "~> 0.4.1"
-  micrate:
-    github: "amberframework/micrate"
-    version: "= 0.12.0"
+    version: "~> 0.5.0"
 dependencies:
   wordsmith:
     github: luckyframework/wordsmith

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,8 @@ jobs:
         run: |
           function version { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
           if [ $(version '${{ matrix.crystal_version }}') -lt $(version '1.8.2') ]; then
-            cp .github/shard_1_3_2.yml shard.yml
+            cp .github/shard_simple.yml shard.yml
+            cp .github/shard.override.yml shard.override.yml
           fi
           shards install
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ dependencies:
 ### Requirements
 
 - you need to choose one of the existing drivers for your DB: [mysql](https://github.com/crystal-lang/crystal-mysql) or [postgres](https://github.com/will/crystal-pg); sqlite3 adapter automatically installs required driver for it;
+  - MySQL <= 8.0.35 is supported
 - crystal `>= 1.0.0`.
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ dependencies:
 ### Requirements
 
 - you need to choose one of the existing drivers for your DB: [mysql](https://github.com/crystal-lang/crystal-mysql) or [postgres](https://github.com/will/crystal-pg); sqlite3 adapter automatically installs required driver for it;
-  - MySQL <= 8.0.35 is supported
 - crystal `>= 1.0.0`.
+
+> MySQL `8.0.36` and above isn't supported at the moment
 
 ## Usage
 
@@ -34,7 +35,7 @@ Jennifer has built-in database migration management system. Migrations allow you
 To start using Jennifer you'll first need to generate a migration:
 
 ```shell
-$ crystal sam.cr -- generate:migration CreateContact
+$ crystal sam.cr generate:migration CreateContact
 ```
 
 then fill the created migration file with content:
@@ -63,7 +64,7 @@ end
 and run
 
 ```shell
-$ crystal sam.cr -- db:setup
+$ crystal sam.cr db:setup
 ```
 
 to create the database and run the newly created migration.

--- a/README.md
+++ b/README.md
@@ -151,10 +151,6 @@ You can easily configure error message generated for certain validation violatio
 Jennifer uses a [standard](https://crystal-lang.org/api/latest/Log.html) Crystal logging mechanism so you could specify your own logger, backend and formatter:
 
 ```crystal
-# This is the default logger configuration
-Jennifer::Config.configure do |conf|
-  conf.logger = Log.for("db", :debug)
-end
 Log.setup "db", :debug, Log::IOBackend.new(formatter: Jennifer::Adapter::DBFormatter)
 ```
 

--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -18,7 +18,7 @@ load_dependencies "jennifer"
 Creates database described in the configuration.
 
 ```shell
-$ crystal sam.cr -- db:create
+$ crystal sam.cr db:create
 ```
 
 > Will create only **one** database. This means that for test environment (and for any extra environment you want) this command should be invoked separately. This is common for all commands in this section.
@@ -30,7 +30,7 @@ If database is already exists - successfully finishes (returns code 0).
 Drops database described in the configuration.
 
 ```shell
-$ crystal sam.cr -- db:drop
+$ crystal sam.cr db:drop
 ```
 
 ### db:setup
@@ -38,7 +38,7 @@ $ crystal sam.cr -- db:drop
 Creates database, invokes all pending migrations and populate database with seeds.
 
 ```shell
-$ crystal sam.cr -- db:setup
+$ crystal sam.cr db:setup
 ```
 
 ### db:migrate
@@ -46,7 +46,7 @@ $ crystal sam.cr -- db:setup
 Runs all pending migrations and stores them in the `versions` table. After execution of new migrations database schema is dumped to the `structure.sql` file.
 
 ```shell
-$ crystal sam.cr -- db:migrate
+$ crystal sam.cr db:migrate
 ```
 
 ### db:step
@@ -54,8 +54,8 @@ $ crystal sam.cr -- db:migrate
 Runs exact count of migrations (1 by default).
 
 ```shell
-$ crystal sam.cr -- db:step
-$ crystal sam.cr -- db:step <count>
+$ crystal sam.cr db:step
+$ crystal sam.cr db:step <count>
 ```
 
 ### db:rollback
@@ -63,19 +63,19 @@ $ crystal sam.cr -- db:step <count>
 Rollbacks the last run migration
 
 ```shell
-$ crystal sam.cr -- db:rollback
+$ crystal sam.cr db:rollback
 ```
 
 To rollbacks specific count of migrations:
 
 ```shell
-$ crystal sam.cr -- db:rollback <count>
+$ crystal sam.cr db:rollback <count>
 ```
 
 To rollback to the specific version:
 
 ```shell
-$ crystal sam.cr -- db:rollback -v <migration_version>
+$ crystal sam.cr db:rollback -v <migration_version>
 ```
 
 ### db:version
@@ -83,7 +83,7 @@ $ crystal sam.cr -- db:rollback -v <migration_version>
 Outputs current database version.
 
 ```shell
-$ crystal sam.cr -- db:version
+$ crystal sam.cr db:version
 ```
 
 ### db:seed
@@ -92,7 +92,7 @@ Populates database with seeds. By default this task is empty and should be defin
 bases.
 
 ```shell
-$ crystal sam.cr -- db:seed
+$ crystal sam.cr db:seed
 ```
 
 ### db:schema:load
@@ -100,7 +100,7 @@ $ crystal sam.cr -- db:seed
 Creates database from the `structure.sql` file.
 
 ```shell
-$ crystal sam.cr -- db:schema:load
+$ crystal sam.cr db:schema:load
 ```
 
 > Running migration after this may cause error messages because of missing any information about run migrations in scope of current schema generating.
@@ -112,13 +112,13 @@ $ crystal sam.cr -- db:schema:load
 Generates model and related migration based on the given definition.
 
 ```shell
-$ crystal sam.cr -- generate:model <ModelName> [field1:type] ... [fieldN:type?]
+$ crystal sam.cr generate:model <ModelName> [field1:type] ... [fieldN:type?]
 ```
 
 Example:
 
 ```shell
-$ crystal sam.cr -- generate:model Article title:string text:text? author:reference
+$ crystal sam.cr generate:model Article title:string text:text? author:reference
 ```
 
 ```crystal
@@ -182,5 +182,5 @@ The `?` symbol at the end of type name means that this field is nilable.
 Generates simple migration template.
 
 ```shell
-$ crystal sam.cr -- generate:migration CreateArticles
+$ crystal sam.cr generate:migration CreateArticles
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,38 +67,17 @@ If your configurations aren't stored on the top level - you can manipulate which
 Jennifer::Config.read("./spec/fixtures/database.yml", &.["database"]["development"])
 ```
 
-Also configuration can be parsed directly from URI:
+Also some configuration can be parsed directly from a URI:
 
 ```crystal
 db_uri = "mysql://root@somehost/some_database?max_pool_size=111&initial_pool_size=222&max_idle_pool_size=333&retry_attempts=444&checkout_timeout=555&retry_delay=666"
 Jennifer::Config.from_uri(db)
 ```
 
-Take into account - some configs can't be initialized using URI or yaml file but all of them always can be initialized using `Jennifer::Config.configure`. Here is the list of such configs:
-
-| Config | YAML | URI |
-| --- | --- | --- |
-| `logger` | ❌ | ❌ |
-| `migration_files_path` | ✔ | ❌ |
-| `verbose_migrations` | ✔ | ❌ |
-| `model_files_path` | ✔ | ❌ |
-| `local_time_zone_name` | ✔ | ❌ |
-| `schema` | ✔ | ❌ |
-| `structure_folder` | ✔ | ❌ |
-| `skip_dumping_schema_sql` | ✔ | ❌ |
-| `docker_container` | ✔ | ❌ |
-| `docker_source_location` | ✔ | ❌ |
-| `command_shell_sudo` | ✔ | ❌ |
-| `migration_failure_handler_method` | ✔ | ❌ |
-| `allow_outdated_pending_migration` | ✔ | ❌ |
-| `max_bind_vars_count` | ✔ | ❌ |
-| `time_zone_aware_attributes` | ✔ | ❌ |
-
 ## Supported configuration options
 
 * `host` - database host; default: `"localhost"`
 * `port` - database port; default: `-1` (`-1` value makes adapter to skip port in building connection URL, specify required port number)
-* `logger` - logger instance; default: `Log.for("db", :debug)`
 * `schema` - PostgreSQL database schema name; default: `"public"`
 * `user` - database user name used to connect to the database
 * `password` - database user password used to connect to the database (if not specified - connection URL will specify only user name)
@@ -134,15 +113,6 @@ Take into account - some configs can't be initialized using URI or yaml file but
 ## Logging
 
 Jennifer uses [standard](https://crystal-lang.org/api/latest/Log.html) Crystal logging mechanism so you could specify your own logger:
-
-```crystal
-# This is default logger configuration
-Jennifer::Config.configure do |conf|
-  conf.logger = Log.for("db", :debug)
-end
-```
-
-As a default formatter `Jennifer::Adapter::DBFormatter` could be used:
 
 ```crystal
 Log.setup "db", :debug, Log::IOBackend.new(formatter: Jennifer::Adapter::DBFormatter)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -115,6 +115,12 @@ Jennifer::Config.from_uri(db)
 Jennifer uses [standard](https://crystal-lang.org/api/latest/Log.html) Crystal logging mechanism so you could specify your own logger:
 
 ```crystal
+require "jennifer/adapter/db_colorized_formatter"
+
+Log.setup "db", :debug, Log::IOBackend.new(formatter: Jennifer::Adapter::DBColorizedFormatter)
+
+# or colorless
+
 Log.setup "db", :debug, Log::IOBackend.new(formatter: Jennifer::Adapter::DBFormatter)
 ```
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -57,10 +57,9 @@ APP_ENV = ENV["APP_ENV"]? || "development"
 Jennifer::Config.configure do |conf|
   conf.read("config/database.yml", APP_ENV)
   conf.from_uri(ENV["DATABASE_URI"]) if ENV.has_key?("DATABASE_URI")
-  conf.logger.level = APP_ENV == "development" ? Log::Severity::Debug : Log::Severity::Error
 end
 
-Log.setup "db", :debug, Log::IOBackend.new(formatter: Jennifer::Adapter::DBFormatter)
+Log.setup "db", APP_ENV == "development" ? :debug : :error, Log::IOBackend.new(formatter: Jennifer::Adapter::DBFormatter)
 ```
 
 This allows you to put all database related configuration to structured yml file and override it with custom database connection URI passing it in `DATABASE_URI`.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -119,7 +119,7 @@ require "sam"
 load_dependencies "jennifer"
 ```
 
-Now you can invoke `$ crystal sam.cr -- help` to get list of all available tasks. Also you can generate makefile shorthand for this - just invoke `$ crystal sam.cr -- generate:makefile`. Now you are able to invoke Sam tasks by `make` - `$make sam help`.
+Now you can invoke `$ crystal sam.cr help` to get list of all available tasks. Also you can generate makefile shorthand for this - just invoke `$ crystal sam.cr generate:makefile`. Now you are able to invoke Sam tasks by `make` - `$make sam help`.
 
 ## Usage
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -170,8 +170,6 @@ exec("ALTER TABLE addresses CHANGE street st VARCHAR(20)")
 
 All changes are executed one by one so you also could add data changes here (in `#up` and/or `#down`).
 
-To be sure that your db is up to date, add `Jennifer::Migration::Runner.migrate` in `spec_helper.cr`.
-
 #### Enum
 
 Now enums are supported as well but each adapter has own implementation. For mysql is enough just write down all values:

--- a/scripts/run.cr
+++ b/scripts/run.cr
@@ -4,8 +4,8 @@ require "./migrations/*"
 require "../src/jennifer/sam"
 
 Log.setup "db",
-  :debug,
-  # :error,
+  # :debug,
+  :error,
   Log::IOBackend.new(formatter: Jennifer::Adapter::DBFormatter)
 
 Sam.namespace "script" do

--- a/scripts/run.cr
+++ b/scripts/run.cr
@@ -3,12 +3,10 @@ require "../spec/support/models"
 require "./migrations/*"
 require "../src/jennifer/sam"
 
-# ameba:disable Lint/UnusedArgument
-Jennifer::Config.configure do |conf|
-  # conf.logger.level = :error
-end
-
-Log.setup "db", :debug, Log::IOBackend.new(formatter: Jennifer::Adapter::DBFormatter)
+Log.setup "db",
+  :debug,
+  # :error,
+  Log::IOBackend.new(formatter: Jennifer::Adapter::DBFormatter)
 
 Sam.namespace "script" do
   task "drop_models" do

--- a/shard.override.yml
+++ b/shard.override.yml
@@ -1,4 +1,0 @@
-dependencies: {}
-  # db:
-  #   github: crystal-lang/crystal-db
-  #   version: ~> 0.11.0

--- a/shard.override.yml
+++ b/shard.override.yml
@@ -1,4 +1,4 @@
-dependencies:
-  db:
-    github: crystal-lang/crystal-db
-    version: ~> 0.11.0
+dependencies: {}
+  # db:
+  #   github: crystal-lang/crystal-db
+  #   version: ~> 0.11.0

--- a/shard.yml
+++ b/shard.yml
@@ -4,7 +4,7 @@ version: 0.13.0
 authors:
   - Roman Kalnytskyi <moranibaca@gmail.com>
 
-crystal: ">= 0.36.0"
+crystal: ">= 1.0.0"
 
 license: MIT
 

--- a/shard.yml
+++ b/shard.yml
@@ -11,10 +11,10 @@ license: MIT
 development_dependencies:
   mysql:
     github: crystal-lang/crystal-mysql
-    version: "= 0.14.0" # FIXME: can be upgraded once micrate is fixed
+    version: "= 0.16.0" # FIXME: can be upgraded once micrate is fixed
   pg:
     github: will/crystal-pg
-    version: "= 0.26.0" # FIXME: can be upgraded once micrate is fixed
+    version: "= 0.28.0" # FIXME: can be upgraded once micrate is fixed
   factory:
     github: imdrasil/factory
     version: "~> 0.1.5"
@@ -24,9 +24,10 @@ development_dependencies:
   ameba:
     github: crystal-ameba/ameba
     version: "~> 1.6.1"
-  micrate:
-    github: "amberframework/micrate"
-    version: "= 0.15.0"
+  # TODO: uncomment once micrate supports the latest versions
+  # micrate:
+  #   github: "amberframework/micrate"
+  #   version: "= 0.15.1"
 dependencies:
   wordsmith:
     github: luckyframework/wordsmith

--- a/spec/adapter/db_colorized_formatter_spec.cr
+++ b/spec/adapter/db_colorized_formatter_spec.cr
@@ -1,5 +1,7 @@
 require "../spec_helper"
 
+Colorize.enabled = true
+
 describe Jennifer::Adapter::DBColorizedFormatter do
   described_class = Jennifer::Adapter::DBColorizedFormatter
 
@@ -10,7 +12,7 @@ describe Jennifer::Adapter::DBColorizedFormatter do
       io = IO::Memory.new
       described_class.format(entry, io)
       io.to_s
-        .should match(/^[\d\-.:TZ]+\s* INFO - \e\[31mdb\e\[0m: #{Regex.escape(metadata[:time].to_s)} μs \e\[34m#{Regex.escape(metadata[:query])}\e\[0m \| \e\[33m#{Regex.escape(metadata[:args])}\e\[0m$/)
+        .should match(/^[\d\-\.:TZ]+\s* INFO - \e\[31mdb\e\[0m: #{Regex.escape(metadata[:time].to_s)} μs \e\[34m#{Regex.escape(metadata[:query])}\e\[0m \| \e\[33m#{Regex.escape(metadata[:args])}\e\[0m$/)
     end
   end
 end

--- a/spec/adapter/db_colorized_formatter_spec.cr
+++ b/spec/adapter/db_colorized_formatter_spec.cr
@@ -1,0 +1,16 @@
+require "../spec_helper"
+
+describe Jennifer::Adapter::DBColorizedFormatter do
+  described_class = Jennifer::Adapter::DBColorizedFormatter
+
+  describe "#run" do
+    it "formats an entry" do
+      metadata = {query: "SELECT COUNT(*) FROM users WHERE id > ?", args: "[1]", time: 582.1}
+      entry = Log::Entry.new("db", :info, "ignored message", Log::Metadata.build(metadata), nil)
+      io = IO::Memory.new
+      described_class.format(entry, io)
+      io.to_s
+        .should match(/^[\d\-.:TZ]+\s* INFO - \e\[31mdb\e\[0m: #{Regex.escape(metadata[:time].to_s)} μs \e\[34m#{Regex.escape(metadata[:query])}\e\[0m \| \e\[33m#{Regex.escape(metadata[:args])}\e\[0m$/)
+    end
+  end
+end

--- a/spec/adapter/db_formatter_spec.cr
+++ b/spec/adapter/db_formatter_spec.cr
@@ -1,0 +1,16 @@
+require "../spec_helper"
+
+describe Jennifer::Adapter::DBFormatter do
+  described_class = Jennifer::Adapter::DBFormatter
+
+  describe "#run" do
+    it "formats an entry" do
+      metadata = {query: "SELECT COUNT(*) FROM users WHERE id > ?", args: "[1]", time: 582.1}
+      entry = Log::Entry.new("db", :info, "ignored message", Log::Metadata.build(metadata), nil)
+      io = IO::Memory.new
+      described_class.format(entry, io)
+      io.to_s
+        .should match(/^[\d\-.:TZ]+\s* INFO - db: #{Regex.escape(metadata[:time].to_s)} μs #{Regex.escape(metadata[:query])} \| #{Regex.escape(metadata[:args])}$/)
+    end
+  end
+end

--- a/spec/adapter/result_parsers_spec.cr
+++ b/spec/adapter/result_parsers_spec.cr
@@ -34,7 +34,7 @@ describe Jennifer::Adapter::ResultParsers do
 
       describe "DATE" do
         it "correctly saves and loads" do
-          AllTypeModel.create!(date_f: Time.utc(2016, 2, 15, 10, 20, 30))
+          AllTypeModel.create!({:date_f => Time.utc(2016, 2, 15, 10, 20, 30)})
           executed = false
           AllTypeModel.all.each_result_set do |rs|
             executed = true

--- a/spec/integration/sam/blank_application.cr
+++ b/spec/integration/sam/blank_application.cr
@@ -2,10 +2,6 @@ require "../shared_helpers"
 require "sam"
 require "../../../src/jennifer/sam"
 
-Spec.config_jennifer do |conf|
-  conf.logger.level = :debug
-end
-
 Log.setup "db", :debug, Log::IOBackend.new(formatter: Jennifer::Adapter::DBFormatter)
 
 if SemanticVersion.parse(Sam::VERSION) < SemanticVersion.new(0, 5, 0)

--- a/spec/integration/sam/blank_application.cr
+++ b/spec/integration/sam/blank_application.cr
@@ -2,6 +2,8 @@ require "../shared_helpers"
 require "sam"
 require "../../../src/jennifer/sam"
 
+Spec.config_jennifer
+
 Log.setup "db", :debug, Log::IOBackend.new(formatter: Jennifer::Adapter::DBFormatter)
 
 if SemanticVersion.parse(Sam::VERSION) < SemanticVersion.new(0, 5, 0)

--- a/spec/integration/spec_helper.cr
+++ b/spec/integration/spec_helper.cr
@@ -83,10 +83,10 @@ class DatabaseSeeder
     case Spec.adapter
     when POSTGRES_DB
       common_command = "docker exec -i -e PGPASSWORD=#{Spec.db_password} #{Spec.settings["docker_container"]} dropdb #{Spec.db} -U#{Spec.db_user}"
-      common_command = "sudo #{common_command}" if Spec.settings["command_shell_sudo"]?
+      common_command = "#{common_command}" if Spec.settings["command_shell_sudo"]?
       common_command
     when MYSQL_DB
-      common_command = "echo \"drop database #{Spec.db};\" | sudo docker exec -i #{Spec.settings["docker_container"]} mysql -u#{Spec.db_user}"
+      common_command = "echo \"drop database #{Spec.db};\" | docker exec -i #{Spec.settings["docker_container"]} mysql -u#{Spec.db_user}"
       common_command += " -p#{Spec.db_password}" unless Spec.db_password.empty?
       common_command
     else

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -50,9 +50,9 @@ end
 # Callbacks =======================
 
 Spec.before_each do
-  set_default_configuration
+  set_default_configuration # NOTE: this allows to test configs changes in tests
   Spec.logger_backend.entries.clear
-  Jennifer::Adapter.default_adapter.begin_transaction
+  Jennifer::Adapter.default_adapter.begin_transaction # NOTE: wraps everything in a transaction
   pair_only { PAIR_ADAPTER.begin_transaction }
 end
 

--- a/spec/support/config.cr
+++ b/spec/support/config.cr
@@ -4,7 +4,10 @@ module Spec
   class_property adapter = ""
   class_getter file_system = FileSystem.new("./")
   class_getter logger_backend = Log::MemoryBackend.new
-  class_getter logger = Log.for("db", Log::Severity::Debug)
+
+  def self.logger
+    Jennifer::Config.instance.logger
+  end
 end
 
 Spec.file_system.tap do |file_system|
@@ -41,7 +44,6 @@ CONFIG_PATH = File.join(__DIR__, "..", "scripts", "database.yml")
   {% end %}
 
   EXTRA_SETTINGS = Jennifer::Config.new.read(CONFIG_PATH, EXTRA_ADAPTER_NAME).tap do |conf|
-    conf.logger = Spec.logger
     conf.user = ENV["PAIR_DB_USER"] if ENV["PAIR_DB_USER"]?
     conf.password = ENV["PAIR_DB_PASSWORD"] if ENV["PAIR_DB_PASSWORD"]?
     conf.verbose_migrations = false
@@ -61,8 +63,6 @@ def set_default_configuration
 
   Jennifer::Config.configure do |conf|
     conf.read(File.join(__DIR__, "../../scripts/database.yml"), Spec.adapter)
-    conf.logger = Spec.logger
-    # conf.logger.level = :debug
     conf.user = ENV["DB_USER"] if ENV["DB_USER"]?
     conf.password = ENV["DB_PASSWORD"] if ENV["DB_PASSWORD"]?
     conf.verbose_migrations = false

--- a/src/jennifer/adapter/db_colorized_formatter.cr
+++ b/src/jennifer/adapter/db_colorized_formatter.cr
@@ -1,0 +1,53 @@
+require "colorize"
+
+module Jennifer::Adapter
+  # Colorized logger formatter
+  #
+  # This formatter has the same structure as `Jennifer::Adapter::DBFormatter` but with colored sections which
+  # simplifies reading. You need to require formatter before use: `require "jennifer/adapter/db_colorized_formatter"`.
+  #
+  # `2020-10-11T12:13:14.424770Z  DEBUG - db: 500.736 μs SELECT COUNT(*) FROM users WHERE users.role = $1  | ["admin"]`
+  #
+  # A log entry has 3 colored sections:
+  # - `db` - namespace
+  # - `SELECT COUNT(*) FROM users WHERE users.role = $1` - query
+  # - `["admin"]` - query arguments
+  #
+  # To customize used colors change `colors` with desired colors:
+  #
+  # ```
+  # Jennifer::Adapter::DBColorizedFormatter.colors = {
+  #   namespace: :green,
+  #   query:     :blue,
+  #   args:      :yellow,
+  # }
+  # ```
+  struct DBColorizedFormatter < Log::StaticFormatter
+    @@colors : NamedTuple(
+      namespace: Symbol | Colorize::Color,
+      query: Symbol | Colorize::Color,
+      args: Symbol | Colorize::Color) = {
+      namespace: :green,
+      query:     :blue,
+      args:      :yellow,
+    }
+
+    def self.colors=(value)
+      @@colors = value
+    end
+
+    def run
+      entry_data = @entry.data
+      timestamp
+      severity
+      @io <<
+        " - " <<
+        @entry.source.colorize(@@colors[:namespace]) <<
+        ": " <<
+        entry_data[:time] <<
+        " μs " <<
+        entry_data[:query].colorize(@@colors[:query])
+      @io << " | " << entry_data[:args].colorize(@@colors[:args]) if entry_data[:args]?
+    end
+  end
+end

--- a/src/jennifer/adapter/db_formatter.cr
+++ b/src/jennifer/adapter/db_formatter.cr
@@ -1,7 +1,7 @@
 module Jennifer::Adapter
   # Default log formatter
   #
-  # 2020-10-11T12:13:14.424770Z  DEBUG - db: 500.736 μs SELECT COUNT(*) FROM users WHERE users.role = $1  | ["admin"]
+  # `2020-10-11T12:13:14.424770Z  DEBUG - db: 500.736 μs SELECT COUNT(*) FROM users WHERE users.role = $1  | ["admin"]`
   struct DBFormatter < Log::StaticFormatter
     def run
       entry_data = @entry.data

--- a/src/jennifer/config.cr
+++ b/src/jennifer/config.cr
@@ -144,7 +144,7 @@ module Jennifer
     # `Log` instance.
     #
     # Default is `Log.for("db")`
-    property logger : Log
+    getter logger : Log
 
     # Whether Jennifer should convert time objects to UTC and back to application time zone when store/load them
     # from a database.
@@ -183,6 +183,11 @@ module Jennifer
       @logger = Log.for(LOG_CONTEXT)
 
       @max_bind_vars_count = nil
+    end
+
+    @[Deprecated("Use Log.setup(\"db\", severity) instead of assigning custom logger")]
+    def logger=(value)
+      @logger = value
     end
 
     # Sets `max_pool_size`, `max_idle_pool_size` and `initial_pool_size` to the given *value*.

--- a/src/jennifer/config.cr
+++ b/src/jennifer/config.cr
@@ -15,7 +15,6 @@ module Jennifer
   # * `structure_folder` parent folder of `migration_files_path`
   # * `host = "localhost"`
   # * `port = -1`
-  # * `logger = Log.for("db", :debug)`
   # * `schema = "public"`
   # * `user`
   # * `password`
@@ -144,7 +143,7 @@ module Jennifer
 
     # `Log` instance.
     #
-    # Default is `Log.for("db", Log::Severity::Debug)`
+    # Default is `Log.for("db")`
     property logger : Log
 
     # Whether Jennifer should convert time objects to UTC and back to application time zone when store/load them
@@ -181,7 +180,7 @@ module Jennifer
 
       @command_shell = "bash"
       @migration_failure_handler_method = MigrationFailureHandler::None
-      @logger = Log.for(LOG_CONTEXT, Log::Severity::Debug)
+      @logger = Log.for(LOG_CONTEXT)
 
       @max_bind_vars_count = nil
     end
@@ -219,11 +218,11 @@ module Jennifer
 
     # Delegates call to #read.
     def self.read(*args, **opts)
-      config.read(*args, **opts)
+      instance.read(*args, **opts)
     end
 
     def self.read(*args, **opts, &)
-      config.read(*args, **opts) { |document| yield document }
+      instance.read(*args, **opts) { |document| yield document }
     end
 
     # Returns maximum size of the pool.

--- a/src/jennifer/migration/runner.cr
+++ b/src/jennifer/migration/runner.cr
@@ -89,7 +89,13 @@ module Jennifer
       #
       # Pending migration - known Jennifer::Migration::Base subclasses that hasn't been run.
       def self.pending_migration?
-        !pending_versions.empty?
+        return true if !pending_versions.empty?
+        if Base.versions.empty? && !Dir[File.join(Config.config.migration_files_path, "*.cr")].empty?
+          puts "WARNING: your migrations location has files but no one hasn't been loaded - " \
+               "it looks like you didn't require migrations"
+        end
+
+        false
       end
 
       private def self.default_adapter


### PR DESCRIPTION
# What does this PR do?

Fix #446 - Instead of accepting custom `Log` instance with specified logging level Jennifer should rely on bound log settings

# Release notes

**General**

* use `0.16.0` of `crystal-lang/crystal-mysql` in tests
* use `0.28.0` of `will/crystal-pg` in tests
* stop supporting crystal `0.36.0`

**Adapter**

* add colorized log formatter `Jennifer::Adapter::DBColorizedFormatter`

**Config**

* change default value of `.logger` to `Log.for("db")` so it it possible to set log level using `Log.setup`; discourage using `config.logger=`

**Migration**

* display a warning message during migration if there is no migration class is loaded but migrations location has crystal files