### PR TITLE
Decouple generator arguments from Sam

### DIFF
--- a/spec/generators/migration_spec.cr
+++ b/spec/generators/migration_spec.cr
@@ -7,7 +7,7 @@ describe Jennifer::Generators::Migration do
     args = Sam::Args.new({} of String => String, %w(CreateArticles))
 
     it "creates migration" do
-      described_class.new(args).render
+      described_class.new(args.raw).render
       expected_content = File.read("./spec/fixtures/generators/migration.cr")
       migration_path = Dir["./scripts/migrations/*.cr"].sort.last
 

--- a/spec/generators/model_spec.cr
+++ b/spec/generators/model_spec.cr
@@ -8,7 +8,7 @@ describe Jennifer::Generators::Model do
       args = Sam::Args.new({} of String => String, %w(Article title:string text:text?))
 
       it "creates model" do
-        described_class.new(args).render
+        described_class.new(args.raw).render
         expected_content = File.read("./spec/fixtures/generators/model.cr")
         model_path = "./scripts/models/article.cr"
         File.exists?(model_path).should be_true
@@ -16,12 +16,13 @@ describe Jennifer::Generators::Model do
       end
 
       it "creates migration" do
-        described_class.new(args).render
+        described_class.new(args.raw).render
         expected_content = File.read("./spec/fixtures/generators/create_migration.cr")
         migration_path = Dir["./scripts/migrations/*.cr"].sort.last
 
         migration_path.should match(/\d{16}_create_articles\.cr/)
-        Time.parse(File.basename(migration_path), "%Y%m%d%H%M%S%L", Time::Location.local).should be_close(Time.local, 1.seconds)
+        Time.parse(File.basename(migration_path), "%Y%m%d%H%M%S%L", Time::Location.local)
+          .should be_close(Time.local, 1.seconds)
         File.read(migration_path).should eq(expected_content)
       end
     end
@@ -30,7 +31,7 @@ describe Jennifer::Generators::Model do
       args = Sam::Args.new({} of String => String, %w(Article title:string text:text? author:reference))
 
       it "creates model" do
-        described_class.new(args).render
+        described_class.new(args.raw).render
         expected_content = File.read("./spec/fixtures/generators/model_with_references.cr")
         model_path = "./scripts/models/article.cr"
         File.exists?(model_path).should be_true
@@ -38,7 +39,7 @@ describe Jennifer::Generators::Model do
       end
 
       it "creates migration" do
-        described_class.new(args).render
+        described_class.new(args.raw).render
         expected_content = File.read("./spec/fixtures/generators/create_migration_with_references.cr")
         migration_path = Dir["./scripts/migrations/*.cr"].sort.last
 

--- a/spec/integration/sam_test.cr
+++ b/spec/integration/sam_test.cr
@@ -38,4 +38,42 @@ describe "Blank application" do
       end
     end
   end
+
+  describe "generate:model" do
+    it "generates model and migration classes" do
+      clean do
+        execute(
+          "crystal spec/integration/sam/blank_application.cr",
+          ["generate:model", "Article", "title:string", "text:text?"]
+        ).should succeed
+
+        model_path = "./scripts/models/article.cr"
+        File.exists?(model_path).should be_true
+        File.read(model_path).should eq(File.read("./spec/fixtures/generators/model.cr"))
+
+        migration_path = Dir["./scripts/migrations/*.cr"].sort.last
+        migration_path.should match(/\d{16}_create_articles\.cr/)
+        Time.parse(File.basename(migration_path), "%Y%m%d%H%M%S%L", Time::Location.local)
+          .should be_close(Time.local, 1.seconds)
+        File.read(migration_path).should eq(File.read("./spec/fixtures/generators/create_migration.cr"))
+      end
+    end
+  end
+
+  describe "generate:migration" do
+    it "generates migration class" do
+      clean do
+        execute(
+          "crystal spec/integration/sam/blank_application.cr",
+          ["generate:migration", "CreateArticles"]
+        ).should succeed
+
+        migration_path = Dir["./scripts/migrations/*.cr"].sort.last
+        migration_path.should match(/\d{16}_create_articles\.cr/)
+        Time.parse(File.basename(migration_path), "%Y%m%d%H%M%S%L", Time::Location.local)
+          .should be_close(Time.local, 1.seconds)
+        File.read(migration_path).should eq(File.read("./spec/fixtures/generators/migration.cr"))
+      end
+    end
+  end
 end

