### PR TITLE
Respect empty user and password connection setting everywhere

### DIFF
--- a/spec/adapter/base_spec.cr
+++ b/spec/adapter/base_spec.cr
@@ -462,7 +462,7 @@ describe Jennifer::Adapter::Base do
       end
     end
 
-    context "without username or password" do
+    context "without username and password" do
       it do
         config.user = ""
         config.password = ""

--- a/spec/adapter/mysql/command_interface_spec.cr
+++ b/spec/adapter/mysql/command_interface_spec.cr
@@ -1,0 +1,94 @@
+require "../../spec_helper"
+
+mysql_only do
+  class StubInterface < Jennifer::Mysql::CommandInterface
+    def execute(command)
+      command
+    end
+  end
+
+  def build_config
+    config = Jennifer::Config.config
+    config.password = "password"
+    config.user = "user"
+    config
+  end
+
+  describe Jennifer::Mysql::CommandInterface do
+    describe "#generate_schema" do
+      it do
+        config = build_config
+        interface = StubInterface.new(Jennifer::Config.config)
+        command = interface.generate_schema
+        command.executable.should eq("mysqldump")
+        command.options.should eq([
+          "-h", config.host, "-u", config.user, "--password='#{config.password}'",
+          "--no-data", "--skip-lock-tables", config.db,
+        ])
+        command.inline_vars.empty?.should be_true
+        command.in_stream.should eq("")
+        command.out_stream.should eq("> #{config.structure_path}")
+      end
+
+      it "when user and password are blank" do
+        config = build_config
+        config.user = ""
+        config.password = ""
+
+        interface = StubInterface.new(Jennifer::Config.config)
+        command = interface.generate_schema
+        command.options.should eq(["-h", config.host, "--no-data", "--skip-lock-tables", config.db])
+      end
+
+      it "with a custom port" do
+        config = build_config
+        config.port = 100
+
+        interface = StubInterface.new(Jennifer::Config.config)
+        command = interface.generate_schema
+        command.options.should eq([
+          "-h", config.host, "-u", config.user, "--password='#{config.password}'", "--port=#{config.port}",
+          "--no-data", "--skip-lock-tables", config.db,
+        ])
+      end
+    end
+
+    describe "#load_schema" do
+      it do
+        config = build_config
+        interface = StubInterface.new(Jennifer::Config.config)
+        command = interface.load_schema
+        command.executable.should eq("mysql")
+        command.options.should eq([
+          "-h", config.host, "-u", config.user, "--password='#{config.password}'", config.db, "-B", "-s",
+        ])
+        command.inline_vars.empty?.should be_true
+        command.in_stream.should eq("cat #{config.structure_path} |")
+        command.out_stream.should eq("")
+      end
+
+      it "when user and password are blank" do
+        config = build_config
+        config.user = ""
+        config.password = ""
+
+        interface = StubInterface.new(Jennifer::Config.config)
+        command = interface.load_schema
+        command.options.should eq(["-h", config.host, config.db, "-B", "-s"])
+      end
+
+      it "with a custom port" do
+        config = build_config
+        config.port = 100
+
+        interface = StubInterface.new(Jennifer::Config.config)
+        command = interface.load_schema
+        command.options.should eq([
+          "-h", config.host, "-u", config.user, "--password='#{config.password}'", "--port=#{config.port}",
+          config.db, "-B", "-s",
+
+        ])
+      end
+    end
+  end
+end

--- a/spec/adapter/postgres/command_interface_spec.cr
+++ b/spec/adapter/postgres/command_interface_spec.cr
@@ -1,6 +1,19 @@
 require "../../spec_helper"
 
 postgres_only do
+  class StubInterface < Jennifer::Postgres::CommandInterface
+    def execute(command)
+      command
+    end
+  end
+
+  def build_config
+    config = Jennifer::Config.config
+    config.password = "password"
+    config.user = "user"
+    config
+  end
+
   describe Jennifer::Postgres::CommandInterface do
     described_class = Jennifer::Postgres::CommandInterface
 
@@ -11,6 +24,142 @@ postgres_only do
         config = Jennifer::Config.config
         config.db = "unexisting_test_database"
         described_class.new(config).database_exists?.should be_false
