### PR TITLE
fix: undefined constant BaseException

### DIFF
--- a/src/jennifer/adapter/command_shell/command.cr
+++ b/src/jennifer/adapter/command_shell/command.cr
@@ -1,3 +1,5 @@
+require "../../exceptions.cr"
+
 module Jennifer
   module Adapter
     abstract class ICommandShell


### PR DESCRIPTION
# What does this PR do?

This pull request fixes the following error:

```
In lib\jennifer\src\jennifer\adapter\command_shell\command.cr:5:24

 5 | class Failed < BaseException
                    ^------------
Error: undefined constant BaseException
```
