### PR TITLE
added unsigned int support

### DIFF
--- a/src/jennifer/adapter.cr
+++ b/src/jennifer/adapter.cr
@@ -3,11 +3,12 @@ require "./adapter/base"
 module Jennifer
   # All possible database types for any driver.
   alias DBAny = Array(Int32) | Array(Char) | Array(Float32) | Array(Float64) |
-                Array(Int16) | Array(Int64) | Array(String) | Array(UUID) | Array(Bool) | Array(Time) |
+                Array(Int8) | Array(Int16) | Array(Int64) | Array(String) | Array(UUID) | Array(Bool) | Array(Time) |
+                Array(UInt8) | Array(UInt16) | Array(UInt32) | Array(UInt64) |
                 Bool | Char | Float32 | Float64 | Int8 | Int16 | Int32 | Int64 | JSON::Any | JSON::PullParser |
                 String | Time | Nil | PG::Geo::Box | PG::Geo::Circle | PG::Geo::Line | PG::Geo::LineSegment |
-                PG::Geo::Path | PG::Geo::Point | PG::Geo::Polygon | PG::Numeric | Slice(UInt8) | Time::Span | UInt32 |
-                UUID
+                PG::Geo::Path | PG::Geo::Point | PG::Geo::Polygon | PG::Numeric | Slice(UInt8) | Time::Span |
+                UInt8 | UInt16 | UInt32 | UInt64 | UUID
 
   module Adapter
     TYPES = %i(


### PR DESCRIPTION
# What does this PR do?

Allows you to define models with unsigned integer fields presuming that the underlying adapter supports it. This also adds `Array(8)` because it looked like it was missing previously.

# Any background context you want to provide?

I added support for these datatypes for sqlite in this pr: https://github.com/crystal-lang/crystal-sqlite3/pull/98. There may be changes made in crystal-db to add support more generally which might be relevant. Locally I'm using UInt16 and Int16, and it seems to be working for my application using my forked versions with sqlite.

# Release notes

**Model**

Adds potential support for Unsigned Integers (8, 16, 32, 64) and also Array(Int8)

**Adapter**

Adds potential support for Unsigned Integers (8, 16, 32, 64) and also Array(Int8)