+      end
+    end
+
+    describe "#drop_database" do
+      it do
+        config = build_config
+        interface = StubInterface.new(Jennifer::Config.config)
+        command = interface.drop_database
+        command.executable.should eq("dropdb")
+        command.options.should eq([config.db, "-h", config.host, "-U", config.user])
+        command.inline_vars.should eq({"PGPASSWORD" => config.password})
+        command.in_stream.should eq("")
+        command.out_stream.should eq("")
+      end
+
+      it "when user and password are blank" do
+        config = build_config
+        config.user = ""
+        config.password = ""
+
+        interface = StubInterface.new(Jennifer::Config.config)
+        command = interface.drop_database
+        command.options.should eq([config.db, "-h", config.host])
+        command.inline_vars.should be_empty
+      end
+
+      it "with a custom port" do
+        config = build_config
+        config.port = 100
+
+        interface = StubInterface.new(Jennifer::Config.config)
+        command = interface.drop_database
+        command.options.should eq([config.db, "-h", config.host, "-U", config.user])
+        command.inline_vars.should eq({"PGPASSWORD" => config.password, "PGPORT" => "100"})
+      end
+    end
+
+    describe "#create_database" do
+      it do
+        config = build_config
+        interface = StubInterface.new(Jennifer::Config.config)
+        command = interface.create_database
+        command.executable.should eq("createdb")
+        command.options.should eq([config.db, "-h", config.host, "-U", config.user, "-O", config.user])
+        command.inline_vars.should eq({"PGPASSWORD" => config.password})
+        command.in_stream.should eq("")
+        command.out_stream.should eq("")
+      end
+
+      it "when user and password are blank" do
+        config = build_config
+        config.user = ""
+        config.password = ""
+
+        interface = StubInterface.new(Jennifer::Config.config)
+        command = interface.create_database
+        command.options.should eq([config.db, "-h", config.host])
+        command.inline_vars.should be_empty
+      end
+
+      it "with a custom port" do
+        config = build_config
+        config.port = 100
+
+        interface = StubInterface.new(Jennifer::Config.config)
+        command = interface.create_database
+        command.options.should eq([config.db, "-h", config.host, "-U", config.user, "-O", config.user])
+        command.inline_vars.should eq({"PGPORT" => "100", "PGPASSWORD" => config.password})
+      end
+    end
+
+    describe "#generate_schema" do
+      it do
+        config = build_config
+        interface = StubInterface.new(Jennifer::Config.config)
+        command = interface.generate_schema
+        command.executable.should eq("pg_dump")
+        command.options.should eq(["-h", config.host, "-U", config.user, "-d", config.db, "-s"])
+        command.inline_vars.should eq({"PGPASSWORD" => config.password})
+        command.in_stream.should eq("")
+        command.out_stream.should eq("> #{config.structure_path}")
+      end
+
+      it "when user and password are blank" do
+        config = build_config
+        config.user = ""
+        config.password = ""
+
+        interface = StubInterface.new(Jennifer::Config.config)
+        command = interface.generate_schema
+        command.options.should eq(["-h", config.host, "-d", config.db, "-s"])
+        command.inline_vars.should be_empty
+      end
+
+      it "with a custom port" do
+        config = build_config
+        config.port = 100
+
+        interface = StubInterface.new(Jennifer::Config.config)
+        command = interface.generate_schema
+        command.inline_vars.should eq({"PGPORT" => "100", "PGPASSWORD" => config.password})
+      end
+    end
+
+    describe "#load_schema" do
+      it do
+        config = build_config
+        interface = StubInterface.new(Jennifer::Config.config)
+        command = interface.load_schema
+        command.executable.should eq("psql")
+        command.options.should eq([
+          "-h", config.host, "-U", config.user, "-d", config.db, "-a", "-f", config.structure_path,
+        ])
+        command.inline_vars.should eq({"PGPASSWORD" => config.password})
+        command.in_stream.should eq("")
+        command.out_stream.should eq("")
+      end
+
+      it "when user and password are blank" do
+        config = build_config
+        config.user = ""
+        config.password = ""
+
+        interface = StubInterface.new(Jennifer::Config.config)
+        command = interface.load_schema
+        command.options.should eq(["-h", config.host, "-d", config.db, "-a", "-f", config.structure_path])
+        command.inline_vars.should be_empty
+      end
+
+      it "with a custom port" do
+        config = build_config
+        config.port = 100
+
+        interface = StubInterface.new(Jennifer::Config.config)
+        command = interface.load_schema
+        command.inline_vars.should eq({"PGPORT" => "100", "PGPASSWORD" => config.password})
       end
     end
   end

--- a/src/jennifer/adapter/base.cr
+++ b/src/jennifer/adapter/base.cr
@@ -265,7 +265,7 @@ module Jennifer
           type.db? ? config.db : "",
           connection_query,
           config.user.blank? ? nil : config.user,
-          config.password && !config.password.empty? ? config.password : nil
+          config.password.blank? ? nil : config.password
         ).to_s
       end
 

--- a/src/jennifer/adapter/mysql/command_interface.cr
+++ b/src/jennifer/adapter/mysql/command_interface.cr
@@ -16,9 +16,8 @@ module Jennifer
       end
 
       def generate_schema
-        options = ["-u", config.user, "--no-data", "-h", config.host, "--skip-lock-tables", config.db]
-        options += ["--password='#{config.password}'"] unless config.password.empty?
-        options += ["--port=#{config.port}"] if config.port > -1
+        options = default_options
+        options += ["--no-data", "--skip-lock-tables", config.db]
         command = Command.new(
           executable: "mysqldump",
           options: options,
@@ -28,15 +27,22 @@ module Jennifer
       end
 
       def load_schema
-        options = ["-u", config.user, "-h", config.host, config.db, "-B", "-s"]
-        options += ["--password='#{config.password}'"] unless config.password.empty?
-        options += ["--port=#{config.port}"] if config.port > -1
+        options = default_options
+        options += [config.db, "-B", "-s"]
         command = Command.new(
           executable: "mysql",
           options: options,
           in_stream: "cat #{config.structure_path} |"
         )
         execute(command)
+      end
+
+      private def default_options
+        options = ["-h", config.host] of Command::Option
+        options += ["-u", config.user] unless config.user.empty?
+        options += ["--password='#{config.password}'"] unless config.password.empty?
+        options += ["--port=#{config.port}"] if config.port > -1
+        options
       end
     end
   end


### PR DESCRIPTION
# What does this PR do?

Fix #444 

# Release notes

**Adapter**

* don't use user and password parameters in system commands for postgres and mysql if they are blank
