### PR TITLE
fix: Command cannot be executed on Windows

### DIFF
--- a/src/jennifer/adapter/command_shell/i_command_shell.cr
+++ b/src/jennifer/adapter/command_shell/i_command_shell.cr
@@ -3,8 +3,8 @@ require "./command"
 module Jennifer
   module Adapter
     abstract class ICommandShell
-      OPTIONS_PLACEHOLDER = {% flag?(:win32) ? "" : %("${@}") %}
-      SUDO                = {% flag?(:win32) ? "" : "sudo" %}
+      OPTIONS_PLACEHOLDER = {% if flag?(:win32) %} "" {% else %} %("${@}") {% end %}
+      SUDO                = {% if flag?(:win32) %} "" {% else %} "sudo" {% end %}
       abstract def execute(command) : NamedTuple
 
       getter config : Config

--- a/src/jennifer/adapter/command_shell/i_command_shell.cr
+++ b/src/jennifer/adapter/command_shell/i_command_shell.cr
@@ -3,9 +3,8 @@ require "./command"
 module Jennifer
   module Adapter
     abstract class ICommandShell
-      OPTIONS_PLACEHOLDER = %("${@}")
-      SUDO                = "sudo"
-
+      OPTIONS_PLACEHOLDER = {% flag?(:win32) ? "" : %("${@}") %}
+      SUDO                = {% flag?(:win32) ? "" : "sudo" %}
       abstract def execute(command) : NamedTuple
 
       getter config : Config
@@ -15,7 +14,13 @@ module Jennifer
 
       private def invoke(command_string, options) : NamedTuple
         io = IO::Memory.new
-        result = Process.run(command_string, options, shell: true, output: io, error: io)
+
+        result = {% if flag?(:win32) %}
+            Process.run("cmd", ["/c", command_string] + options, output: io, error: io)
+          {% else %}
+            Process.run(command_string, options, shell: true, output: io, error: io)
+          {% end %}
+
         raise Command::Failed.new(result.exit_code, io) if result.exit_code != 0
         {status: result, output: io}
       end


### PR DESCRIPTION
## Summary
This pull request introduces platform-specific adjustments to the `ICommandShell` class within the `Jennifer::Adapter` module. These changes ensure compatibility with both Windows and Unix-like systems by conditionally modifying command execution behavior and related constants.

## Changes Made
1. **Platform-Specific Constants:**
   - `OPTIONS_PLACEHOLDER` is now conditionally set based on the operating system. For Windows (`win32`), it is an empty string, while for other systems, it remains as `%("${@}")`.
   - `SUDO` is conditionally set to an empty string for Windows and `"sudo"` for Unix-like systems.

2. **Command Execution Logic:**
   - The `invoke` method now uses platform-specific logic to execute commands. On Windows, it uses `cmd /c` to run the command, whereas on Unix-like systems, it uses the shell directly.

## Testing
- **Windows:** Verified that commands execute correctly using `cmd /c`.

## Notes
- Further testing and validation are recommended to ensure robustness across different environments and scenarios.