### PR TITLE
Disable string query warning for postgres materialized view

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -104,8 +104,8 @@ Jennifer::Config.from_uri(db)
   * `"reverse_direction"` - invokes an opposite method to migration direction (`#down` for an up-migration)
   * `"callback"` - invokes `#after_up_failure` on a failed up-migration and `#after_down_failure` on a failed down-migration
 * `migration_files_path` - path to the location with migration files; default: `"./db/migrations"`
-* `verbose_migrations` - outputs basic invoked migration information if set to `true`; default: `true`
-* `model_files_path` - path to the models locations; is used by model and migration generators; default: `"./src/models"`
+* `verbose_migrations` - outputs basic information about invoked migrations; default: `true`
+* `model_files_path` - path to the models location; is used by model and migration generators; default: `"./src/models"`
 * `structure_folder` - path to the database structure file location; if set to empty string - parent folder of `migration_files_path` is used; default: `""`
 * `max_bind_vars_count` - maximum allowed count of bind variables; if nothing specified - used adapter's default value; default: `nil`
 * `time_zone_aware_attributes` - whether Jennifer should convert time objects to UTC and back to application time zone when store/load them from a database; default: `true`

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -60,8 +60,11 @@ Jennifer::Config.configure do |conf|
   conf.from_uri(ENV["DATABASE_URI"]) if ENV.has_key?("DATABASE_URI")
 end
 
-if APP_ENV == "development"
+case APP_ENV
+when "development"
   Log.setup "db", :debug, Log::IOBackend.new(formatter: Jennifer::Adapter::DBColorizedFormatter)
+when "test"
+  Log.setup "db", :none, Log::IOBackend.new
 else
   Log.setup "db", :error, Log::IOBackend.new(formatter: Jennifer::Adapter::DBFormatter)
 end
@@ -216,4 +219,14 @@ To be sure that your test database has all latest migration ran add this to your
 require "../db/migrations/*" # you need to load all your migrations
 
 Jennifer::Migration::Runner.migrate
+```
+
+To suppress all logs:
+
+```crystal
+Log.setup "db", :none, Log::IOBackend.new
+
+Jennifer::Config.configure do |conf|
+  conf.verbose_migrations = false
+end
 ```

--- a/src/jennifer/adapter/postgres/migration/table_builder/create_materialized_view.cr
+++ b/src/jennifer/adapter/postgres/migration/table_builder/create_materialized_view.cr
@@ -26,7 +26,10 @@ module Jennifer
 
           private def generate_query
             if @query.is_a?(String)
-              puts "String was used for describing source request of materialized  view. Use QueryBuilder::Query instead"
+              if Config.config.verbose_migrations
+                puts "WARNING: string was used for describing source request of materialized view. " \
+                     "Use QueryBuilder::Query instead"
+              end
               @query.as(String)
             else
               String.build do |io|


### PR DESCRIPTION
# What does this PR do?

Address #454: show `verbose_migrations` usage in docs

# Release notes

**Migration**

* disable warning message in `Postgres::Migration::TableBuilder::CreateMaterializedView` if `verbose_migrations` configuration set to `false`