--- a/spec/integration/shared_helpers.cr
+++ b/spec/integration/shared_helpers.cr
@@ -6,15 +6,7 @@ POSTGRES_DB                 = "postgres"
 MYSQL_DB                    = "mysql"
 
 module Spec
-  @@adapter = ""
-
-  def self.adapter
-    @@adapter
-  end
-
-  def self.adapter=(v)
-    @@adapter = v
-  end
+  class_property adapter = ""
 
   def self.config_jennifer
     config_jennifer { }

--- a/spec/integration/spec_helper.cr
+++ b/spec/integration/spec_helper.cr
@@ -1,5 +1,6 @@
 require "spec"
 require "../support/matchers"
+require "../support/file_system"
 require "./shared_helpers"
 
 macro jennifer_adapter
@@ -8,6 +9,15 @@ macro jennifer_adapter
   {% else %}
     Jennifer::Adapter.default_adapter.as(Jennifer::Mysql::Adapter)
   {% end %}
+end
+
+module Spec
+  class_getter file_system = FileSystem.new("./")
+end
+
+Spec.file_system.tap do |file_system|
+  file_system.watch "scripts/models"
+  file_system.watch "scripts/migrations"
 end
 
 def execute(command, options)
@@ -22,6 +32,7 @@ def clean(type = DatabaseSeeder.default_interface, &)
   yield
 ensure
   DatabaseSeeder.drop(type)
+  Spec.file_system.clean
 end
 
 def with_connection(&)

--- a/src/jennifer/generators/base.cr
+++ b/src/jennifer/generators/base.cr
@@ -3,7 +3,7 @@ require "ecr"
 module Jennifer
   module Generators
     abstract class Base
-      getter name : String, args : Sam::Args
+      getter name : String, args : Array(Float64 | Int32 | String)
 
       def initialize(@args)
         @name = @args[0].as(String)
@@ -21,7 +21,7 @@ module Jennifer
       end
 
       private def definitions
-        args.raw[1..-1]
+        args[1..-1]
       end
     end
   end

--- a/src/jennifer/model/base.cr
+++ b/src/jennifer/model/base.cr
@@ -322,8 +322,8 @@ module Jennifer
       end
 
       # Alias for `.new`.
-      def self.build(pull : DB::ResultSet)
-        new(pull)
+      def self.build(values : DB::ResultSet)
+        new(values)
       end
 
       def self.coercer

--- a/src/jennifer/sam.cr
+++ b/src/jennifer/sam.cr
@@ -65,11 +65,11 @@ end
 Sam.namespace "generate" do
   desc "Generates migration template. Usage - generate:migration <migration_name>"
   task "migration" do |_, args|
-    Jennifer::Generators::Migration.new(args).render
+    Jennifer::Generators::Migration.new(args.raw).render
   end
 
-  desc "Generates model and migrations template. Usage - generate:model <ModelName>"
+  desc "Generates model and migrations template. Usage - generate:model <ModelName> <optional fields definition>"
   task "model" do |_, args|
-    Jennifer::Generators::Model.new(args).render
+    Jennifer::Generators::Model.new(args.raw).render
   end
 end

--- a/src/jennifer/view/base.cr
+++ b/src/jennifer/view/base.cr
@@ -50,8 +50,8 @@ module Jennifer
       end
 
       # Alias for `.new`.
-      def self.build(pull : DB::ResultSet)
-        new(pull)
+      def self.build(values : DB::ResultSet)
+        new(values)
       end
 
       # :ditto:


### PR DESCRIPTION
# What does this PR do?

Decouples Jennifer's generators from Sam implementation so it should be easier to use it standalone. This should not affect any common user flow.

Thank you @charles-liang for the initial implementation :pray: 

# Release notes

**General**

* `Jennifer::Generators::Base#args` is now `Array(Float64 | Int32 | String)` instead of `Sam::Args`

**Model**

* rename argument `pull` of `Base.build` to `values` 

**View**

* rename argument `pull` of `Base.build` to `values`
